### PR TITLE
partially eliminate sequenceIndex - requires new PDF query in DLCS

### DIFF
--- a/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
@@ -13,5 +13,7 @@
         public string PortalPageTemplate { get; set; }
         public string PortalBatchTemplate { get; set; }
         public bool PreventSynchronisation { get; set; } = false;
+        public string PdfQueryName { get; set; } = "pdf-item";
+        public string PdfQueryType { get; set; } = "sequenceIndex";
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dashboard/IDashboardRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dashboard/IDashboardRepository.cs
@@ -24,7 +24,7 @@ namespace Wellcome.Dds.AssetDomain.Dashboard
         Task<Page<ErrorByMetadata>> GetErrorsByMetadata(int page);
 
         Task<int> FindSequenceIndex(string identifier);
-        Task<bool> DeletePdf(string string1, int number1);
+        Task<bool> DeletePdf(string identifier);
         Task<int> RemoveOldJobs(string id);
         Task<int> DeleteOrphans(string id);
         

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dashboard/IDigitisedManifestation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dashboard/IDigitisedManifestation.cs
@@ -20,7 +20,7 @@ namespace Wellcome.Dds.AssetDomain.Dashboard
         /// <summary>
         /// TODO: This doesn't belong here! Only here for PDF link to work and be same as in IIIF manifest
         /// </summary>
-        int SequenceIndex { get; set; }
+        // int SequenceIndex { get; set; }
 
         string DlcsStatus { get; set; }
         string DlcsResponse { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
@@ -91,10 +91,12 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
         /// <summary>
         /// TODO: This MUST be changed to use string3 as soon as the manifest has that info to emit into the rendering
         /// </summary>
-        Task<IPdf> GetPdfDetails(string string1, int number1);
-        
-        Task<bool> DeletePdf(string string1, int number1);
-        
+        // Task<IPdf> GetPdfDetails(string string1, int number1);
+        Task<IPdf> GetPdfDetails(string identifier);
+
+        // Task<bool> DeletePdf(string string1, int number1);
+        Task<bool> DeletePdf(string identifier);
+
         int DefaultSpace { get; }
         
         int BatchSize { get; }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DashboardRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DashboardRepository.cs
@@ -501,8 +501,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
 
         public async Task<IEnumerable<DlcsIngestJob>> GetMostRecentIngestJobs(string identifier, int number)
         {
-            int sequenceIndex = await metsRepository.FindSequenceIndex(identifier);
-            var jobQuery = GetJobQuery(identifier, legacySequenceIndex: sequenceIndex);
+            // int sequenceIndex = await metsRepository.FindSequenceIndex(identifier);
+            var jobQuery = GetJobQuery(identifier); //, legacySequenceIndex: sequenceIndex);
             if (jobQuery == null)
             {
                 return new DlcsIngestJob[0];
@@ -530,8 +530,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
 
         public async Task<int> RemoveOldJobs(string id)
         {
-            int sequenceIndex = await metsRepository.FindSequenceIndex(id);
-            var jobQuery = GetJobQuery(id, legacySequenceIndex: sequenceIndex);
+            // int sequenceIndex = await metsRepository.FindSequenceIndex(id);
+            var jobQuery = GetJobQuery(id); // , legacySequenceIndex: sequenceIndex);
             if (jobQuery == null)
             {
                 return 0;
@@ -561,7 +561,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
         /// <returns></returns>
         private IEnumerable<DlcsIngestJob> GetUpdatedIngestJobs(SyncOperation syncOperation, List<Batch> activeBatches)
         {
-            var jobQuery = GetJobQuery(syncOperation.ManifestationIdentifier, legacySequenceIndex: syncOperation.LegacySequenceIndex);
+            var jobQuery = GetJobQuery(syncOperation.ManifestationIdentifier); // , legacySequenceIndex: syncOperation.LegacySequenceIndex);
             if (jobQuery == null)
             {
                 return new DlcsIngestJob[0];
@@ -589,7 +589,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
             return jobs;
         }
 
-        private IQueryable<DlcsIngestJob> GetJobQuery(string identifier, int legacySequenceIndex = -1)
+        private IQueryable<DlcsIngestJob> GetJobQuery(string identifier) // , int legacySequenceIndex = -1)
         {
             var ddsId = new DdsIdentifier(identifier);            
             IQueryable<DlcsIngestJob> jobQuery = null;
@@ -602,8 +602,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                 case IdentifierType.Volume:
                     //int sequenceIndex = metsRepository.FindSequenceIndex(identifier);
                     jobQuery = ddsInstrumentationContext.DlcsIngestJobs
-                        .Where(j => (j.VolumePart != null && j.VolumePart == identifier)
-                        || (j.VolumePart == null && j.Identifier == ddsId.BNumber && j.SequenceIndex == legacySequenceIndex));
+                        .Where(j => (j.VolumePart != null && j.VolumePart == identifier));
+                        // || (j.VolumePart == null && j.Identifier == ddsId.BNumber && j.SequenceIndex == legacySequenceIndex));
                     break;
                 case IdentifierType.BNumberAndSequenceIndex:
                     jobQuery = ddsInstrumentationContext.DlcsIngestJobs
@@ -674,17 +674,17 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
 
         public Task<Page<ErrorByMetadata>> GetErrorsByMetadata(int page) => dlcs.GetErrorsByMetadata(page);
 
-        /// <summary>
-        /// This could be removed once alto search is replaced.
-        /// </summary>
-        /// <param name="identifier"></param>
-        /// <returns></returns>
+        ///// <summary>
+        ///// This could be removed once alto search is replaced.
+        ///// </summary>
+        ///// <param name="identifier"></param>
+        ///// <returns></returns>
         public async Task<int> FindSequenceIndex(string identifier)
         {
             return await metsRepository.FindSequenceIndex(identifier);
         }
 
-        public Task<bool> DeletePdf(string string1, int number1) => dlcs.DeletePdf(string1, number1);
+        public Task<bool> DeletePdf(string identifier) => dlcs.DeletePdf(identifier);
 
         public async Task<int> DeleteOrphans(string id)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DigitisedManifestation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DigitisedManifestation.cs
@@ -20,7 +20,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
         /// <summary>
         /// TODO: This doesn't belong here! Only here for PDF link to work and be same as in IIIF manifest
         /// </summary>
-        public int SequenceIndex { get; set; }
+        // public int SequenceIndex { get; set; }
 
         private IPdf pdf;
 
@@ -29,13 +29,14 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
             if (pdf == null && PdfGetter != null)
             {
                 // TODO - change to use proper identifiers, not bnum/seq
-                pdf = await PdfGetter(MetsManifestation.GetRootId(), SequenceIndex);
+                pdf = await PdfGetter(MetsManifestation.Id); // GetRootId(), SequenceIndex);
             }
 
             return pdf;
         }
 
-        public Func<string, int, Task<IPdf>> PdfGetter; 
+        // public Func<string, int, Task<IPdf>> PdfGetter;
+        public Func<string, Task<IPdf>> PdfGetter;
 
         public string DlcsStatus { get; set; }
         public string DlcsResponse { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/MetsRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/MetsRepository.cs
@@ -207,7 +207,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets
                 case IdentifierType.BNumberAndSequenceIndex:
                     throw new ArgumentException("Identifier already assumes sequence index");
                 case IdentifierType.Issue:
-                    throw new NotImplementedException("TODO - restore issue cache mechanism");
+                    return -1; // No finding issues by sequence index ANY MORE
+                    // throw new NotSupportedException("No finding issues by sequence index ANY MORE");
                     // return GetCachedIssueSequenceIndex(ddsId);
             }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashController.cs
@@ -175,7 +175,7 @@ namespace Wellcome.Dds.Dashboard.Controllers
                 // THIS IS ONLY HERE TO SUPPORT THE PDF LINK
                 // IT MUST GO AS SOON AS THE IIIF MANIFEST KNOWS String3
                 logger.Log("Start dashboardRepository.FindSequenceIndex(id)");
-                dgManifestation.SequenceIndex = await dashboardRepository.FindSequenceIndex(id);
+                // dgManifestation.SequenceIndex = await dashboardRepository.FindSequenceIndex(id);
                 logger.Log("Finished dashboardRepository.FindSequenceIndex(id)");
                 // represents the set of differences between the METS view of the world and the DLCS view
                 logger.Log("Start dashboardRepository.GetDlcsSyncOperation(id)");
@@ -257,11 +257,9 @@ namespace Wellcome.Dds.Dashboard.Controllers
                 logger.Log("Start cacheBuster queries");
                 model.CachedPackageFileInfo = cacheBuster.GetPackageCacheFileInfo(ddsId.BNumber);
                 logger.Log("Finished cacheBuster.GetPackageCacheFileInfo(ddsId.BNumber)");
-                model.CachedTextModelFileInfo = cacheBuster.GetAltoSearchTextCacheFileInfo(
-                    ddsId.BNumber, dgManifestation.SequenceIndex);
+                model.CachedTextModelFileInfo = cacheBuster.GetAltoSearchTextCacheFileInfo(ddsId);
                 logger.Log("Finished cacheBuster.GetAltoSearchTextCacheFileInfo(..)");
-                model.CachedAltoAnnotationsFileInfo = cacheBuster.GetAllAnnotationsCacheFileInfo(
-                    ddsId.BNumber, dgManifestation.SequenceIndex);
+                model.CachedAltoAnnotationsFileInfo = cacheBuster.GetAllAnnotationsCacheFileInfo(ddsId);
                 logger.Log("Finished cacheBuster.GetAllAnnotationsCacheFileInfo(..)");
                 ViewBag.Log = LoggingEvent.FromTuples(logger.GetEvents());
                 if (json)
@@ -614,8 +612,7 @@ namespace Wellcome.Dds.Dashboard.Controllers
 
         public async Task<ActionResult> DeletePdf(string id)
         {
-            var seqIndex = await dashboardRepository.FindSequenceIndex(id);
-            var deleteResult = new DeleteResult { Success = await dashboardRepository.DeletePdf(new DdsIdentifier(id).BNumber, seqIndex) };
+            var deleteResult = new DeleteResult { Success = await dashboardRepository.DeletePdf(id) };
             TempData["PdfDeletion"] = deleteResult;
             dashboardRepository.LogAction(id, null, User.Identity.Name, "Delete PDF");
             return RedirectToAction("Manifestation", new { id });

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
@@ -372,7 +372,7 @@ namespace Wellcome.Dds.Dashboard.Models
                 SyncOperation = SyncOperation,
                 MetsManifestation = DigitisedManifestation.MetsManifestation,
                 DlcsImages = DigitisedManifestation.DlcsImages,
-                SequenceIndex = DigitisedManifestation.SequenceIndex,
+                SequenceIndex = -1, // DigitisedManifestation.SequenceIndex,
                 WorkStore = DigitisedManifestation.MetsManifestation.Sequence[0].WorkStore
             };
             foreach (var physicalFile in model.MetsManifestation.Sequence)

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
@@ -22,7 +22,9 @@
     "BatchSize": 100,
     "PortalPageTemplate": "https://portal.dlcs.io/Image.aspx?space={0}&image={1}",
     "PortalBatchTemplate": "https://portal.dlcs.io/Batch.aspx?batch={0}",
-    "PreventSynchronisation": false
+    "PreventSynchronisation": false,
+    "PdfQueryName": "pdf-item",
+    "PdfQueryType": "sequenceIndex"
   },
   "Dds": {
     "StatusContainer": "wellcomecollection-stage-iiif-presentation",
@@ -49,9 +51,8 @@
         "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
         "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
         "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "MemoryCacheSeconds": 3600,
         "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 60
+        "MaxAgeStorageMap": 180
     },
     "BinaryObjectCache": {
       "StorageMaps": {
@@ -60,7 +61,7 @@
         "WriteFailThrowsException": true,
         "Container": "wellcomecollection-stage-iiif-storagemaps",
         "Prefix": "stgmap-",
-        "MemoryCacheSeconds": 60
+        "MemoryCacheSeconds": 180
       }
     },
     "AzureAd": {

--- a/src/Wellcome.Dds/Wellcome.Dds/CacheBuster.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/CacheBuster.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Utils.Storage;
+using Wellcome.Dds.Common;
 
 namespace Wellcome.Dds
 {
@@ -13,13 +14,13 @@ namespace Wellcome.Dds
             //throw new NotImplementedException();
         }
 
-        public ISimpleStoredFileInfo GetAltoSearchTextCacheFileInfo(string bNumber, int sequenceIndex)
+        public ISimpleStoredFileInfo GetAltoSearchTextCacheFileInfo(DdsIdentifier ddsId)
         {
             return new NonExistentFileInfo();
             //throw new NotImplementedException();
         }
 
-        public ISimpleStoredFileInfo GetAllAnnotationsCacheFileInfo(string bNumber, int sequenceIndex)
+        public ISimpleStoredFileInfo GetAllAnnotationsCacheFileInfo(DdsIdentifier ddsId)
         {
             return new NonExistentFileInfo();
             //throw new NotImplementedException();

--- a/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Utils\Utils.csproj" />
+    <ProjectReference Include="..\Wellcome.Dds.Common\Wellcome.Dds.Common.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Why?
Part of the way to solving https://github.com/wellcomecollection/platform/issues/4659

What does it do?

* No longer determines sequence index for Chemist and Druggist (DLCS receives `-1` for the `number1` field for C&D issues)
* Retains sequenceIndex for everything else (not expensive to compute), has some query utility
* Supports (but doesn't yet enable) a pdf named query format that doesn't rely on ordinals
* Eliminates the IssueCache (you can view a C&D issue in dashboard without it)
* paves the way for using METS-derived identifiers for manifests and collections 
