### PR TITLE
after removing sequenceIndex, some things no longer awaitable

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dashboard/IDashboardRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dashboard/IDashboardRepository.cs
@@ -13,7 +13,7 @@ namespace Wellcome.Dds.AssetDomain.Dashboard
             bool reIngestErrorImages);
         Task ExecuteDlcsSyncOperation(SyncOperation syncOperation, bool usePriorityQueue);
         int DefaultSpace { get; set; }
-        Task<IEnumerable<DlcsIngestJob>> GetMostRecentIngestJobs(string identifier, int number);
+        IEnumerable<DlcsIngestJob> GetMostRecentIngestJobs(string identifier, int number);
         //IEnumerable<DlcsIngestJob> GetUpdatedIngestJobs(string identifier, SyncOperation syncOperation);
         Task<Batch> GetBatch(string batchId);
 
@@ -25,7 +25,7 @@ namespace Wellcome.Dds.AssetDomain.Dashboard
 
         Task<int> FindSequenceIndex(string identifier);
         Task<bool> DeletePdf(string identifier);
-        Task<int> RemoveOldJobs(string id);
+        int RemoveOldJobs(string id);
         Task<int> DeleteOrphans(string id);
         
         IngestAction LogAction(string manifestationId, int? jobId, string userName, string action, string description = null);

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DashboardRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DashboardRepository.cs
@@ -499,7 +499,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
             return imageRegistration;
         }
 
-        public async Task<IEnumerable<DlcsIngestJob>> GetMostRecentIngestJobs(string identifier, int number)
+        public IEnumerable<DlcsIngestJob> GetMostRecentIngestJobs(string identifier, int number)
         {
             // int sequenceIndex = await metsRepository.FindSequenceIndex(identifier);
             var jobQuery = GetJobQuery(identifier); //, legacySequenceIndex: sequenceIndex);
@@ -528,7 +528,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
             return new JobActivity {BatchesForCurrentImages = imageBatches, UpdatedJobs = updatedJobs};
         }
 
-        public async Task<int> RemoveOldJobs(string id)
+        public int RemoveOldJobs(string id)
         {
             // int sequenceIndex = await metsRepository.FindSequenceIndex(id);
             var jobQuery = GetJobQuery(id); // , legacySequenceIndex: sequenceIndex);

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Ingest/DashboardCloudServicesJobProcessor.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Ingest/DashboardCloudServicesJobProcessor.cs
@@ -276,7 +276,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Ingest
                 syncOperation.DlcsImagesToIngest.AddRange(ingestingImagesToIncludeInJob);
             }
 
-            dashboardRepository.ExecuteDlcsSyncOperation(syncOperation, usePriorityQueue);
+            await dashboardRepository.ExecuteDlcsSyncOperation(syncOperation, usePriorityQueue);
 
             var result = new ImageIngestResult
             {

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashController.cs
@@ -632,15 +632,13 @@ namespace Wellcome.Dds.Dashboard.Controllers
             return RedirectToAction("StopStatus");
         }
 
-        public async Task<ActionResult> CleanOldJobs(string id)
+        public ActionResult CleanOldJobs(string id)
         {
-            int removed = await dashboardRepository.RemoveOldJobs(id);
+            int removed = dashboardRepository.RemoveOldJobs(id);
             TempData["remove-old-jobs"] = removed;
             return RedirectToAction("Manifestation", new { id });
         }
-
-
-
+        
         public Task<Dictionary<string, long>> GetDlcsQueueLevel()
         {
             return dashboardRepository.GetDlcsQueueLevel();


### PR DESCRIPTION
A few calls to `await FindSequenceIndex` were removed, which led to their calling contexts becoming synchronous.