### PR TITLE
Handle canonical + specific URLs for IIIF Presentation

### DIFF
--- a/Dockerfile-dashboard
+++ b/Dockerfile-dashboard
@@ -26,7 +26,7 @@ RUN dotnet build "Wellcome.Dds.Dashboard.csproj" -c Release
 
 FROM build AS testrunner
 WORKDIR "/src"
-RUN dotnet test "Wellcome.Dds.sln" --filter Category\!=Database
+RUN dotnet test "Wellcome.Dds.sln" --filter "Category!=Database&Category!=Manual"
 
 FROM build AS publish
 WORKDIR "/src/Wellcome.Dds.Dashboard"

--- a/Dockerfile-iiifbuilder
+++ b/Dockerfile-iiifbuilder
@@ -22,7 +22,7 @@ RUN dotnet build "Wellcome.Dds.Server.csproj" -c Release
 
 FROM build AS testrunner
 WORKDIR "/src"
-RUN dotnet test "Wellcome.Dds.sln" --filter Category\!=Database
+RUN dotnet test "Wellcome.Dds.sln" --filter "Category!=Database&Category!=Manual"
 
 FROM build AS publish
 WORKDIR "/src/Wellcome.Dds.Server"

--- a/Dockerfile-jobprocessor
+++ b/Dockerfile-jobprocessor
@@ -20,7 +20,7 @@ RUN dotnet build "DlcsJobProcessor.csproj" -c Release
 
 FROM build AS testrunner
 WORKDIR "/src"
-RUN dotnet test "Wellcome.Dds.sln" --filter Category\!=Database
+RUN dotnet test "Wellcome.Dds.sln" --filter "Category!=Database&Category!=Manual"
 
 FROM build AS publish
 WORKDIR "/src/DlcsJobProcessor"

--- a/Dockerfile-workflowprocessor
+++ b/Dockerfile-workflowprocessor
@@ -22,7 +22,7 @@ RUN dotnet build "WorkflowProcessor.csproj" -c Release
 
 FROM build AS testrunner
 WORKDIR "/src"
-RUN dotnet test "Wellcome.Dds.sln" --filter Category\!=Database
+RUN dotnet test "Wellcome.Dds.sln" --filter "Category!=Database&Category!=Manual"
 
 FROM build AS publish
 WORKDIR "/src/WorkflowProcessor"

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Conneg/IIIFPresentationTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Conneg/IIIFPresentationTests.cs
@@ -8,43 +8,52 @@ namespace Wellcome.Dds.Server.Tests.Conneg
 {
     public class IIIFPresentationTests
     {
-        [Fact]
-        public void GetIIIFPresentationType_Unknown_IfMediaTypeHeadersNull()
+        [Theory]
+        [InlineData(IIIFPresentationVersion.Unknown)]
+        [InlineData(IIIFPresentationVersion.V2)]
+        [InlineData(IIIFPresentationVersion.V3)]
+        public void GetIIIFPresentationType_FallbackVersion_IfMediaTypeHeadersNull(IIIFPresentationVersion fallback)
         {
             // Arrange
             IEnumerable<MediaTypeHeaderValue> mediaTypeHeaders = null;
             
             // Act
-            var result = mediaTypeHeaders.GetIIIFPresentationType();
+            var result = mediaTypeHeaders.GetIIIFPresentationType(fallback);
 
             // Assert
-            result.Should().Be(IIIFPresentationVersion.Unknown);
+            result.Should().Be(fallback);
         }
         
-        [Fact]
-        public void GetIIIFPresentationType_Unknown_IfMediaTypeHeadersEmpty()
+        [Theory]
+        [InlineData(IIIFPresentationVersion.Unknown)]
+        [InlineData(IIIFPresentationVersion.V2)]
+        [InlineData(IIIFPresentationVersion.V3)]
+        public void GetIIIFPresentationType_FallbackVersion_IfMediaTypeHeadersEmpty(IIIFPresentationVersion fallback)
         {
             // Arrange
             var mediaTypeHeaders = new MediaTypeHeaderValue[0];
             
             // Act
-            var result = mediaTypeHeaders.GetIIIFPresentationType();
+            var result = mediaTypeHeaders.GetIIIFPresentationType(fallback);
 
             // Assert
-            result.Should().Be(IIIFPresentationVersion.Unknown);
+            result.Should().Be(fallback);
         }
         
-        [Fact]
-        public void GetIIIFPresentationType_Unknown_IfNoKnownIIIFPresentationType()
+        [Theory]
+        [InlineData(IIIFPresentationVersion.Unknown)]
+        [InlineData(IIIFPresentationVersion.V2)]
+        [InlineData(IIIFPresentationVersion.V3)]
+        public void GetIIIFPresentationType_FallbackVersion_IfNoKnownIIIFPresentationType(IIIFPresentationVersion fallback)
         {
             // Arrange
             var mediaTypeHeaders = new[] {MediaTypeHeaderValue.Parse("application/json")};
             
             // Act
-            var result = mediaTypeHeaders.GetIIIFPresentationType();
+            var result = mediaTypeHeaders.GetIIIFPresentationType(fallback);
 
             // Assert
-            result.Should().Be(IIIFPresentationVersion.Unknown);
+            result.Should().Be(fallback);
         }
         
         [Theory]

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Conneg/IIIFPresentationTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Conneg/IIIFPresentationTests.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Net.Http.Headers;
+using Wellcome.Dds.Server.Conneg;
+using Xunit;
+
+namespace Wellcome.Dds.Server.Tests.Conneg
+{
+    public class IIIFPresentationTests
+    {
+        [Fact]
+        public void GetIIIFPresentationType_Unknown_IfMediaTypeHeadersNull()
+        {
+            // Arrange
+            IEnumerable<MediaTypeHeaderValue> mediaTypeHeaders = null;
+            
+            // Act
+            var result = mediaTypeHeaders.GetIIIFPresentationType();
+
+            // Assert
+            result.Should().Be(IIIFPresentationVersion.Unknown);
+        }
+        
+        [Fact]
+        public void GetIIIFPresentationType_Unknown_IfMediaTypeHeadersEmpty()
+        {
+            // Arrange
+            var mediaTypeHeaders = new MediaTypeHeaderValue[0];
+            
+            // Act
+            var result = mediaTypeHeaders.GetIIIFPresentationType();
+
+            // Assert
+            result.Should().Be(IIIFPresentationVersion.Unknown);
+        }
+        
+        [Fact]
+        public void GetIIIFPresentationType_Unknown_IfNoKnownIIIFPresentationType()
+        {
+            // Arrange
+            var mediaTypeHeaders = new[] {MediaTypeHeaderValue.Parse("application/json")};
+            
+            // Act
+            var result = mediaTypeHeaders.GetIIIFPresentationType();
+
+            // Assert
+            result.Should().Be(IIIFPresentationVersion.Unknown);
+        }
+        
+        [Theory]
+        [InlineData("application/ld+json;profile=\"http://iiif.io/api/presentation/2/context.json\"", IIIFPresentationVersion.V2)]
+        [InlineData("application/json;profile=\"http://iiif.io/api/presentation/3/context.json\"", IIIFPresentationVersion.V3)]
+        public void GetIIIFPresentationType_ReturnsExpectedType(string mediaType, IIIFPresentationVersion expected)
+        {
+            // Arrange
+            var mediaTypeHeaders = new[] {MediaTypeHeaderValue.Parse(mediaType)};
+            
+            // Act
+            var result = mediaTypeHeaders.GetIIIFPresentationType();
+
+            // Assert
+            result.Should().Be(expected);
+        }
+        
+        [Fact]
+        public void GetIIIFPresentationType_PrefersLatestVersion()
+        {
+            // Arrange
+            const string v2 = "application/ld+json;profile=\"http://iiif.io/api/presentation/2/context.json\"";
+            const string v3 = "application/json;profile=\"http://iiif.io/api/presentation/3/context.json\"";
+            
+            var mediaTypeHeaders = new[] {MediaTypeHeaderValue.Parse(v2), MediaTypeHeaderValue.Parse(v3)};
+            
+            // Act
+            var result = mediaTypeHeaders.GetIIIFPresentationType();
+
+            // Assert
+            result.Should().Be(IIIFPresentationVersion.V3);
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/PresentationControllerTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/PresentationControllerTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Wellcome.Dds.Server.Conneg;
+using Wellcome.Dds.Server.Tests.Integration;
+using Xunit;
+
+namespace Wellcome.Dds.Server.Tests.Controllers
+{
+    // NOTE - marked as manual for now - can deal with catalogue API + s3 dependencies when fully implemented
+    [Trait("Category", "Integration")]
+    [Trait("Category", "Manual")]
+    public class PresentationControllerTests : IClassFixture<DdsServerAppFactory>
+    {
+        private readonly HttpClient client;
+
+        public PresentationControllerTests(DdsServerAppFactory factory)
+        {
+            client = factory.CreateClient();
+        }
+
+        [Fact]
+        public async Task Presentation_ReturnsV3_IfNoSpecificVersionRequested()
+        {
+            // Arrange
+            var requestUri = "/presentation/b29718697";
+
+            // Act
+            var response = await client.GetAsync(requestUri);
+
+            // Assert
+            var contentType = response.Content.Headers.ContentType;
+            contentType.MediaType.Should().Be("application/ld+json");
+            contentType.Parameters.Single(p => p.Name == "profile").Value.Should()
+                .Be("\"http://iiif.io/api/presentation/3/context.json\"");
+        }
+
+        [Fact]
+        public async Task Presentation_ReturnsV2_FromV2Endpoint()
+        {
+            // Arrange
+            var requestUri = "/presentation/v2/b29718697";
+
+            // Act
+            var response = await client.GetAsync(requestUri);
+
+            // Assert
+            var contentType = response.Content.Headers.ContentType;
+            contentType.MediaType.Should().Be("application/ld+json");
+            contentType.Parameters.Single(p => p.Name == "profile").Value.Should()
+                .Be("\"http://iiif.io/api/presentation/2/context.json\"");
+        }
+
+        [Fact]
+        public async Task Presentation_ReturnsV3_FromV3Endpoint()
+        {
+            // Arrange
+            var requestUri = "/presentation/v3/b29718697";
+
+            // Act
+            var response = await client.GetAsync(requestUri);
+
+            // Assert
+            var contentType = response.Content.Headers.ContentType;
+            contentType.MediaType.Should().Be("application/ld+json");
+            contentType.Parameters.Single(p => p.Name == "profile").Value.Should()
+                .Be("\"http://iiif.io/api/presentation/3/context.json\"");
+        }
+
+        [Theory]
+        [InlineData(IIIFPresentation.ContentTypes.V3, "\"http://iiif.io/api/presentation/3/context.json\"")]
+        [InlineData(IIIFPresentation.ContentTypes.V2, "\"http://iiif.io/api/presentation/2/context.json\"")]
+        public async Task Presentation_ReturnsSpecifiedVersion_UsingAcceptsHeader(string accepts,
+            string expectedContentType)
+        {
+            // Arrange
+            var requestUri = "/presentation/b29718697";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(accepts));
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            var contentType = response.Content.Headers.ContentType;
+            contentType.MediaType.Should().Be("application/ld+json");
+            contentType.Parameters.Single(p => p.Name == "profile").Value.Should()
+                .Be(expectedContentType);
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/RoleProviderControllerTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/RoleProviderControllerTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Wellcome.Dds.Server.Tests.Controllers
 {
     [Trait("Category","Integration")]
-    public class RoleProviderControllerTests: IClassFixture<DdsServerAppFactory>
+    public class RoleProviderControllerTests : IClassFixture<DdsServerAppFactory>
     {
         private readonly HttpClient client;
         private const string BasicAuth = "ZGxjczpkbGNzcHdvcmQ="; //dlcs:dlcspword

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Auth/ServiceCollectionX.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Auth/ServiceCollectionX.cs
@@ -14,6 +14,5 @@ namespace Wellcome.Dds.Server.Auth
             => services.AddAuthentication(BasicAuthenticationDefaults.AuthenticationScheme)
                 .AddScheme<BasicAuthenticationOptions, DlcsBasicAuthenticationHandler>(
                     BasicAuthenticationDefaults.AuthenticationScheme, configureOptions);
-
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Conneg/IIIFPresentation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Conneg/IIIFPresentation.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.Net.Http.Headers;
+
+namespace Wellcome.Dds.Server.Conneg
+{
+    /// <summary>
+    /// Contains IIIFPresentation related methods and constants.
+    /// </summary>
+    /// TODO - move this to IIIF project once it exists. Should IIIFPresentation be a ns rather than class? 
+    public static class IIIFPresentation
+    {
+        /// <summary>
+        /// Contains JSON-LD Contexts for IIIF Presentation API.
+        /// </summary>
+        public static class Context
+        {
+            /// <summary>
+            /// JSON-LD context for IIIF presentation 2.
+            /// </summary>
+            public const string V2 = "http://iiif.io/api/presentation/2/context.json";
+
+            /// <summary>
+            /// JSON-LD context for IIIF presentation 3. 
+            /// </summary>
+            public const string V3 = "http://iiif.io/api/presentation/3/context.json";
+        }
+
+        /// <summary>
+        /// Contains Content-Type/Accepts headers for IIIF Presentation API. 
+        /// </summary>
+        public static class ContentTypes
+        {
+            /// <summary>
+            /// Content-Type for IIIF presentation 2.
+            /// </summary>
+            public const string V2 = "application/ld+json;profile=\"" + Context.V2 + "\"";
+
+            /// <summary>
+            /// Content-Type for IIIF presentation 3. 
+            /// </summary>
+            public const string V3 = "application/ld+json;profile=\"" + Context.V3 + "\"";
+        }
+
+        /// <summary>
+        /// Get <see cref="IIIFPresentationVersion"/> for provided mediaTypeHeader, favouring latest version.
+        /// </summary>
+        /// <param name="mediaTypeHeaders">Collection of <see cref="MediaTypeHeaderValue"/> objects.</param>
+        /// <returns><see cref="IIIFPresentationVersion"/> derived from provided values.</returns>
+        public static IIIFPresentationVersion GetIIIFPresentationType(
+            this IEnumerable<MediaTypeHeaderValue> mediaTypeHeaders)
+        {
+            var mediaTypes = mediaTypeHeaders ?? Enumerable.Empty<MediaTypeHeaderValue>();
+            
+            // Get a list of all "profile" parameters, ordered to prefer most recent.
+            var profiles = mediaTypes
+                .Select(m =>
+                    m.Parameters.SingleOrDefault(p =>
+                        string.Equals(p.Name.Value, "profile", StringComparison.OrdinalIgnoreCase))?.Value.Value)
+                .OrderByDescending(s => s);
+
+            var v3Profile = $"\"{Context.V3}\"";
+            var v2Profile = $"\"{Context.V2}\"";
+
+            foreach (var profile in profiles)
+            {
+                if (string.IsNullOrEmpty(profile)) continue;
+                if (profile == v3Profile)
+                {
+                    return IIIFPresentationVersion.V3;
+                }
+
+                if (profile == v2Profile)
+                {
+                    return IIIFPresentationVersion.V2;
+                }
+            }
+
+            return IIIFPresentationVersion.Unknown;
+        }
+    }
+
+    /// <summary>
+    /// Available IIIF presentation API Versions.
+    /// </summary>
+    public enum IIIFPresentationVersion
+    {
+        /// <summary>
+        /// Fallback value, unknown version.
+        /// </summary>
+        [Display(Description = "Unknown")]
+        Unknown = 0,
+        
+        /// <summary>
+        /// IIIF Presentation version 2.
+        /// </summary>
+        [Display(Description = IIIFPresentation.Context.V2)]
+        V2,
+        
+        /// <summary>
+        /// IIIF Presentation version 3.
+        /// </summary>
+        [Display(Description = IIIFPresentation.Context.V3)]
+        V3
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Conneg/IIIFPresentation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Conneg/IIIFPresentation.cs
@@ -48,9 +48,11 @@ namespace Wellcome.Dds.Server.Conneg
         /// Get <see cref="IIIFPresentationVersion"/> for provided mediaTypeHeader, favouring latest version.
         /// </summary>
         /// <param name="mediaTypeHeaders">Collection of <see cref="MediaTypeHeaderValue"/> objects.</param>
+        /// <param name="fallbackVersion">Value to return if no specific version found.</param>
         /// <returns><see cref="IIIFPresentationVersion"/> derived from provided values.</returns>
         public static IIIFPresentationVersion GetIIIFPresentationType(
-            this IEnumerable<MediaTypeHeaderValue> mediaTypeHeaders)
+            this IEnumerable<MediaTypeHeaderValue> mediaTypeHeaders,
+            IIIFPresentationVersion fallbackVersion = IIIFPresentationVersion.Unknown)
         {
             var mediaTypes = mediaTypeHeaders ?? Enumerable.Empty<MediaTypeHeaderValue>();
             
@@ -78,7 +80,7 @@ namespace Wellcome.Dds.Server.Conneg
                 }
             }
 
-            return IIIFPresentationVersion.Unknown;
+            return fallbackVersion;
         }
     }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DlcsWebClient.Config;
-using DlcsWebClient.Dlcs;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Wellcome.Dds.AssetDomain.Dashboard;
@@ -47,13 +47,32 @@ namespace Wellcome.Dds.Server.Controllers
                 Id = id,
                 CatalogueMetadata = work,
                 Label = digitisedResource.BNumberModel.DisplayTitle,
-                Comment = "This is a " + digitisedResource.GetType(),
+                Comment = $"This is a {digitisedResource.GetType()}",
                 ManifestSource = digitisedResource as DigitisedManifestation,
                 SimpleCollectionSource = SimpleCollectionModel.MakeSimpleCollectionModel(digitisedResource as IDigitisedCollection),
                 Pdf = string.Format(dlcsOptions.SkeletonNamedPdfTemplate, dlcsOptions.CustomerDefaultSpace, id)
             };
             return model;
         }
+
+        [HttpGet("v2/{id}")]
+        public ActionResult V2(string id)
+        {
+            var acceptHeader = Request.GetTypedHeaders().Accept;
+            return Ok("V2");
+        }
+        
+        [HttpGet("v3/{id}")]
+        public ActionResult V3(string id)
+        {
+            var acceptHeader = Request.GetTypedHeaders().Accept;
+            return Ok("V3");
+        }
+        
+        // /b12345678 returns 3.0, unless conneg header specifies. return header to canonical version
+        // Accept: application/ld+json;profile=http://iiif.io/api/presentation/3/context.json
+        // /v2/b12345678 returns 2.1
+        // /v3/b12345678 returns 3.0
 
         private void CleanManifestation(IDigitisedResource manifestation)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Models/IIIFPrecursor.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Models/IIIFPrecursor.cs
@@ -12,5 +12,6 @@ namespace Wellcome.Dds.Server.Models
         public DigitisedManifestation ManifestSource { get; set; }
         public SimpleCollectionModel SimpleCollectionSource { get; set; }
         public string Pdf { get; set; }
+        public string IIIFVersion { get; set; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Linq;
 using Community.Microsoft.Extensions.Caching.PostgreSql;
 using DlcsWebClient.Config;
 using DlcsWebClient.Dlcs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,6 +27,7 @@ using Wellcome.Dds.Common;
 using Wellcome.Dds.Repositories;
 using Wellcome.Dds.Repositories.Catalogue;
 using Wellcome.Dds.Server.Auth;
+using Wellcome.Dds.Server.Conneg;
 using Wellcome.Dds.Server.Infrastructure;
 
 namespace Wellcome.Dds.Server
@@ -71,7 +74,12 @@ namespace Wellcome.Dds.Server
 
             services.AddSwagger();
             services.AddCors();
-            services.AddMvc();
+            services.AddMvc(options =>
+            {
+                var jsonFormatter = options.OutputFormatters.OfType<SystemTextJsonOutputFormatter>().FirstOrDefault();
+                jsonFormatter?.SupportedMediaTypes.Add(IIIFPresentation.ContentTypes.V2);
+                jsonFormatter?.SupportedMediaTypes.Add(IIIFPresentation.ContentTypes.V3);
+            });
 
             services.AddHealthChecks()
                 .AddDbContextCheck<DdsContext>("Dds-db");


### PR DESCRIPTION
This is still demo code (returning `IIIFPrecursor`) but adds the following endpoints:

* `/presentation/v3/b12345678` - will return iiif v3
* `/presentation/v2/b12345678` - will return iiif v2
* `/presentation/b12345678`  - will return iiif v3 by default, but will use `Accepts: application/ld+json;profile="http://iiif.io/api/presentation/2/context.json"` or `Accepts: application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"` to control version.

As a note, I think `public static class IIIFPresentation` is a candidate to move to the reusable/generic IIIF project once it exists.