### PR TITLE
Add new route to avoid /dash/dash urls

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
@@ -156,9 +156,11 @@ namespace Wellcome.Dds.Dashboard
                     .MapControllers()
                     .RequireAuthorization();
                 
-                endpoints.MapControllerRoute("Default", "{controller}/{action}/{id?}/{*parts}",
-                    defaults: new { controller = "Dash", action = "Index" }
-                );
+                endpoints.MapControllerRoute(name: "dash",
+                    pattern: "{action}/{id?}/{*parts}",
+                    constraints: new { action = "^(?!account|goobicall|job|log|peek|settings).*$", },
+                    defaults: new { controller = "Dash" });
+                endpoints.MapControllerRoute("Default", "{controller=Dash}/{action=Index}/{id?}/{*parts}");
                 endpoints.MapHealthChecks("/management/healthcheck");
             });
         }


### PR DESCRIPTION
This new route will set controller to 'Dash' and check the first slug (`{action}`) via a [regex route constraint](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-3.1#regular-expressions-in-constraints). It checks that the `{action}` slug is _not_ a value matching the name of another controller.

The alternative was to use a regex constraint to whitelist all ActionMethods on DashController. I went with exclude as it's a much smaller list.

> Both approaches come with the potential danger of having an actionMethod on Dash which matches the name of a controller. 

No need to change views as `@Html.ActionLink` etc use route table to generate links.