### PR TITLE
Get user by username or barcode

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web.Tests/RolesTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web.Tests/RolesTests.cs
@@ -52,7 +52,7 @@ namespace Wellcome.Dds.Auth.Web.Tests
         {
             // Arrange
             var sierraRoles = new[] {"k:True", "r:True", "w:True"};
-            var roles = new Roles(sierraRoles, DateTime.Today);
+            var roles = new Roles(sierraRoles, DateTime.Today, new string[0]);
 
             // Act
             var fromString = new Roles(roles.ToString());

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/IUserService.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/IUserService.cs
@@ -4,6 +4,6 @@ namespace Wellcome.Dds.Auth.Web
 {
     public interface IUserService
     {
-        Task<UserRolesResult> GetUserRoles(string username);
+        Task<UserRolesResult> GetUserRoles(string nameCredential);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/MillenniumIntegration.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/MillenniumIntegration.cs
@@ -24,10 +24,10 @@ namespace Wellcome.Dds.Auth.Web
             UserRolesResult userRoles = null;
             if (StringUtils.AllHaveText(username, password))
             {
+                userRoles = await userService.GetUserRoles(username);
                 var authenticationResult = await authenticationService.Authenticate(username, password);
                 if (authenticationResult.Success)
                 {
-                    userRoles = await userService.GetUserRoles(username);
                     if (userRoles.Success)
                     {
                         if (userRoles.Roles.Expires > DateTime.Now.AddDays(-1))

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/MillenniumIntegration.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/MillenniumIntegration.cs
@@ -24,6 +24,11 @@ namespace Wellcome.Dds.Auth.Web
             UserRolesResult userRoles = null;
             if (StringUtils.AllHaveText(username, password))
             {
+                // TODO - come back to the following code once we have Sierra 5.2 running.
+                // - Get userRoles by the supplied username, where this might be either a username or a barcode
+                // - then validate the password using the barcode or username, whichever 5.2 expects here
+                // (we have options to do both via config)
+                // If you _need_ to user barcode(s), they will be in userRoles.Roles.BarCodes
                 userRoles = await userService.GetUserRoles(username);
                 var authenticationResult = await authenticationService.Authenticate(username, password);
                 if (authenticationResult.Success)

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Roles.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Roles.cs
@@ -15,10 +15,11 @@ namespace Wellcome.Dds.Auth.Web
 
         private readonly string[] sierraRoles;
 
-        public Roles(string[] sierraRoles, DateTime expires)
+        public Roles(string[] sierraRoles, DateTime expires, string[] barcodes)
         {
             this.sierraRoles = sierraRoles;
-            this.Expires = expires;
+            Expires = expires;
+            BarCodes = barcodes;
         }
 
         public Roles(string serialisedRoles)
@@ -46,6 +47,8 @@ namespace Wellcome.Dds.Auth.Web
             => sierraRoles.Contains($"{RestrictedArchiveFieldTag}:True");
 
         public DateTime Expires { get; set; }
+        
+        public string[] BarCodes { get; set; }
 
         public string[] GetSierraRoles() => sierraRoles;
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Sierra/SierraRestAPIOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Sierra/SierraRestAPIOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Wellcome.Dds.Auth.Web.Sierra
 {
-    public class SierraRestAPIOptions
+    public class SierraRestApiOptions
     {
         public string TokenEndPoint { get; set; }
         public string Scope { get; set; }
@@ -8,5 +8,6 @@
         public string ClientSecret { get; set; }
         public string PatronValidateUrl { get; set; }
         public string PatronFindUrl { get; set; }
+        public string PatronGetUrl { get; set; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Sierra/SierraSoapPatronAPI.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Sierra/SierraSoapPatronAPI.cs
@@ -11,24 +11,24 @@ using Wellcome.Dds.MillenniumClient;
 
 namespace Wellcome.Dds.Auth.Web.Sierra
 {
-    public class SierraSoapPatronAPI : IUserService
+    public class SierraSoapPatronApi : IUserService
     {
         private DdsOptions ddsOptions;
-        private ILogger<SierraSoapPatronAPI> logger;
+        private ILogger<SierraSoapPatronApi> logger;
 
 
 
-        public SierraSoapPatronAPI(
-            ILogger<SierraSoapPatronAPI> logger,
+        public SierraSoapPatronApi(
+            ILogger<SierraSoapPatronApi> logger,
             IOptions<DdsOptions> options)
         {
             this.logger = logger;
             ddsOptions = options.Value;
         }
 
-        public async Task<UserRolesResult> GetUserRoles(string username)
+        public async Task<UserRolesResult> GetUserRoles(string nameCredential)
         {
-            string millenniumVersion = "b" + username;
+            string millenniumVersion = "b" + nameCredential;
             return await GetUserInternal(millenniumVersion);
         }
 
@@ -74,7 +74,7 @@ namespace Wellcome.Dds.Auth.Web.Sierra
                     }
 
                     var expires = GetExpiryDate(patron.patronFields.Single(f => f.fieldTag == "43").value);
-                    var roles = new Roles(patronRoles.ToArray(), expires);
+                    var roles = new Roles(patronRoles.ToArray(), expires, new string[0]);
 
                     result.Roles = roles;
                     result.Success = true;

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -100,7 +100,7 @@ namespace Wellcome.Dds.Server
             services.Configure<DlcsOptions>(Configuration.GetSection("Dlcs"));
             services.Configure<DdsOptions>(Configuration.GetSection("Dds"));
             services.Configure<StorageOptions>(Configuration.GetSection("Storage"));
-            services.Configure<SierraRestAPIOptions>(Configuration.GetSection("SierraRestAPI"));
+            services.Configure<SierraRestApiOptions>(Configuration.GetSection("SierraRestAPI"));
 
             // we need more than one of these
             services.Configure<BinaryObjectCacheOptionsByType>(Configuration.GetSection("BinaryObjectCache"));
@@ -128,9 +128,9 @@ namespace Wellcome.Dds.Server
                 .AddScoped<IMetsRepository, MetsRepository>()
                 .AddScoped<IDashboardRepository, DashboardRepository>();
 
-            services.AddSingleton<IAuthenticationService, SierraRestPatronAPI>();
+            services.AddSingleton<IAuthenticationService, SierraRestPatronApi>();
             // services.AddSingleton<IAuthenticationService, AllowAllAuthenticator>();
-            services.AddSingleton<IUserService, SierraRestPatronAPI>();
+            services.AddSingleton<IUserService, SierraRestPatronApi>();
             services.AddSingleton<MillenniumIntegration>();
 
             services.AddControllers().AddJsonOptions(

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
@@ -38,7 +38,8 @@
     "ClientId": "xxx",
     "ClientSecret": "xxx",
     "PatronValidateUrl": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/validate",
-    "PatronFindUrl": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/find"
+    "PatronFindUrl": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/find",
+    "PatronGetUrl": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/"
   },
   "Dds": {
     "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works",


### PR DESCRIPTION
This is odd...
I made the code changes (see discussion https://digirati.slack.com/archives/CBT40CMKQ/p1597920708003300)

Now it can get user by username, or ID (which is not the same as barcode)

But when I came to test first time round, still using username (varField `s`), the patronValidate now successfully validates! I didn't need to pass the barcode!

More, if I do use the barcode, that works too.

So we're good here. But something in Sierra has changed to allow this, that isn't mentioned in that thread.