### PR TITLE
Tidy appSettings for all services

### DIFF
--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Development.Example.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Development.Example.json
@@ -8,41 +8,6 @@
   },
   "Dlcs": {
     "ApiKey": "xxxxxxxxxxxx",
-    "ApiSecret": "xxxxxxxxxxxxxxxxxxxxxxxxx",
-    "CustomerId": 2,
-    "CustomerName": "Wellcome",
-    "CustomerDefaultSpace": 6,
-    "ApiEntryPoint": "xxx",
-    "ResourceEntryPoint": "xxx",
-    "avDerivativeTemplateVideo": "xxx",
-    "avDerivativeTemplateAudio": "xxx"
-  },
-  "Dds": {
-    "GoFile": "<a sentinel file stored in S3>\\DDS_LIVE\\dds.txt",
-    "StatusProviderHeartbeat": "DDS_DEV_PRELIVE\\jobprocessor.txt",
-    "StatusProviderLogSpecialFile": "\\DDS_DEV_PRELIVE\\jobprocessor-diagnostics.txt"
-  },
-  "Dashboard": {
-    "avoidCaching": false,
-    "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
-    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-    "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-    "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log"
-  },
-  "ArchiveStorage": {
-    "StorageApiTemplate": "xxx",
-    "TokenEndPoint": "xxx",
-    "Scope": "xxx",
-    "ClientId": "xxxxxxxxxxxxxxx",
-    "ClientSecret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    "StorageApiTemplateIngest": "xxx",
-    "ScopeIngest": "xxx",
-    "PreventSynchronisation": false,
-    "StorageMapCache": "S3 Bucket equivalent of \\DDSLiveCache\\storageMaps\\production-min\" />",
-    "MapHttpRuntimeCacheSeconds": 3600,
-    "PreferCachedStorageMap": false,
-    "GoobiCall": "DO NOT CALL",
-    "dash-body-inject": " style=background-image:url(/content/staging.png); background-repeat;"
+    "ApiSecret": "xxxxxxxxxxxxxxxxxxxxxxxxx"
   }
 }

--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Production.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Production.json
@@ -1,61 +1,39 @@
 ﻿{
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "ApplicationName": "Job-Processor",
-            "Environment": "Production"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dlcs": {
-        "CustomerDefaultSpace": 5
-    },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-iiif-presentation",
-        "GoFile": "_status/dds.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-        "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-        "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "Job-Processor",
+      "Environment": "Production"
+    }
+  },
+  "Dlcs": {
+    "CustomerDefaultSpace": 5
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-iiif-presentation",
+    "GoFile": "_status/dds.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests"
+  },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-iiif-storagemaps",
-      "Prefix": "map-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "map-"
     }
   }
 }

--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging-Prod.json
@@ -1,61 +1,39 @@
 ﻿{
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "ApplicationName": "Job-Processor",
-            "Environment": "Staging-Prod"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dlcs": {
-        "CustomerDefaultSpace": 6
-    },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-stage-iiif-presentation",
-        "GoFile": "_status/dds-test.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor-test.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-test/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-        "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-        "DashBodyInject": "background-image:url(/img/staging.png); background-repeat;",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "Job-Processor",
+      "Environment": "Staging-Prod"
+    }
+  },
+  "Dlcs": {
+    "CustomerDefaultSpace": 6
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "GoFile": "_status/dds-stage.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor-stage.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
+  },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-storagemaps",
-      "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "stgmap-"
     }
   }
 }

--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging.json
@@ -24,38 +24,16 @@
     "StatusContainer": "wellcomecollection-stage-iiif-presentation",
     "GoFile": "_status/dds-stage.txt",
     "StatusProviderHeartbeat": "_status/jobprocessor-stage.txt",
-    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/",
-    "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-    "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-    "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-    "LinkedDataDomain": "https://wellcomelibrary.org",
-    "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-    "AvoidCaching": false,
-    "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
-    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-    "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-    "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-    "DashBodyInject": "background-image:url(/img/staging.png); background-repeat;",
-    "GoobiCall": "DO NOT CALL"
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/"
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-    "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-    "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests",
-    "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-    "PreferCachedStorageMap": false,
-    "MaxAgeStorageMap": 180
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-storagemaps",
-      "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "stgmap-"
     }
   }
 }

--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.json
@@ -28,6 +28,7 @@
   "Dlcs": {
     "CustomerId": 2,
     "CustomerName": "Wellcome",
+    "CustomerDefaultSpace": 6,
     "SkeletonNamedPdfTemplate": "https://dlcs.io/pdf/wellcome/pdf/{0}/{1}",
     "SkeletonNamedQueryTemplate": "https://dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
     "PortalPageTemplate": "https://portal.dlcs.io/Image.aspx?space={0}&image={1}",
@@ -35,6 +36,47 @@
     "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://dlcs.io/",
     "BatchSize": 100,
-    "PreventSynchronisation": false
+    "PreventSynchronisation": false,
+    "PdfQueryName": "pdf-item",
+    "PdfQueryType": "sequenceIndex"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
+    "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests",
+    "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
+    "StorageMapCache": "",
+    "MemoryCacheSeconds": 3600,
+    "PreferCachedStorageMap": false,
+    "MaxAgeStorageMap": 180
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
+    "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
+    "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
+    "LinkedDataDomain": "https://wellcomelibrary.org",
+    "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
+    "AvoidCaching": false,
+    "EarliestJobDateTime": "2016-07-07",
+    "MinimumJobAgeMinutes": 0,
+    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
+    "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
+    "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
+    "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
+    "GoobiCall": "DO NOT CALL",
+    "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works",
+    "DlcsReturnUrl": "https://dlcs.io/auth/2/fromcas"
+  },
+  "BinaryObjectCache": {
+    "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
+      "AvoidCaching": false,
+      "AvoidSaving": false,
+      "WriteFailThrowsException": true,
+      "Container": "wellcomecollection-stage-iiif-storagemaps",
+      "Prefix": "stgmap-",
+      "MemoryCacheSeconds": 180
+    }
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Development.Example.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Development.Example.json
@@ -8,42 +8,7 @@
   },
   "Dlcs": {
     "ApiKey": "xxxxxxxxxxxx",
-    "ApiSecret": "xxxxxxxxxxxxxxxxxxxxxxxxx",
-    "CustomerId": 2,
-    "CustomerName": "Wellcome",
-    "CustomerDefaultSpace": 6,
-    "ApiEntryPoint": "xxx",
-    "ResourceEntryPoint": "xxx",
-    "avDerivativeTemplateVideo": "xxx",
-    "avDerivativeTemplateAudio": "xxx"
-  },
-  "Dds": {
-    "GoFile": "<a sentinel file stored in S3>\\DDS_LIVE\\dds.txt",
-    "StatusProviderHeartbeat": "DDS_DEV_PRELIVE\\jobprocessor.txt",
-    "StatusProviderLogSpecialFile": "\\DDS_DEV_PRELIVE\\jobprocessor-diagnostics.txt"
-  },
-  "Dashboard": {
-    "avoidCaching": false,
-    "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
-    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-    "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-    "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log"
-  },
-  "ArchiveStorage": {
-    "StorageApiTemplate": "xxx",
-    "TokenEndPoint": "xxx",
-    "Scope": "xxx",
-    "ClientId": "xxxxxxxxxxxxxxx",
-    "ClientSecret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    "StorageApiTemplateIngest": "xxx",
-    "ScopeIngest": "xxx",
-    "PreventSynchronisation": false,
-    "StorageMapCache": "S3 Bucket equivalent of \\DDSLiveCache\\storageMaps\\production-min\" />",
-    "MapHttpRuntimeCacheSeconds": 3600,
-    "PreferCachedStorageMap": false,
-    "GoobiCall": "DO NOT CALL",
-    "dash-body-inject": " style=background-image:url(/content/staging.png); background-repeat;"
+    "ApiSecret": "xxxxxxxxxxxxxxxxxxxxxxxxx"
   },
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Production.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Production.json
@@ -1,67 +1,43 @@
 ﻿{
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "ApplicationName": "Dashboard",
-            "Environment": "Production"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-iiif-presentation",
-        "GoFile": "_status/dds.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Dash": {
-        "JobProcessorName": "job-processor-prod",
-        "WorkflowProcessorName": "workflow-processor-prod"
-    },
-    "Dlcs": {
-        "CustomerDefaultSpace": 5
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
-  "BinaryObjectCache": {
-    "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
-      "Container": "wellcomecollection-iiif-storagemaps",
-      "Prefix": "map-",
-      "MemoryCacheSeconds": 180
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "Dashboard",
+      "Environment": "Production"
     }
   },
-    "AzureAd": {
-        "Instance": "https://login.microsoftonline.com/",
-        "Domain": "wellcomecloud.onmicrosoft.com",
-        "CallbackPath": "/signin-oidc"
+  "Dds": {
+    "StatusContainer": "wellcomecollection-iiif-presentation",
+    "GoFile": "_status/dds.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/"
+  },
+  "Dash": {
+    "JobProcessorName": "job-processor-prod",
+    "WorkflowProcessorName": "workflow-processor-prod"
+  },
+  "Dlcs": {
+    "CustomerDefaultSpace": 5
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests"
+  },
+  "BinaryObjectCache": {
+    "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
+      "Container": "wellcomecollection-iiif-storagemaps",
+      "Prefix": "map-"
     }
+  }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
@@ -1,67 +1,43 @@
 ﻿{
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "Environment": "Staging-Prod"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dlcs": {
-        "CustomerDefaultSpace": 6
-    },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-stage-iiif-presentation",
-        "GoFile": "_status/dds-test.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor-test.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-test/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Dash": {
-        "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
-        "JobProcessorName": "job-processor-stageprd",
-        "WorkflowProcessorName": "workflow-processor-stageprd"
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
-  "BinaryObjectCache": {
-    "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
-      "Container": "wellcomecollection-stage-iiif-storagemaps",
-      "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "Environment": "Staging-Prod"
     }
   },
-    "AzureAd": {
-        "Instance": "https://login.microsoftonline.com/",
-        "Domain": "wellcomecloud.onmicrosoft.com",
-        "CallbackPath": "/signin-oidc"
+  "Dlcs": {
+    "CustomerDefaultSpace": 6
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "GoFile": "_status/dds-stage.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor-stage.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/"
+  },
+  "Dash": {
+    "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
+    "JobProcessorName": "job-processor-stageprd",
+    "WorkflowProcessorName": "workflow-processor-stageprd"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
+  },
+  "BinaryObjectCache": {
+    "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
+      "Container": "wellcomecollection-stage-iiif-storagemaps",
+      "Prefix": "stgmap-"
     }
+  }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
@@ -23,17 +23,7 @@
     "StatusContainer": "wellcomecollection-stage-iiif-presentation",
     "GoFile": "_status/dds-stage.txt",
     "StatusProviderHeartbeat": "_status/jobprocessor-stage.txt",
-    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/",
-    "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-    "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-    "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-    "LinkedDataDomain": "https://wellcomelibrary.org",
-    "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-    "AvoidCaching": false,
-    "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
-    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-    "GoobiCall": "DO NOT CALL"
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/"
   },
   "Dash": {
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
@@ -42,26 +32,12 @@
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-    "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-    "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests",
-    "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-    "PreferCachedStorageMap": false,
-    "MaxAgeStorageMap": 180
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-storagemaps",
-      "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "stgmap-"
     }
-  },
-  "AzureAd": {
-    "Instance": "https://login.microsoftonline.com/",
-    "Domain": "wellcomecloud.onmicrosoft.com",
-    "CallbackPath": "/signin-oidc"
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
@@ -32,9 +32,53 @@
     "BatchSize": 100,
     "PreventSynchronisation": false
   },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
+    "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests",
+    "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
+    "StorageMapCache": "",
+    "MemoryCacheSeconds": 3600,
+    "PreferCachedStorageMap": false,
+    "MaxAgeStorageMap": 180
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
+    "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
+    "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
+    "LinkedDataDomain": "https://wellcomelibrary.org",
+    "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
+    "AvoidCaching": false,
+    "EarliestJobDateTime": "2016-07-07",
+    "MinimumJobAgeMinutes": 0,
+    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
+    "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
+    "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
+    "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
+    "GoobiCall": "DO NOT CALL",
+    "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works",
+    "DlcsReturnUrl": "https://dlcs.io/auth/2/fromcas"
+  },
+  "BinaryObjectCache": {
+    "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
+      "AvoidCaching": false,
+      "AvoidSaving": false,
+      "WriteFailThrowsException": true,
+      "Container": "wellcomecollection-stage-iiif-storagemaps",
+      "Prefix": "stgmap-",
+      "MemoryCacheSeconds": 180
+    }
+  },
   "Dash": {
     "LoggingFormat": "https://logging.wellcomecollection.org/app/kibana#/discover?_a=(columns:!(log),index:'978cbc80-af0d-11ea-b454-cb894ee8b269',query:(language:lucene,query:'service_name:%20%22{0}%22'))",
     "JobProcessorName": "",
     "WorkflowProcessorName": ""
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "Domain": "wellcomecloud.onmicrosoft.com",
+    "CallbackPath": "/signin-oidc"
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Development.Example.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Development.Example.json
@@ -5,5 +5,17 @@
   "ConnectionStrings": {
     "Dds": "<postgres-connection-string-for-Dds-Database>",
     "DdsInstrumentation": "<postgres-connection-string-for-DdsInstrumentation-Database>"
+  },
+  "Dlcs": {
+    "ApiKey": "*****",
+    "ApiSecret": "*****"
+  },
+  "SierraRestAPI": {
+    "ClientId": "xxx",
+    "ClientSecret": "xxx"
+  },
+  "Dds": {
+    "DlcsOriginUsername": "xxx",
+    "DlcsOriginPassword": "xxx"
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Production.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Production.json
@@ -1,61 +1,39 @@
 {
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "ApplicationName": "Dashboard",
-            "Environment": "Production"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-iiif-presentation",
-        "GoFile": "_status/dds.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-        "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-        "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Dlcs": {
-        "CustomerDefaultSpace": 5
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "Dashboard",
+      "Environment": "Production"
+    }
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-iiif-presentation",
+    "GoFile": "_status/dds.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/"
+  },
+  "Dlcs": {
+    "CustomerDefaultSpace": 5
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests"
+  },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-iiif-storagemaps",
-      "Prefix": "map-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "map-"
     }
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-Prod.json
@@ -1,60 +1,38 @@
 {
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "Environment": "Staging-Prod"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dlcs": {
-        "CustomerDefaultSpace": 6
-    },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-stage-iiif-presentation",
-        "GoFile": "_status/dds-test.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor-test.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-test/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-        "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-        "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "Environment": "Staging-Prod"
+    }
+  },
+  "Dlcs": {
+    "CustomerDefaultSpace": 6
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "GoFile": "_status/dds-stage.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor-stage.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
+  },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-storagemaps",
-      "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "stgmap-"
     }
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging.json
@@ -1,60 +1,38 @@
 {
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "Environment": "Staging"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dlcs": {
-        "CustomerDefaultSpace": 6
-    },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-stage-iiif-presentation",
-        "GoFile": "_status/dds-stage.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor-stage.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-        "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-        "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "Environment": "Staging"
+    }
+  },
+  "Dlcs": {
+    "CustomerDefaultSpace": 6
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "GoFile": "_status/dds-stage.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor-stage.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
+  },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-storagemaps",
-      "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "stgmap-"
     }
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
@@ -16,13 +16,14 @@
       }
     ],
     "Properties": {
-      "ApplicationName": "Engine"
+      "ApplicationName": "IIIF-Builder"
     }
   },
   "AllowedHosts": "*",
   "Dlcs": {
     "CustomerId": 2,
     "CustomerName": "Wellcome",
+    "CustomerDefaultSpace": 6,
     "SkeletonNamedPdfTemplate": "https://dlcs.io/pdf/wellcome/pdf/{0}/{1}",
     "SkeletonNamedQueryTemplate": "https://dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
     "PortalPageTemplate": "https://portal.dlcs.io/Image.aspx?space={0}&image={1}",
@@ -30,19 +31,54 @@
     "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://dlcs.io/",
     "BatchSize": 100,
-    "PreventSynchronisation": false
+    "PreventSynchronisation": false,
+    "PdfQueryName": "pdf-item",
+    "PdfQueryType": "sequenceIndex"
   },
   "SierraRestAPI": {
     "TokenEndPoint": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/token",
     "Scope": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5",
-    "ClientId": "xxx",
-    "ClientSecret": "xxx",
     "PatronValidateUrl": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/validate",
     "PatronFindUrl": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/find",
     "PatronGetUrl": "https://libsys.wellcomelibrary.org/iii/sierra-api/v5/patrons/"
   },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
+    "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests",
+    "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
+    "StorageMapCache": "",
+    "MemoryCacheSeconds": 3600,
+    "PreferCachedStorageMap": false,
+    "MaxAgeStorageMap": 180
+  },
   "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
+    "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
+    "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
+    "LinkedDataDomain": "https://wellcomelibrary.org",
+    "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
+    "AvoidCaching": false,
+    "EarliestJobDateTime": "2016-07-07",
+    "MinimumJobAgeMinutes": 0,
+    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
+    "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
+    "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
+    "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
+    "GoobiCall": "DO NOT CALL",
     "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works",
     "DlcsReturnUrl": "https://dlcs.io/auth/2/fromcas"
+  },
+  "BinaryObjectCache": {
+    "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
+      "AvoidCaching": false,
+      "AvoidSaving": false,
+      "WriteFailThrowsException": true,
+      "Container": "wellcomecollection-stage-iiif-storagemaps",
+      "Prefix": "stgmap-",
+      "MemoryCacheSeconds": 180
+    }
   }
 }

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Development.Example.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Development.Example.json
@@ -1,0 +1,32 @@
+{
+  "Serilog": {
+    "WriteTo": [
+      "Debug"
+    ]
+  },
+  "ConnectionStrings": {
+    "Dds": "<postgres-connection-string-for-Dds-Database>",
+    "DdsInstrumentation": "<postgres-connection-string-for-DdsInstrumentation-Database>"
+  },
+  "Dlcs": {
+    "ApiKey": "*****",
+    "ApiSecret": "*****"
+  },
+  "Storage-AWS": {
+    "Profile": "wcstorage",
+    "Region": "eu-west-1"
+  },
+  "Dds-AWS": {
+    "Profile": "wcdev",
+    "Region": "eu-west-1"
+  },
+  "Storage": {
+    "ClientId": "*****",
+    "ClientSecret": "*****"
+  },
+  "Dds": {
+    "GoFile": "_status/dds.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/"
+  }
+}

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Production.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Production.json
@@ -1,58 +1,47 @@
 ﻿{
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "ApplicationName": "Workflow-Processor",
-            "Environment": "Production"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-iiif-presentation",
-        "GoFile": "_status/dds.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-        "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-        "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "Workflow-Processor",
+      "Environment": "Production"
+    }
+  },
+  "Dlcs": {
+    "CustomerDefaultSpace": 5
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-iiif-presentation",
+    "GoFile": "_status/dds.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics/"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
+  },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-iiif-storagemaps",
-      "Prefix": "map-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "map-"
+    },
+    "Wellcome.Dds.WordsAndPictures.Text": {
+      "Container": "wellcomecollection-iiif-text",
+      "Prefix": "text-"
+    },
+    "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
+      "Container": "wellcomecollection-iiif-annotations",
+      "Prefix": "annos-"
     }
   }
 }

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
@@ -1,58 +1,47 @@
 ﻿{
-    "Serilog": {
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        },
-        "WriteTo": [
-            {
-                "Name": "Console"
-            }
-        ],
-        "Properties": {
-            "ApplicationName": "Workflow-Processor",
-            "Environment": "Staging-Prod"
-        }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     },
-    "Dds": {
-        "StatusContainer": "wellcomecollection-stage-iiif-presentation",
-        "GoFile": "_status/dds-test.txt",
-        "StatusProviderHeartbeat": "_status/jobprocessor-test.txt",
-        "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-test/",
-        "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-        "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-        "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-        "LinkedDataDomain": "https://wellcomelibrary.org",
-        "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-        "AvoidCaching": false,
-        "EarliestJobDateTime": "2016-07-07",
-        "MinimumJobAgeMinutes": 0,
-        "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-        "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-        "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-        "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
-        "GoobiCall": "DO NOT CALL"
-    },
-    "Storage": {
-        "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-        "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-        "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-        "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-        "PreferCachedStorageMap": false,
-        "MaxAgeStorageMap": 180
-    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "Workflow-Processor",
+      "Environment": "Staging-Prod"
+    }
+  },
+  "Dlcs": {
+    "CustomerDefaultSpace": 6
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "GoFile": "_status/dds-test.txt",
+    "StatusProviderHeartbeat": "_status/jobprocessor-test.txt",
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-test/"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
+  },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-storagemaps",
-      "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "stgmap-"
+    },
+    "Wellcome.Dds.WordsAndPictures.Text": {
+      "Container": "wellcomecollection-stage-iiif-text",
+      "Prefix": "stgtext-"
+    },
+    "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
+      "Container": "wellcomecollection-stage-iiif-annotations",
+      "Prefix": "stgannos-"
     }
   }
 }

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
@@ -17,42 +17,31 @@
       "Environment": "Staging"
     }
   },
+  "Dlcs": {
+    "CustomerDefaultSpace": 6
+  },
   "Dds": {
     "StatusContainer": "wellcomecollection-stage-iiif-presentation",
     "GoFile": "_status/dds-stage.txt",
     "StatusProviderHeartbeat": "_status/jobprocessor-stage.txt",
-    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/",
-    "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
-    "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
-    "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
-    "LinkedDataDomain": "https://wellcomelibrary.org",
-    "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
-    "AvoidCaching": false,
-    "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
-    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
-    "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
-    "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
-    "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
-    "GoobiCall": "DO NOT CALL"
+    "StatusProviderLogSpecialFile": "_status/_jobprocessor-diagnostics-stage/"
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
-    "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
-    "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
-    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests",
-    "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
-    "PreferCachedStorageMap": false,
-    "MaxAgeStorageMap": 180
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
-      "AvoidCaching": false,
-      "AvoidSaving": false,
-      "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-storagemaps",
-      "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+      "Prefix": "stgmap-"
+    },
+    "Wellcome.Dds.WordsAndPictures.Text": {
+      "Container": "wellcomecollection-stage-iiif-text",
+      "Prefix": "stgtext-"
+    },
+    "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
+      "Container": "wellcomecollection-stage-iiif-annotations",
+      "Prefix": "stgannos-"
     }
   }
 }

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
@@ -23,6 +23,7 @@
   "Dlcs": {
     "CustomerId": 2,
     "CustomerName": "Wellcome",
+    "CustomerDefaultSpace": 6,
     "SkeletonNamedPdfTemplate": "https://dlcs.io/pdf/wellcome/pdf/{0}/{1}",
     "SkeletonNamedQueryTemplate": "https://dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
     "PortalPageTemplate": "https://portal.dlcs.io/Image.aspx?space={0}&image={1}",
@@ -30,7 +31,20 @@
     "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://dlcs.io/",
     "BatchSize": 100,
-    "PreventSynchronisation": false
+    "PreventSynchronisation": false,
+    "PdfQueryName": "pdf-item",
+    "PdfQueryType": "sequenceIndex"
+  },
+  "Storage": {
+    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
+    "TokenEndPoint": "https://auth.wellcomecollection.org/oauth2/token",
+    "Scope": "https://api.wellcomecollection.org/storage/v1/bags",
+    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests",
+    "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
+    "StorageMapCache": "",
+    "MemoryCacheSeconds": 3600,
+    "PreferCachedStorageMap": false,
+    "MaxAgeStorageMap": 180
   },
   "AllowedHosts": "*",
   "WorkflowProcessor": {
@@ -39,5 +53,47 @@
     "RebuildIIIF3": false,
     "RebuildTextCaches": false,
     "RebuildAllAnnoPageCaches": false
+  },
+  "Dds": {
+    "StatusContainer": "wellcomecollection-stage-iiif-presentation",
+    "PersistentPlayerUri": "https://wellcomelibrary.org/item/{0}",
+    "PersistentCatalogueRecord": "https://search.wellcomelibrary.org/iii/encore/record/C__R{0}",
+    "EncoreBibliographicData": "https://search.wellcomelibrary.org/iii/queryapi/collection/bib/{0}?profiles=b(full)i(brief)&amp;format=xml",
+    "LinkedDataDomain": "https://wellcomelibrary.org",
+    "ManifestTemplate": "https://wellcomelibrary.org/iiif/{0}/manifest",
+    "AvoidCaching": false,
+    "EarliestJobDateTime": "2016-07-07",
+    "MinimumJobAgeMinutes": 0,
+    "CacheBuster": "TODO - may not need these but if we do it's an object { }",
+    "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
+    "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
+    "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
+    "GoobiCall": "DO NOT CALL"
+  },
+  "BinaryObjectCache": {
+    "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
+      "AvoidCaching": false,
+      "AvoidSaving": false,
+      "WriteFailThrowsException": true,
+      "Container": "wellcomecollection-stage-iiif-storagemaps",
+      "Prefix": "stgmap-",
+      "MemoryCacheSeconds": 180
+    },
+    "Wellcome.Dds.WordsAndPictures.Text": {
+      "AvoidCaching": false,
+      "AvoidSaving": false,
+      "WriteFailThrowsException": true,
+      "Container": "wellcomecollection-stage-iiif-text",
+      "Prefix": "stgtext-",
+      "MemoryCacheSeconds": 180
+    },
+    "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
+      "AvoidCaching": false,
+      "AvoidSaving": false,
+      "WriteFailThrowsException": true,
+      "Container": "wellcomecollection-stage-iiif-annotations",
+      "Prefix": "stgannos-",
+      "MemoryCacheSeconds": 180
+    }
   }
 }


### PR DESCRIPTION
Turned into a bigger job than I anticipated. Took the approach of moving as much as possible into the base `appsettings.json`. 

This should provide almost enough to get running locally (bar some secrets).

Sometime settings are in both `appsettings.json` and `appsettings.Staging.json`/`appsettings.Staging-Prod.json`. These are settings that are safe to use as defaults but are set again in `.Staging.` and `.Staging-Prod.` to avoid issues if the source appsettings was changed. E.g.

```json
"Storage": {
    "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/digitised/{0}",
    "StorageApiTemplateIngest": "https://api-stage.wellcomecollection.org/storage/v1/ingests"
  },
```