### PR TITLE
Upgrade all projects to .NET Framework 5

### DIFF
--- a/src/Wellcome.Dds/CatalogueAPI.Tests/CatalogueAPI.Tests.csproj
+++ b/src/Wellcome.Dds/CatalogueAPI.Tests/CatalogueAPI.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/CatalogueAPI.Tests/CatalogueTests.cs
+++ b/src/Wellcome.Dds/CatalogueAPI.Tests/CatalogueTests.cs
@@ -71,7 +71,7 @@ namespace CatalogueAPI.Tests
             var work = await sut.GetWorkByOtherIdentifier(identifier);
 
             // Assert
-            work.Title.Should().Be("[Report 1954]");
+            work.Title.Should().Be("[Report 1954] / Medical Officer of Health, St Austell R.D.C.");
         }
         
         

--- a/src/Wellcome.Dds/CatalogueClient/CatalogueClient.csproj
+++ b/src/Wellcome.Dds/CatalogueClient/CatalogueClient.csproj
@@ -2,7 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj
+++ b/src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj
+++ b/src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9</LangVersion>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/DlcsWebClient.Tests/DlcsWebClient.Tests.csproj
+++ b/src/Wellcome.Dds/DlcsWebClient.Tests/DlcsWebClient.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/DlcsWebClient/DlcsWebClient.csproj
+++ b/src/Wellcome.Dds/DlcsWebClient/DlcsWebClient.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/IIIF.Tests/IIIF.Tests.csproj
+++ b/src/Wellcome.Dds/IIIF.Tests/IIIF.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/IIIF/IIIF.csproj
+++ b/src/Wellcome.Dds/IIIF/IIIF.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/OAuth2/OAuth2.csproj
+++ b/src/Wellcome.Dds/OAuth2/OAuth2.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2Client.Tests.csproj
+++ b/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2Client.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Test.Helpers/Test.Helpers.csproj
+++ b/src/Wellcome.Dds/Test.Helpers/Test.Helpers.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
 </Project>

--- a/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
+++ b/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Utils.Tests/Utils.Tests.csproj
+++ b/src/Wellcome.Dds/Utils.Tests/Utils.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Utils/Utils.csproj
+++ b/src/Wellcome.Dds/Utils/Utils.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Wellcome.Dds.AssetDomainRepositories.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Wellcome.Dds.AssetDomainRepositories.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Wellcome.Dds.AssetDomainRepositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Wellcome.Dds.AssetDomainRepositories.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web.Tests/Wellcome.Dds.Auth.Web.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web.Tests/Wellcome.Dds.Auth.Web.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Wellcome.Dds.Auth.Web.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Wellcome.Dds.Auth.Web.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/Wellcome.Dds.Common.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/Wellcome.Dds.Common.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/Wellcome.Dds.Common.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/Wellcome.Dds.Common.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9</LangVersion>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Data/Wellcome.Dds.Data.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Data/Wellcome.Dds.Data.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.MillenniumClient/Wellcome.Dds.MillenniumClient.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.MillenniumClient/Wellcome.Dds.MillenniumClient.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/PresentationControllerTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/PresentationControllerTests.cs
@@ -25,7 +25,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
         public async Task Presentation_ReturnsV3_IfNoSpecificVersionRequested()
         {
             // Arrange
-            var requestUri = "/presentation/b29718697";
+            var requestUri = "/presentation/b16235083";
 
             // Act
             var response = await client.GetAsync(requestUri);
@@ -57,7 +57,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
         public async Task Presentation_ReturnsV3_FromV3Endpoint()
         {
             // Arrange
-            var requestUri = "/presentation/v3/b29718697";
+            var requestUri = "/presentation/v3/b16235083";
 
             // Act
             var response = await client.GetAsync(requestUri);
@@ -76,7 +76,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
             string expectedContentType)
         {
             // Arrange
-            var requestUri = "/presentation/b29718697";
+            var requestUri = "/presentation/b16235083";
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(accepts));
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <LangVersion>9</LangVersion>
+        <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowProcessor.Tests.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowProcessor.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9</LangVersion>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
On Ubuntu I first installed the current .NET 5 SDK.
After restarting Rider, the target framework and C#9 became available in the UI.
I went through each project changing targets, and rebuilt.