### PR TITLE
Update dockerfile for .net5

### DIFF
--- a/Dockerfile-dashboard
+++ b/Dockerfile-dashboard
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj Wellcome.Dds.Dashboard/
@@ -33,7 +34,7 @@ WORKDIR "/src/Wellcome.Dds.Dashboard"
 RUN dotnet publish "Wellcome.Dds.Dashboard.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
 WORKDIR /app
 
 EXPOSE 80

--- a/Dockerfile-iiifbuilder
+++ b/Dockerfile-iiifbuilder
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj Wellcome.Dds.Server/
@@ -29,7 +30,7 @@ WORKDIR "/src/Wellcome.Dds.Server"
 RUN dotnet publish "Wellcome.Dds.Server.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
 WORKDIR /app
 
 EXPOSE 80

--- a/Dockerfile-jobprocessor
+++ b/Dockerfile-jobprocessor
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj DlcsJobProcessor/
@@ -27,7 +28,7 @@ WORKDIR "/src/DlcsJobProcessor"
 RUN dotnet publish "DlcsJobProcessor.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
 WORKDIR /app
 
 EXPOSE 80

--- a/Dockerfile-workflowprocessor
+++ b/Dockerfile-workflowprocessor
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj WorkflowProcessor/
@@ -29,7 +30,7 @@ WORKDIR "/src/WorkflowProcessor"
 RUN dotnet publish "WorkflowProcessor.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
 WORKDIR /app
 
 EXPOSE 80


### PR DESCRIPTION
Debian based .net SDK images have a known issue with certificate chains which prevents nuget working. This is the reason for the specific sdk version.

We can revert to the 'correct' one when this fix has been merged back, I've left that commented out. e.g.

```dockerfile
FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
# FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
```

Without the specific version we get the error `the author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain` when restoring nuget packages.

See the following for details: https://github.com/NuGet/Announcements/issues/49