### PR TITLE
Install curl for job + wf processor for healthchecks

### DIFF
--- a/Dockerfile-jobprocessor
+++ b/Dockerfile-jobprocessor
@@ -29,6 +29,8 @@ RUN dotnet publish "DlcsJobProcessor.csproj" -c Release -o /app/publish
 
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
+
+RUN apt-get update && apt-get install curl -y
 WORKDIR /app
 
 EXPOSE 80

--- a/Dockerfile-workflowprocessor
+++ b/Dockerfile-workflowprocessor
@@ -31,6 +31,8 @@ RUN dotnet publish "WorkflowProcessor.csproj" -c Release -o /app/publish
 
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
+
+RUN apt-get update && apt-get install curl -y
 WORKDIR /app
 
 EXPOSE 80


### PR DESCRIPTION
curl is no longer in base debian image and these are required for ECS healthchecks:

```hcl
healthcheck = {
    command     = ["CMD-SHELL", "curl -f http://localhost:80/management/healthcheck"]
    interval    = 30
    retries     = 5
    timeout     = 5
    startPeriod = 30
  }
```