### PR TITLE
Update pdfcoverpage path

### DIFF
--- a/src/PdfCoverPage/generator.py
+++ b/src/PdfCoverPage/generator.py
@@ -21,7 +21,7 @@ manifest_bucket = os.environ.get("MANIFEST_BUCKET", "wellcomecollection-stage-ii
 key_prefix = os.environ.get("KEY_PREFIX", "v3")
 
 
-@app.route('/pdfcoverpage/<string:identifier>', methods=["GET"])
+@app.route('/pdf-cover/<string:identifier>', methods=["GET"])
 def generate_pdf(identifier: str):
     """Uses data from S3 manifest to construct PDF response"""
     manifest = get_manifest(identifier)
@@ -169,7 +169,7 @@ def page_not_found(e):
     return jsonify({"Error": "Resource not found"}), 404
 
 
-@app.route('/pdfcoverpage/ping', methods=["GET"])
+@app.route('/pdf-cover/ping', methods=["GET"])
 def ping():
     return jsonify(status='working')
 

--- a/src/PdfCoverPage/readme.md
+++ b/src/PdfCoverPage/readme.md
@@ -4,8 +4,8 @@ This is a Flask app run as via Docker image.
 
 It has the following endpoints:
 
-* `/pdfcoverpage/{bnumber}` - generate PDF cover-page using manifest for specified bnumber.
-* `/pdfcoverpage/ping` - for health-checks
+* `/pdf-cover/{bnumber}` - generate PDF cover-page using manifest for specified bnumber.
+* `/pdf-cover/ping` - for health-checks
 
 ## Implementation Notes
 


### PR DESCRIPTION
`pdfcoverpage` -> `pdf-cover` to match paths on iiif.wc.org to avoid need to rewrite rules.