### PR TITLE
Search API and Alto annotations to S3

### DIFF
--- a/src/Wellcome.Dds/IIIF/Auth/AuthCookieService1.cs
+++ b/src/Wellcome.Dds/IIIF/Auth/AuthCookieService1.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace IIIF.Auth
 {
-    public class AuthCookieService1 : ServiceBase, IService
+    public class AuthCookieService1 : LegacyResourceBase, IService
     {
         private const string LoginProfile = "http://iiif.io/api/auth/1/login";
         private const string ClickthroughProfile = "http://iiif.io/api/auth/1/clickthrough";

--- a/src/Wellcome.Dds/IIIF/Auth/AuthLogoutService1.cs
+++ b/src/Wellcome.Dds/IIIF/Auth/AuthLogoutService1.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace IIIF.Auth
 {
-    public class AuthLogoutService1: ServiceBase, IService
+    public class AuthLogoutService1: LegacyResourceBase, IService
     {
         public AuthLogoutService1()
         {

--- a/src/Wellcome.Dds/IIIF/Auth/AuthTokenService1.cs
+++ b/src/Wellcome.Dds/IIIF/Auth/AuthTokenService1.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace IIIF.Auth
 {
-    public class AuthTokenService1 : ServiceBase, IService
+    public class AuthTokenService1 : LegacyResourceBase, IService
     {
         public AuthTokenService1()
         {

--- a/src/Wellcome.Dds/IIIF/ImageApi/Service/ImageService2.cs
+++ b/src/Wellcome.Dds/IIIF/ImageApi/Service/ImageService2.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace IIIF.ImageApi.Service
 {
-    public class ImageService2 : ServiceBase, IService
+    public class ImageService2 : LegacyResourceBase, IService
     {
         public const string Image2Context = "http://iiif.io/api/image/2/context.json";
         public const string Level0Profile = "http://iiif.io/api/image/2/level0.json";

--- a/src/Wellcome.Dds/IIIF/JsonLdBase.cs
+++ b/src/Wellcome.Dds/IIIF/JsonLdBase.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace IIIF
+{
+    public abstract class JsonLdBase
+    {
+        // TODO - this can be List<string> or string - how will deserializer handle this? string[] or string? 
+        [JsonProperty(Order = 1, PropertyName = "@context")]
+        public object? Context { get; set; } // This one needs its serialisation name changing...
+    }
+}

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/Annotation.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/Annotation.cs
@@ -1,0 +1,29 @@
+using IIIF.Presentation.Annotation;
+using Newtonsoft.Json;
+
+namespace IIIF.LegacyInclusions
+{
+    public class Annotation : LegacyResourceBase, IAnnotation
+    {   
+        [JsonProperty(Order = 10, PropertyName = "motivation")]
+        public virtual string Motivation { get; set; }
+
+        public override string Type => "oa:Annotation";
+        
+        [JsonProperty(Order = 40, PropertyName = "resource")]
+        public LegacyResourceBase Resource { get; set; }
+
+        // TODO - on can be an object with an @id and a "within" as well as a URI
+        // "on" : {
+        //  "@id": "http://example.org/identifier/canvas1#xywh=100,100,250,20",
+        //  "within": {
+        //    "@id": "http://example.org/identifier/manifest",
+        //    "type": "sc:Manifest",
+        //    "label": "Example Manifest"
+        //  }
+        // }
+        [JsonProperty(Order = 50, PropertyName = "on")]
+        public string On { get; set; }
+    }
+     
+}

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/AnnotationList.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/AnnotationList.cs
@@ -1,0 +1,13 @@
+﻿using IIIF.Presentation.Annotation;
+using Newtonsoft.Json;
+
+namespace IIIF.LegacyInclusions
+{
+    public class AnnotationList : LegacyResourceBase
+    {
+        public override string Type => "sc:AnnotationList";
+
+        [JsonProperty(Order = 20, PropertyName = "resources")]
+        public IAnnotation[] Resources { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/AnnotationList.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/AnnotationList.cs
@@ -1,4 +1,5 @@
-﻿using IIIF.Presentation.Annotation;
+﻿using System.Collections.Generic;
+using IIIF.Presentation.Annotation;
 using Newtonsoft.Json;
 
 namespace IIIF.LegacyInclusions
@@ -8,6 +9,6 @@ namespace IIIF.LegacyInclusions
         public override string Type => "sc:AnnotationList";
 
         [JsonProperty(Order = 20, PropertyName = "resources")]
-        public IAnnotation[] Resources { get; set; }
+        public List<IAnnotation> Resources { get; set; }
     }
 }

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/ContentAsTextAnnotationResource.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/ContentAsTextAnnotationResource.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace IIIF.LegacyInclusions
+{
+    public class ContentAsTextAnnotationResource : LegacyResourceBase
+    {
+        public override string Type => "cnt:ContentAsText";
+        
+        [JsonProperty(Order = 20, PropertyName = "chars")]
+        public string Chars { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/ContentAsTextAnnotationResource.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/ContentAsTextAnnotationResource.cs
@@ -8,5 +8,6 @@ namespace IIIF.LegacyInclusions
         
         [JsonProperty(Order = 20, PropertyName = "chars")]
         public string Chars { get; set; }
+        public string Format { get; set; }
     }
 }

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/ContentAsTextAnnotationResource.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/ContentAsTextAnnotationResource.cs
@@ -5,9 +5,11 @@ namespace IIIF.LegacyInclusions
     public class ContentAsTextAnnotationResource : LegacyResourceBase
     {
         public override string Type => "cnt:ContentAsText";
-        
+
+        [JsonProperty(Order = 10, PropertyName = "format")]
+        public string Format { get; set; }
+
         [JsonProperty(Order = 20, PropertyName = "chars")]
         public string Chars { get; set; }
-        public string Format { get; set; }
     }
 }

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/IllustrationAnnotationResource.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/IllustrationAnnotationResource.cs
@@ -1,0 +1,7 @@
+namespace IIIF.LegacyInclusions
+{
+    public class IllustrationAnnotationResource : LegacyResourceBase
+    {
+        public override string Type => "cnt:ContentAsText";
+    }
+}

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/IllustrationAnnotationResource.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/IllustrationAnnotationResource.cs
@@ -2,6 +2,6 @@ namespace IIIF.LegacyInclusions
 {
     public class IllustrationAnnotationResource : LegacyResourceBase
     {
-        public override string Type => "cnt:ContentAsText";
+        public override string Type => null;
     }
 }

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/LegacyResourceBase.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/LegacyResourceBase.cs
@@ -2,11 +2,8 @@ using Newtonsoft.Json;
 
 namespace IIIF.LegacyInclusions
 {
-    public abstract class ServiceBase
+    public abstract class LegacyResourceBase : JsonLdBase
     {
-        [JsonProperty(PropertyName = "@context", Order = 1)]
-        public string? Context { get; set; } 
-        
         [JsonProperty(PropertyName = "@id", Order = 2)]
         public string? Id { get; set; }
 

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/SearchResultAnnotation.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/SearchResultAnnotation.cs
@@ -1,0 +1,7 @@
+namespace IIIF.LegacyInclusions
+{
+    public class SearchResultAnnotation : Annotation
+    {
+        public override string Motivation => "sc:painting";
+    }
+}

--- a/src/Wellcome.Dds/IIIF/LegacyInclusions/SearchResultAnnotationResource.cs
+++ b/src/Wellcome.Dds/IIIF/LegacyInclusions/SearchResultAnnotationResource.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace IIIF.LegacyInclusions
+{
+    public class SearchResultAnnotationResource : LegacyResourceBase
+    {
+        public override string Type => "cnt:ContentAsText";
+        
+        [JsonProperty(Order = 10, PropertyName = "chars")]
+        public string? Chars { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Presentation/Annotation/Annotation.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/Annotation/Annotation.cs
@@ -20,6 +20,6 @@ namespace IIIF.Presentation.Annotation
         /// Note that this is a IIIF-specific use of target; can be anything in W3C
         /// </summary>
         [JsonProperty(Order = 900)]
-        public IStructuralLocation Target { get; set; }
+        public IStructuralLocation? Target { get; set; }
     }
 }

--- a/src/Wellcome.Dds/IIIF/Presentation/Annotation/ClassifyingBody.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/Annotation/ClassifyingBody.cs
@@ -1,0 +1,14 @@
+using IIIF.Presentation.Strings;
+
+namespace IIIF.Presentation.Annotation
+{
+    public class ClassifyingBody : ResourceBase
+    {
+        public ClassifyingBody(string classifyingType)
+        {
+            Id = classifyingType;
+        }
+        
+        public override string Type => null;
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Presentation/Annotation/SupplementingAnnotation.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/Annotation/SupplementingAnnotation.cs
@@ -6,6 +6,6 @@ namespace IIIF.Presentation.Annotation
     {
         public override string Motivation => Constants.Motivation.Supplementing;
         
-        public ExternalResource Body { get; set; }
+        public ResourceBase? Body { get; set; }
     }
 }

--- a/src/Wellcome.Dds/IIIF/Presentation/Annotation/TextualBody.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/Annotation/TextualBody.cs
@@ -1,0 +1,21 @@
+namespace IIIF.Presentation.Annotation
+{
+    public class TextualBody : ResourceBase
+    {
+        public TextualBody(string value)
+        {
+            Value = value;
+        }
+        
+        public TextualBody(string value, string format)
+        {
+            Value = value;
+            Format = format;
+        }
+        
+        public override string Type => nameof(TextualBody);
+        
+        public string? Value { get; set; }
+        public string? Format { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Presentation/Annotation/TypeClassifyingAnnotation.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/Annotation/TypeClassifyingAnnotation.cs
@@ -1,0 +1,9 @@
+namespace IIIF.Presentation.Annotation
+{
+    public class TypeClassifyingAnnotation : Annotation
+    {
+        public override string Motivation => Constants.Motivation.Classifying;
+        
+        public ResourceBase? Body { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Presentation/Constants/Context.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/Constants/Context.cs
@@ -5,17 +5,65 @@ namespace IIIF.Presentation.Constants
 {
     public static class Context
     {
-        public const string Presentation3Context = "http://iiif.io/api/presentation/3/context.json";
+        public const string Presentation3Context = "http://iiif.io/api/presentation/3/contextToEnsure.json";
 
-        public static void AddPresentation3Context(this ResourceBase resource, params string[] additionalContexts)
+        public static void EnsurePresentation3Context(this ResourceBase resource)
         {
-            if (additionalContexts.Length > 0)
+            resource.EnsureContext(Presentation3Context);
+        }
+
+        // The IIIF context must be last in the list, to override any that come before it.
+        public static void EnsureContext(this ResourceBase resource, string contextToEnsure)
+        {
+            if (resource.Context == null)
             {
-                resource.Context = new List<string>(additionalContexts) {Presentation3Context};
+                resource.Context = contextToEnsure;
+                return;
+            }
+
+            List<string> workingContexts = new();
+            if (resource.Context is List<string> existingContexts)
+            {
+                workingContexts = existingContexts;
+            }
+
+            if (resource.Context is string singleContext)
+            {
+                workingContexts = new List<string> { singleContext };
+            }
+            
+            List<string> newContexts = new();
+            bool hasPresentation3Context = false;
+            foreach (string workingContext in workingContexts)
+            {
+                if (workingContext == Presentation3Context)
+                {
+                    hasPresentation3Context = true;
+                }
+                else
+                {
+                    newContexts.Add(workingContext);
+                }
+            }
+
+            if (!newContexts.Contains(contextToEnsure))
+            {
+                newContexts.Add(contextToEnsure);
+            }
+
+            if (hasPresentation3Context)
+            {
+                // always last
+                newContexts.Add(Presentation3Context);
+            }
+
+            if (newContexts.Count == 1)
+            {
+                resource.Context = newContexts[0];
             }
             else
             {
-                resource.Context = Presentation3Context;
+                resource.Context = newContexts;
             }
         }
     }

--- a/src/Wellcome.Dds/IIIF/Presentation/Constants/Context.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/Constants/Context.cs
@@ -1,19 +1,25 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
 
 namespace IIIF.Presentation.Constants
 {
     public static class Context
     {
-        public const string Presentation3Context = "http://iiif.io/api/presentation/3/contextToEnsure.json";
+        public const string Presentation3Context = "http://iiif.io/api/presentation/3/context.json";
+        public const string Presentation2Context = "http://iiif.io/api/presentation/2/context.json";
 
-        public static void EnsurePresentation3Context(this ResourceBase resource)
+        public static void EnsurePresentation3Context(this JsonLdBase resource)
         {
             resource.EnsureContext(Presentation3Context);
         }
+        
+        public static void EnsurePresentation2Context(this JsonLdBase resource)
+        {
+            resource.EnsureContext(Presentation2Context);
+        }
 
         // The IIIF context must be last in the list, to override any that come before it.
-        public static void EnsureContext(this ResourceBase resource, string contextToEnsure)
+        public static void EnsureContext(this JsonLdBase resource, string contextToEnsure)
         {
             if (resource.Context == null)
             {
@@ -34,11 +40,16 @@ namespace IIIF.Presentation.Constants
             
             List<string> newContexts = new();
             bool hasPresentation3Context = false;
+            bool hasPresentation2Context = false;
             foreach (string workingContext in workingContexts)
             {
                 if (workingContext == Presentation3Context)
                 {
                     hasPresentation3Context = true;
+                }
+                else if (workingContext == Presentation2Context)
+                {
+                    hasPresentation2Context = true;
                 }
                 else
                 {
@@ -51,12 +62,22 @@ namespace IIIF.Presentation.Constants
                 newContexts.Add(contextToEnsure);
             }
 
+            if (hasPresentation2Context && hasPresentation3Context)
+            {
+                throw new InvalidOperationException(
+                    "You cannot have Presentation 2 and Presentation 3 contexts in the same resource.");
+            }
+            // These have to come last
             if (hasPresentation3Context)
             {
-                // always last
                 newContexts.Add(Presentation3Context);
             }
+            if (hasPresentation2Context)
+            {
+                newContexts.Add(Presentation2Context);
+            }
 
+            // Now JSON-LD rules. The @context is the only Presentation 3 element that has this.
             if (newContexts.Count == 1)
             {
                 resource.Context = newContexts[0];

--- a/src/Wellcome.Dds/IIIF/Presentation/Constants/Motivation.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/Constants/Motivation.cs
@@ -3,7 +3,98 @@ namespace IIIF.Presentation.Constants
 {
     public static class Motivation
     {
+        // IIIF-specific extension motivations
+        
+        /// <summary>
+        /// The content can be thought of as being *of* the Canvas.
+        /// For example, an image of a book page, that is expected to be rendered to a user.
+        /// </summary>
         public const string Painting = "painting";
+        
+        /// <summary>
+        /// The content can be thought of as being *from* the Canvas.
+        /// For example, a textual transcription of a line or a page.
+        /// </summary>
         public const string Supplementing = "supplementing";
+        
+        // W3C Annotation motivations
+        
+        /// <summary>
+        /// The motivation for when the user intends to assess the target resource in some way, rather than
+        /// simply make a comment about it. For example to write a review or assessment of a book, assess the
+        /// quality of a dataset, or provide an assessment of a student's work.
+        /// </summary>
+        public const string Assessing = "assessing";
+
+        /// <summary>
+        /// The motivation for when the user intends to create a bookmark to the Target or part thereof.
+        /// For example an Annotation that bookmarks the point in a text where the reader finished reading.
+        /// </summary>
+        public const string Bookmarking = "bookmarking";
+
+        /// <summary>
+        /// The motivation for when the user intends to classify the Target as something.
+        /// For example to classify an image as a portrait.
+        /// </summary>
+        public const string Classifying = "classifying";
+
+        /// <summary>
+        /// The motivation for when the user intends to comment about the Target.
+        /// For example to provide a commentary about a particular PDF document.
+        /// </summary>
+        public const string Commenting = "commenting";
+
+        /// <summary>
+        /// The motivation for when the user intends to describe the Target,
+        /// as opposed to (for example) a comment about it.
+        /// For example describing the above PDF's contents, rather than commenting on their accuracy.
+        /// </summary>
+        public const string Describing = "describing";
+
+        /// <summary>
+        /// The motivation for when the user intends to request a change or edit to the Target resource.
+        /// For example an Annotation that requests a typo to be corrected.
+        /// </summary>
+        public const string Editing = "editing";
+
+        /// <summary>
+        /// The motivation for when the user intends to highlight the Target resource or segment of it.
+        /// For example to draw attention to the selected text that the annotator disagrees with.
+        /// </summary>
+        public const string Highlighting = "highlighting";
+
+        /// <summary>
+        /// The motivation for when the user intends to assign an identity to the Target.
+        /// For example to associate the IRI that identifies a city with a mention of the city in a web page.
+        /// </summary>
+        public const string Identifying = "identifying";
+
+        /// <summary>
+        /// The motivation for when the user intends to link to a resource related to the Target.
+        /// </summary>
+        public const string Linking = "linking";
+        
+        /// <summary>
+        /// The motivation for when the user intends to assign some value or quality to the Target.
+        /// For example annotating an Annotation to moderate it up in a trust network or threaded discussion.
+        /// </summary>
+        public const string Moderating = "moderating";
+        
+        /// <summary>
+        /// The motivation for when the user intends to ask a question about the Target.
+        /// For example to ask for assistance with a particular section of text, or question its veracity.
+        /// </summary>
+        public const string Questioning = "questioning";
+
+        /// <summary>
+        /// The motivation for when the user intends to reply to a previous statement,
+        /// either an Annotation or another resource. For example providing the assistance requested in the above.
+        /// </summary>
+        public const string Replying = "replying";
+
+        /// <summary>
+        /// The motivation for when the user intends to associate a tag with the Target.
+        /// </summary>
+        public const string Tagging = "tagging";
     }
 }

--- a/src/Wellcome.Dds/IIIF/Presentation/ResourceBase.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/ResourceBase.cs
@@ -8,12 +8,8 @@ namespace IIIF.Presentation
     /// <summary>
     /// Base class for all IIIF presentation resources. 
     /// </summary>
-    public abstract class ResourceBase
+    public abstract class ResourceBase : JsonLdBase
     {
-        // TODO - this can be List<string> or string - how will deserializer handle this? string[] or string? 
-        [JsonProperty(Order = 1, PropertyName = "@context")]
-        public object? Context { get; set; } // This one needs its serialisation name changing...
-        
         /// <summary>
         /// The URI that identifies the resource.
         /// See <a href="https://iiif.io/api/presentation/3.0/#id">id</a>

--- a/src/Wellcome.Dds/IIIF/Search/IHasIgnorableParameters.cs
+++ b/src/Wellcome.Dds/IIIF/Search/IHasIgnorableParameters.cs
@@ -1,0 +1,7 @@
+﻿namespace IIIF.Search
+{
+    public interface IHasIgnorableParameters
+    {
+        string[] Ignored { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V1/AutoCompleteService1.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V1/AutoCompleteService1.cs
@@ -1,0 +1,11 @@
+﻿using IIIF.LegacyInclusions;
+
+namespace IIIF.Search.V1
+{
+    public class AutoCompleteService1 : LegacyResourceBase, IService
+    {
+        public const string AutoCompleteService1Profile = "http://iiif.io/api/search/1/autocomplete";
+
+        public override string Type => nameof(AutoCompleteService1);
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V1/Hit.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V1/Hit.cs
@@ -1,0 +1,27 @@
+﻿using IIIF.LegacyInclusions;
+using Newtonsoft.Json;
+
+namespace IIIF.Search.V1
+{
+    public class Hit : LegacyResourceBase
+    {
+        public override string Type => "search:Hit";
+
+        [JsonProperty(Order = 40, PropertyName = "annotations")]
+        public string[] Annotations { get; set; }
+
+        [JsonProperty(Order = 50, PropertyName = "match")]
+        public string Match { get; set; }
+
+        [JsonProperty(Order = 51, PropertyName = "before")]
+        public string Before { get; set; }
+
+        [JsonProperty(Order = 52, PropertyName = "after")]
+        public string After { get; set; }
+
+        // Not used for Wellcome
+        [JsonProperty(Order = 60, PropertyName = "selectors")]
+
+        public TextQuoteSelector[] Selectors { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V1/SearchResultAnnotationList.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V1/SearchResultAnnotationList.cs
@@ -1,0 +1,23 @@
+﻿using IIIF.LegacyInclusions;
+using Newtonsoft.Json;
+
+namespace IIIF.Search.V1
+{
+    public class SearchResultAnnotationList : AnnotationList
+    {
+        [JsonProperty(Order = 10, PropertyName = "within")]
+        public SearchResultsLayer Within { get; set; }
+
+        [JsonProperty(Order = 12, PropertyName = "previous")]
+        public string Previous { get; set; }
+
+        [JsonProperty(Order = 13, PropertyName = "next")]
+        public string Next { get; set; }
+
+        [JsonProperty(Order = 16, PropertyName = "startIndex")]
+        public int StartIndex { get; set; }
+
+        [JsonProperty(Order = 30, PropertyName = "hits")]
+        public Hit[] Hits { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V1/SearchResultsLayer.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V1/SearchResultsLayer.cs
@@ -1,0 +1,25 @@
+﻿using IIIF.LegacyInclusions;
+using Newtonsoft.Json;
+
+namespace IIIF.Search.V1
+{    
+    /// <summary>
+    /// Each AnnotationList references a Layer.  The Layer can be a blank node, and must be included in every annotation list. 
+    /// </summary>
+    public class SearchResultsLayer : LegacyResourceBase, IHasIgnorableParameters
+    {
+        public override string Type => "sc:Layer";
+
+        [JsonProperty(Order = 10, PropertyName = "total")]
+        public int Total { get; set; }
+
+        [JsonProperty(Order = 14, PropertyName = "first")]
+        public string First { get; set; }
+
+        [JsonProperty(Order = 15, PropertyName = "last")]
+        public string Last { get; set; }
+
+        [JsonProperty(Order = 20, PropertyName = "ignored")]
+        public string[] Ignored { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V1/SearchService1.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V1/SearchService1.cs
@@ -1,0 +1,18 @@
+﻿using IIIF.LegacyInclusions;
+using Newtonsoft.Json;
+
+namespace IIIF.Search.V1
+{
+    public class SearchService1 : LegacyResourceBase, IService
+    {
+        public const string Search1Context = "http://iiif.io/api/search/1/context.json";
+        public const string Search1Profile = "http://iiif.io/api/search/1/search";
+
+        [JsonProperty(PropertyName = "@type", Order = 3)]
+        public override string Type => nameof(SearchService1);
+
+        
+
+        public AutoCompleteService1? Service { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V1/Term.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V1/Term.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace IIIF.Search.V1
+{
+    public class Term
+    {
+        [JsonProperty(Order = 11, PropertyName = "match")]
+        public string Match { get; set; }
+
+        // Hide for now, Wellcome don't know this
+        //[JsonProperty(Order = 12, PropertyName = "total")]
+        //public int Total { get; set; }
+
+        [JsonProperty(Order = 13, PropertyName = "label")]
+        public string Label { get; set; }
+
+        [JsonProperty(Order = 14, PropertyName = "search")]
+        public string Search { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V1/TermList.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V1/TermList.cs
@@ -1,0 +1,16 @@
+﻿using IIIF.LegacyInclusions;
+using Newtonsoft.Json;
+
+namespace IIIF.Search.V1
+{
+    public class TermList : LegacyResourceBase, IHasIgnorableParameters
+    {
+        public override string Type => "search:TermList";
+
+        [JsonProperty(Order = 20, PropertyName = "ignored")]
+        public string[] Ignored { get; set; }
+
+        [JsonProperty(Order = 40, PropertyName = "terms")]
+        public Term[] Terms { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V1/TextQuoteSelector.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V1/TextQuoteSelector.cs
@@ -1,0 +1,19 @@
+﻿using IIIF.LegacyInclusions;
+using Newtonsoft.Json;
+
+namespace IIIF.Search.V1
+{
+    public class TextQuoteSelector: LegacyResourceBase
+    {
+        public override string Type => "oa:TextQuoteSelector";
+
+        [JsonProperty(Order = 51, PropertyName = "exact")]
+        public string Exact { get; set; }
+
+        [JsonProperty(Order = 52, PropertyName = "prefix")]
+        public string Prefix { get; set; }
+
+        [JsonProperty(Order = 53, PropertyName = "suffix")]
+        public string Suffix { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Search/V2/AutoCompleteService2.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V2/AutoCompleteService2.cs
@@ -1,6 +1,6 @@
 using IIIF.Presentation.Content;
 
-namespace IIIF.Search
+namespace IIIF.Search.V2
 {
     public class AutoCompleteService2 : ExternalResource, IService
     {

--- a/src/Wellcome.Dds/IIIF/Search/V2/SearchService2.cs
+++ b/src/Wellcome.Dds/IIIF/Search/V2/SearchService2.cs
@@ -1,6 +1,6 @@
 using IIIF.Presentation.Content;
 
-namespace IIIF.Search
+namespace IIIF.Search.V2
 {
     public class SearchService2 : ExternalResource, IService
     {

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -11,6 +11,7 @@
         // TODO - leave this with the name "LinkedDataDomain" for now, for ease of migration,
         // but later, refactor to "SchemeAndHost"
         public string LinkedDataDomain { get; set; }
+        public string RewriteDomainLinksTo { get; set; }
         
         public bool AvoidCaching { get; set; }
         public string EarliestJobDateTime { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -37,5 +37,6 @@
         public string PresentationContainer { get; set; }
         public string TextContainer { get; set; }
         public string AnnotationContainer { get; set; }
+        public bool ReferenceV0SearchService { get; set; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Dds.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Dds.cs
@@ -27,9 +27,9 @@ namespace Wellcome.Dds.Repositories
             this.synchroniser = synchroniser;
         }
 
-        public List<Manifestation> AutoComplete(string id)
+        public List<Manifestation> AutoComplete(string query)
         {
-            return ddsContext.AutoComplete(id);
+            return ddsContext.AutoComplete(query);
         }
 
         public List<Manifestation> GetByAssetType(string type)

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/DdsContext.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/DdsContext.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Wellcome.Dds.Repositories
 {
@@ -22,9 +25,22 @@ namespace Wellcome.Dds.Repositories
             throw new NotImplementedException();
         }
 
-        public List<Manifestation> AutoComplete(string id)
+        public List<Manifestation> AutoComplete(string query)
         {
-            throw new NotImplementedException();
+            if (Regex.IsMatch(query, "\\Ab\\d+\\z"))
+            {
+                return Manifestations.Where(m => 
+                    m.Index == 0 &&
+                    m.PackageIdentifier.Contains(query)).ToList();
+            }
+            if (query == "imfeelinglucky")
+            {
+                var sql = "SELECT * FROM manifestations OFFSET floor(random()*(select count(*) from manifestations)) LIMIT 1";
+                return Manifestations.FromSqlRaw(sql).ToList();
+            }
+            return Manifestations.Where(m => 
+                m.Index == 0 &&
+                m.Label.Contains(query)).ToList();
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -16,6 +16,7 @@ using Wellcome.Dds.Catalogue;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
 using Wellcome.Dds.Repositories.Presentation.SpecialState;
+using Wellcome.Dds.WordsAndPictures.SimpleAltoServices;
 
 namespace Wellcome.Dds.Repositories.Presentation
 {
@@ -381,13 +382,26 @@ namespace Wellcome.Dds.Repositories.Presentation
             return p2Version;
         }
 
-        
-        public string Serialise(StructureBase iiifResource)
+        public AltoAnnotationBuildResult BuildW3CAnnotations(IManifestation manifestation, AnnotationPageList annotationPages)
+        {
+            var result = new AltoAnnotationBuildResult(manifestation);
+            // See IIIFConverter in ecosystem, line 1610
+            // loop through annotationPages
+            // build annos for each page
+            // emit a single page and key per page
+            // append the annos to the all list
+            // append just the images to the image list
+            return result;
+        }
+
+        public string Serialise(ResourceBase iiifResource)
         {
             return JsonConvert.SerializeObject(iiifResource, GetJsFriendlySettings());
         }
         // we'll need another Serialise for IIIFv2
 
+        
+        
         private static JsonSerializerSettings GetJsFriendlySettings()
         {
             var settings = new JsonSerializerSettings
@@ -398,6 +412,8 @@ namespace Wellcome.Dds.Repositories.Presentation
             };
             return settings;
         }
+        
+        
 
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -446,6 +446,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                 result.ImageAnnotations.Items.AddRange(illustrations);
                 result.ImageAnnotations.Items.AddRange(composedBlocks);
                 w3CPage.Items.AddRange(allPageAnnotations);
+                result.PageAnnotations[i] = w3CPage;
             }
             return result;
         }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -452,10 +452,10 @@ namespace Wellcome.Dds.Repositories.Presentation
         }
 
 
-        private SupplementingDocumentAnnotation GetTextLineAnnotation(
+        private Annotation GetTextLineAnnotation(
             AnnotationPage altoPage, TextLine tl, int lineIndex, string canvasId)
         {
-            return new()
+            return new SupplementingDocumentAnnotation
             {
                 Id = uriPatterns.CanvasSupplementingAnnotation(
                     altoPage.ManifestationIdentifier, altoPage.AssetIdentifier, $"t{lineIndex}"),
@@ -472,7 +472,6 @@ namespace Wellcome.Dds.Repositories.Presentation
                 Id = uriPatterns.CanvasClassifyingAnnotation(
                     altoPage.ManifestationIdentifier, altoPage.AssetIdentifier, $"i{index}"),
                 Target = new Canvas { Id = $"{canvasId}#xywh={il.X},{il.Y},{il.Width},{il.Height}" },
-                Motivation = Motivation.Classifying,
                 Body = new ClassifyingBody("Image")
                 {
                     Label = Lang.Map(il.Type) // https://github.com/w3c/web-annotation/issues/437

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -314,7 +314,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                         {
                             canvas.SeeAlso = new List<ExternalResource>
                             {
-                                new ExternalResource("Dataset")
+                                new("Dataset")
                                 {
                                     Id = uriPatterns.MetsAlto(manifestIdentifier, assetIdentifier),
                                     Format = "text/html",
@@ -324,9 +324,9 @@ namespace Wellcome.Dds.Repositories.Presentation
                             };
                             canvas.Annotations = new List<AnnotationPage>
                             {
-                                new AnnotationPage
+                                new ()
                                 {
-                                    Id = uriPatterns.CanvasOtherAnnotationPage(manifestIdentifier, assetIdentifier),
+                                    Id = uriPatterns.CanvasOtherAnnotationPageWithVersion(manifestIdentifier, assetIdentifier, 3),
                                     Label = Lang.Map(orderLabel.HasText() ? $"Text of page {orderLabel}" : "Text of this page")
                                 }
                             };
@@ -780,12 +780,12 @@ namespace Wellcome.Dds.Repositories.Presentation
                 {
                     new AnnotationPage
                     {
-                        Id = uriPatterns.ManifestAnnotationPageAll(metsManifestation.Id),
+                        Id = uriPatterns.ManifestAnnotationPageAllWithVersion(metsManifestation.Id, 3),
                         Label = Lang.Map($"All OCR-derived annotations for {metsManifestation.Id}")
                     },
                     new AnnotationPage
                     {
-                        Id = uriPatterns.ManifestAnnotationPageImages(metsManifestation.Id),
+                        Id = uriPatterns.ManifestAnnotationPageImagesWithVersion(metsManifestation.Id, 3),
                         Label = Lang.Map($"OCR-identified images and figures for {metsManifestation.Id}")
                     },
                 };

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -30,6 +30,7 @@ namespace Wellcome.Dds.Repositories.Presentation
     {
         private readonly UriPatterns uriPatterns;
         private readonly int dlcsDefaultSpace;
+        private readonly bool referenceV0SearchService;
         private readonly ManifestStructureHelper manifestStructureHelper;
         private readonly IAuthServiceProvider authServiceProvider;
 
@@ -42,10 +43,12 @@ namespace Wellcome.Dds.Repositories.Presentation
         
         public IIIFBuilderParts(
             UriPatterns uriPatterns,
-            int dlcsDefaultSpace)
+            int dlcsDefaultSpace,
+            bool referenceV0SearchService)
         {
             this.uriPatterns = uriPatterns;
             this.dlcsDefaultSpace = dlcsDefaultSpace;
+            this.referenceV0SearchService = referenceV0SearchService;
             manifestStructureHelper = new ManifestStructureHelper();
             authServiceProvider = new DlcsIIIFAuthServiceProvider();
             
@@ -228,9 +231,13 @@ namespace Wellcome.Dds.Repositories.Presentation
             {
                 manifest.EnsureContext(SearchService1.Search1Context);
                 manifest.Service ??= new List<IService>();
+                string searchServiceId;
+                searchServiceId = referenceV0SearchService ? 
+                    uriPatterns.IIIFContentSearchService0(digitisedManifestation.Identifier) : 
+                    uriPatterns.IIIFContentSearchService1(digitisedManifestation.Identifier);
                 manifest.Service.Add(new SearchService1
                 {
-                    Id = uriPatterns.IIIFContentSearchService1(digitisedManifestation.Identifier),
+                    Id = searchServiceId,
                     Profile = SearchService1.Search1Profile,
                     Label = new MetaDataValue("Search within this manifest"),
                     Service = new AutoCompleteService1

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using IIIF;
 using IIIF.ImageApi.Service;
+using IIIF.LegacyInclusions;
 using IIIF.Presentation;
 using IIIF.Presentation.Annotation;
 using IIIF.Presentation.Constants;
 using IIIF.Presentation.Content;
 using IIIF.Presentation.Strings;
-using IIIF.Search;
+using IIIF.Search.V1;
 using Utils;
 using Wellcome.Dds.AssetDomain.Dashboard;
 using Wellcome.Dds.AssetDomain.Dlcs;
@@ -225,18 +226,18 @@ namespace Wellcome.Dds.Repositories.Presentation
         {
             if (digitisedManifestation.MetsManifestation.Sequence.SupportsSearch())
             {
+                manifest.EnsureContext(SearchService1.Search1Context);
                 manifest.Service ??= new List<IService>();
-                manifest.Service.Add(new SearchService2
+                manifest.Service.Add(new SearchService1
                 {
-                    Id = uriPatterns.IIIFContentSearchService2(digitisedManifestation.Identifier),
-                    Label = Lang.Map("Search within this manifest"),
-                    Service = new List<IService>
+                    Id = uriPatterns.IIIFContentSearchService1(digitisedManifestation.Identifier),
+                    Profile = SearchService1.Search1Profile,
+                    Label = new MetaDataValue("Search within this manifest"),
+                    Service = new AutoCompleteService1
                     {
-                        new AutoCompleteService2
-                        {
-                            Id = uriPatterns.IIIFAutoCompleteService2(digitisedManifestation.Identifier),
-                            Label = Lang.Map("Autocomplete words in this manifest")
-                        }
+                        Id = uriPatterns.IIIFAutoCompleteService1(digitisedManifestation.Identifier),
+                        Profile = AutoCompleteService1.AutoCompleteService1Profile,
+                        Label = new MetaDataValue("Autocomplete words in this manifest")
                     }
                 });
             }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -284,7 +284,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                         var (mainImage, thumbImage) = GetCanvasImages(physicalFile);
                         canvas.Items = new List<AnnotationPage>
                         {
-                            new AnnotationPage
+                            new()
                             {
                                 Id = uriPatterns.CanvasPaintingAnnotationPage(manifestIdentifier, assetIdentifier),
                                 Items = new List<IAnnotation>
@@ -930,7 +930,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                     new SupplementingDocumentAnnotation
                     {
                         Id = uriPatterns.CanvasSupplementingAnnotation(
-                            manifestIdentifier, storedPdf.StorageIdentifier),
+                            manifestIdentifier, storedPdf.StorageIdentifier, "transcript"),
                         Body = new ExternalResource("Text")
                         {
                             Id = uriPatterns.DlcsFile(dlcsDefaultSpace, storedPdf.StorageIdentifier),

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/AltoSearchTextProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/AltoSearchTextProvider.cs
@@ -29,7 +29,6 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
             this.logger = logger;
         }
 
-        // TODO - replace with single identifier
         public async Task<Text> GetSearchText(string identifier)
         {
             var sw = new Stopwatch();

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/CachingAllAnnotationProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/CachingAllAnnotationProvider.cs
@@ -62,6 +62,8 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
                     var page = altoProvider.GetAnnotationPage(altoRoot,
                         physicalFile.AssetMetadata.GetImageWidth(),
                         physicalFile.AssetMetadata.GetImageHeight(),
+                        identifier,
+                        physicalFile.StorageIdentifier,
                         (physicalFile.Order ?? 1) - 1);
                     logger.LogInformation($"Adding page - {page}");
                     pages.Add(page);

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/CachingAltoSearchTextProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/CachingAltoSearchTextProvider.cs
@@ -8,12 +8,12 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
 {
     public class CachingAltoSearchTextProvider : ISearchTextProvider
     {
-        private readonly ISearchTextProvider altoSearchTextProvider;
+        private readonly AltoSearchTextProvider altoSearchTextProvider;
         private readonly IBinaryObjectCache<Text> searchTextCache; 
         // needs options altoCache and httpRuntimeSeconds, prefix "alto_"
         
         public CachingAltoSearchTextProvider(
-            ISearchTextProvider altoSearchTextProvider,
+            AltoSearchTextProvider altoSearchTextProvider,
             IBinaryObjectCache<Text> searchTextCache)
         {
             this.altoSearchTextProvider = altoSearchTextProvider;

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Utils.Storage;
+using Wellcome.Dds.Common;
+using Wellcome.Dds.Server.Conneg;
+
+namespace Wellcome.Dds.Server.Controllers
+{    
+    [Route("[controller]")]
+    [ApiController]
+    public class AnnotationsController : ControllerBase
+    {
+        private readonly IStorage storage;
+        private readonly DdsOptions ddsOptions;
+        private Helpers helpers;
+
+        public AnnotationsController(
+            IStorage storage,
+            IOptions<DdsOptions> options,
+            Helpers helpers
+        )
+        {
+            this.storage = storage;
+            ddsOptions = options.Value;
+            this.helpers = helpers;
+        }
+
+        // TODO: What is the correct content type for W3C Web annos?
+        [HttpGet("v3/{*id}")]
+        public Task<IActionResult> GetVersion3Annos(string id) => GetIIIFResource($"v3/{id}", IIIFPresentation.ContentTypes.V3);
+
+        // TODO: What do we do for the V2 path?
+        // either... emit at creation time (=> 2x the resources in S3)
+        // or convert dynamically (=> computational overhead when harvested)
+        private async Task<IActionResult> GetIIIFResource(string path, string contentType)
+        {
+            return await helpers.ServeIIIFContent(ddsOptions.AnnotationContainer, path, contentType, this);
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Utils.Storage;
 using Wellcome.Dds.Common;
+using Wellcome.Dds.IIIFBuilding;
 using Wellcome.Dds.Server.Conneg;
 
 namespace Wellcome.Dds.Server.Controllers
@@ -14,25 +15,39 @@ namespace Wellcome.Dds.Server.Controllers
         private readonly IStorage storage;
         private readonly DdsOptions ddsOptions;
         private Helpers helpers;
+        private UriPatterns uriPatterns;
 
         public AnnotationsController(
             IStorage storage,
             IOptions<DdsOptions> options,
-            Helpers helpers
+            Helpers helpers,
+            UriPatterns uriPatterns
         )
         {
             this.storage = storage;
             ddsOptions = options.Value;
             this.helpers = helpers;
+            this.uriPatterns = uriPatterns;
         }
 
-        // TODO: What is the correct content type for W3C Web annos?
         [HttpGet("v3/{*id}")]
         public Task<IActionResult> GetVersion3Annos(string id) => GetIIIFResource($"v3/{id}", IIIFPresentation.ContentTypes.V3);
 
-        // TODO: What do we do for the V2 path?
-        // either... emit at creation time (=> 2x the resources in S3)
-        // or convert dynamically (=> computational overhead when harvested)
+        [HttpGet("v2/{identifier}/{assetIdentifier}/line")]
+        public Task<IActionResult> GetVersion2CanvasAnnos(string identifier, string assetIdentifier)
+        {
+            // load the v3 Key
+            var key = $"v3/{identifier}/{assetIdentifier}/line";
+            var v3 = helpers.LoadAsJson(ddsOptions.AnnotationContainer, key);
+            
+            // parse and convert to v2
+            
+            // Jsonify and serve: return Content(..)
+        }
+        
+        [HttpGet("v2/{*id}")]
+        public Task<IActionResult> GetVersion2ManifestAnnos(string id) => GetIIIFResource($"v2/{id}", IIIFPresentation.ContentTypes.V2);
+        
         private async Task<IActionResult> GetIIIFResource(string path, string contentType)
         {
             return await helpers.ServeIIIFContent(ddsOptions.AnnotationContainer, path, contentType, this);

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -12,41 +14,48 @@ namespace Wellcome.Dds.Server.Controllers
     [ApiController]
     public class AnnotationsController : ControllerBase
     {
-        private readonly IStorage storage;
         private readonly DdsOptions ddsOptions;
         private Helpers helpers;
-        private UriPatterns uriPatterns;
+        private IIIIFBuilder iiifBuilder;
 
         public AnnotationsController(
-            IStorage storage,
             IOptions<DdsOptions> options,
             Helpers helpers,
-            UriPatterns uriPatterns
+            IIIIFBuilder iiifBuilder
         )
         {
-            this.storage = storage;
             ddsOptions = options.Value;
             this.helpers = helpers;
-            this.uriPatterns = uriPatterns;
+            this.iiifBuilder = iiifBuilder;
         }
 
         [HttpGet("v3/{*id}")]
-        public Task<IActionResult> GetVersion3Annos(string id) => GetIIIFResource($"v3/{id}", IIIFPresentation.ContentTypes.V3);
+        public Task<IActionResult> GetVersion3Annos(string id) => 
+            GetIIIFResource($"v3/{id}", IIIFPresentation.ContentTypes.V3);
 
         [HttpGet("v2/{identifier}/{assetIdentifier}/line")]
-        public Task<IActionResult> GetVersion2CanvasAnnos(string identifier, string assetIdentifier)
+        public async Task<IActionResult> GetVersion2CanvasAnnos(string identifier, string assetIdentifier)
         {
             // load the v3 Key
             var key = $"v3/{identifier}/{assetIdentifier}/line";
-            var v3 = helpers.LoadAsJson(ddsOptions.AnnotationContainer, key);
+            var v3 = await helpers.LoadAsJson(ddsOptions.AnnotationContainer, key);
+
+            if (v3 == null)
+            {
+                return NotFound($"No annotation page available for {identifier}/{assetIdentifier}.");
+            }
             
             // parse and convert to v2
+            var v2 = iiifBuilder.ConvertW3CAnnoPageJsonToOAAnnoList(
+                v3, identifier, assetIdentifier);
             
             // Jsonify and serve: return Content(..)
+            return Content(iiifBuilder.Serialise(v2), IIIFPresentation.ContentTypes.V2);
         }
         
         [HttpGet("v2/{*id}")]
-        public Task<IActionResult> GetVersion2ManifestAnnos(string id) => GetIIIFResource($"v2/{id}", IIIFPresentation.ContentTypes.V2);
+        public Task<IActionResult> GetVersion2ManifestAnnos(string id) => 
+            GetIIIFResource($"v2/{id}", IIIFPresentation.ContentTypes.V2);
         
         private async Task<IActionResult> GetIIIFResource(string path, string contentType)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
@@ -1,8 +1,10 @@
+#nullable enable
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Utils;
 using Utils.Storage;
 using Wellcome.Dds.Common;
@@ -57,6 +59,24 @@ namespace Wellcome.Dds.Server.Controllers
             string raw = await reader.ReadToEndAsync();
             string rewritten = raw.Replace(ddsOptions.LinkedDataDomain, ddsOptions.RewriteDomainLinksTo);
             return controller.Content(rewritten, contentType);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public async Task<object?> LoadAsJson(string container, string path)
+        {
+            var stream = await storage.GetStream(container, path);
+            if(stream == null)
+            {
+                return null;
+            }
+            using StreamReader reader = new(stream);
+            using JsonTextReader jsonReader = new(reader);
+            return new JsonSerializer().Deserialize(jsonReader);
         }
         
     }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Utils;
 using Utils.Storage;
 using Wellcome.Dds.Common;
@@ -67,7 +68,7 @@ namespace Wellcome.Dds.Server.Controllers
         /// <param name="container"></param>
         /// <param name="path"></param>
         /// <returns></returns>
-        public async Task<object?> LoadAsJson(string container, string path)
+        public async Task<JObject?> LoadAsJson(string container, string path)
         {
             var stream = await storage.GetStream(container, path);
             if(stream == null)
@@ -76,7 +77,8 @@ namespace Wellcome.Dds.Server.Controllers
             }
             using StreamReader reader = new(stream);
             using JsonTextReader jsonReader = new(reader);
-            return new JsonSerializer().Deserialize(jsonReader);
+            // In the IIIF context, this should ALWAYS come out as JObject.
+            return new JsonSerializer().Deserialize(jsonReader) as JObject;
         }
         
     }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
@@ -1,0 +1,63 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Utils;
+using Utils.Storage;
+using Wellcome.Dds.Common;
+
+namespace Wellcome.Dds.Server.Controllers
+{
+    public class Helpers
+    {
+        private readonly IStorage storage;
+        private readonly DdsOptions ddsOptions;
+
+        public Helpers(
+            IStorage storage,
+            IOptions<DdsOptions> options)
+        {
+            this.storage = storage;
+            ddsOptions = options.Value;
+        }
+
+        /// <summary>
+        /// We don't have separate S3 buckets with IIIF content that uses localhost paths.
+        /// And we don't want to do that, you'd need a lot of test content.
+        /// This optionally allows the locally run Dds.Server to rewrite the LinedDataDomain in the response.
+        /// This is obviously slower and inefficient, but it only does it if an overriding domain is provided.
+        /// It allows localhost to create content in the test S3 bucket, but serve it with correct paths.
+        ///
+        /// Add an extra local appSetting to the Dds section:
+        /// 
+        /// "RewriteDomainLinksTo": "http://localhost:8084",
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="path"></param>
+        /// <param name="contentType"></param>
+        /// <param name="controller"></param>
+        /// <returns></returns>
+        public async Task<IActionResult> ServeIIIFContent(string container, string path, string contentType,
+            ControllerBase controller)
+        {            
+            var stream = await storage.GetStream(container, path);
+            if (stream == null)
+            {
+                return controller.NotFound($"No IIIF resource found for {path}");
+            }
+            if (string.IsNullOrWhiteSpace(ddsOptions.RewriteDomainLinksTo))
+            {
+                // This is the efficient way to return the response
+                return controller.File(stream, contentType);
+            }
+
+            // This is an inefficient method but allows us to manipulate the response.
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            string raw = await reader.ReadToEndAsync();
+            string rewritten = raw.Replace(ddsOptions.LinkedDataDomain, ddsOptions.RewriteDomainLinksTo);
+            return controller.Content(rewritten, contentType);
+        }
+        
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
@@ -1,17 +1,11 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using DlcsWebClient.Config;
 using IIIF.Presentation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Utils.Storage;
-using Wellcome.Dds.AssetDomain.Dashboard;
-using Wellcome.Dds.AssetDomainRepositories.Dashboard;
-using Wellcome.Dds.Catalogue;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.Server.Conneg;
-using Wellcome.Dds.Server.Models;
 
 namespace Wellcome.Dds.Server.Controllers
 {
@@ -24,19 +18,23 @@ namespace Wellcome.Dds.Server.Controllers
     {
         private readonly IStorage storage;
         private readonly DdsOptions ddsOptions;
+        private Helpers helpers;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="storage"></param>
         /// <param name="options"></param>
+        /// <param name="helpers"></param>
         public PresentationController(
             IStorage storage,
-            IOptions<DdsOptions> options
+            IOptions<DdsOptions> options,
+            Helpers helpers
             )
         {
             this.storage = storage;
             ddsOptions = options.Value;
+            this.helpers = helpers;
         }
         
         /// <summary>
@@ -73,12 +71,7 @@ namespace Wellcome.Dds.Server.Controllers
 
         private async Task<IActionResult> GetIIIFResource(string path, string contentType)
         {
-            var stream = await storage.GetStream(ddsOptions.PresentationContainer, path);
-            if (stream == null)
-            {
-                return NotFound($"No IIIF resource found for {path}");
-            }
-            return File(stream, contentType);
+            return await helpers.ServeIIIFContent(ddsOptions.PresentationContainer, path, contentType, this);
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SearchController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SearchController.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using IIIF.Search;
+using Utils;
+using Wellcome.Dds.IIIFBuilding;
+using Wellcome.Dds.Repositories.WordsAndPictures;
+using Wellcome.Dds.WordsAndPictures.Search;
+
+namespace Wellcome.Dds.Server.Controllers
+{
+    [Route("[controller]")]
+    [ApiController]
+    public class SearchController : ControllerBase
+    {
+        private CachingAltoSearchTextProvider searchTextProvider;
+        private IIIIFBuilder iiifBuilder;
+
+        private static readonly string[] SearchParameters = { "motivation", "date", "user", "box" };
+
+        public SearchController(
+            CachingAltoSearchTextProvider searchTextProvider,
+            IIIIFBuilder iiifBuilder
+            )
+        {
+            this.searchTextProvider = searchTextProvider;
+            this.iiifBuilder = iiifBuilder;
+        }
+
+        [HttpGet("autocomplete/v1/{manifestationIdentifier}")]
+        public async Task<IActionResult> AutoCompleteV1(string manifestationIdentifier, string q)
+        {
+            var text = await searchTextProvider.GetSearchText(manifestationIdentifier);
+            var suggestions = text.GetSuggestions(q);
+            var termList = iiifBuilder.BuildTermListV1(manifestationIdentifier, q, suggestions);
+            IgnoreParams(termList);
+            return Content(iiifBuilder.Serialise(termList), "application/json");
+        }
+
+
+        [HttpGet("v1/{manifestationIdentifier}")]
+        public async Task<IActionResult> SearchV1(string manifestationIdentifier, string q)
+        {
+            var text = await searchTextProvider.GetSearchText(manifestationIdentifier);
+            IEnumerable<SearchResult> results;
+            if (q.HasText())
+            {
+                results = SearchConverter.ConvertToSimplePlayerResults(text.Search(q));
+            }
+            else
+            {
+                results = new SearchResult[0];
+            }
+            var asAnnotations = iiifBuilder.BuildSearchResultsV1(results, manifestationIdentifier, q);
+            IgnoreParams(asAnnotations.Within);
+            // this implementation ignores all the other params
+            return Content(iiifBuilder.Serialise(asAnnotations), "application/json");
+        }
+
+        private void IgnoreParams(IHasIgnorableParameters resource)
+        {
+            var ignored = GetIgnoredParameters();
+            if (ignored.Any())
+            {
+                resource.Ignored = ignored;
+            }
+        }
+
+        /// <summary>
+        /// Request parameters for search that IIIF-Builder does not process
+        /// </summary>
+        /// <returns></returns>
+        private string[] GetIgnoredParameters()
+        {
+            var ignored = new List<string>();
+            foreach (string key in Request.Query.Keys)
+            {
+                var value = Request.Query[key][0];
+                if (SearchParameters.Contains(key) && !string.IsNullOrWhiteSpace(value))
+                {
+                    ignored.Add(key);
+                }
+            }
+            return ignored.ToArray();
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SearchController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SearchController.cs
@@ -4,7 +4,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using IIIF.Search;
+using IIIF.Search.V1;
+using Microsoft.Extensions.Options;
 using Utils;
+using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
 using Wellcome.Dds.Repositories.WordsAndPictures;
 using Wellcome.Dds.WordsAndPictures.Search;
@@ -17,14 +20,17 @@ namespace Wellcome.Dds.Server.Controllers
     {
         private CachingAltoSearchTextProvider searchTextProvider;
         private IIIIFBuilder iiifBuilder;
+        private readonly DdsOptions ddsOptions;
 
         private static readonly string[] SearchParameters = { "motivation", "date", "user", "box" };
 
         public SearchController(
+            IOptions<DdsOptions> options,
             CachingAltoSearchTextProvider searchTextProvider,
             IIIIFBuilder iiifBuilder
             )
         {
+            ddsOptions = options.Value;
             this.searchTextProvider = searchTextProvider;
             this.iiifBuilder = iiifBuilder;
         }
@@ -40,22 +46,49 @@ namespace Wellcome.Dds.Server.Controllers
         }
 
 
-        [HttpGet("v1/{manifestationIdentifier}")]
-        public async Task<IActionResult> SearchV1(string manifestationIdentifier, string q)
+        /// <summary>
+        /// http://localhost:8084/search/v0/b28047345?q=more%20robust
+        /// note the v0 path. Behaves like old DDS. "Simple Search" results.
+        /// </summary>
+        /// <param name="manifestationIdentifier"></param>
+        /// <param name="q"></param>
+        /// <returns></returns>
+        [HttpGet("v0/{manifestationIdentifier}")]
+        public async Task<IActionResult> SearchV0(string manifestationIdentifier, string q)
         {
             var text = await searchTextProvider.GetSearchText(manifestationIdentifier);
             IEnumerable<SearchResult> results;
             if (q.HasText())
             {
-                results = SearchConverter.ConvertToSimplePlayerResults(text.Search(q));
+                var resultRects = text.Search(q);
+                results = SearchConverter.ConvertToSimplePlayerResults(resultRects);
             }
             else
             {
                 results = new SearchResult[0];
             }
-            var asAnnotations = iiifBuilder.BuildSearchResultsV1(results, manifestationIdentifier, q);
+            var asAnnotations = iiifBuilder.BuildSearchResultsV0(text, results, manifestationIdentifier, q);
             IgnoreParams(asAnnotations.Within);
-            // this implementation ignores all the other params
+            return Content(iiifBuilder.Serialise(asAnnotations), "application/json");
+        }
+        
+        
+        /// <summary> 
+        /// http://localhost:8084/search/v1/b28047345?q=more%20robust
+        /// Hits are properly distributed.
+        /// One hit can span more than one canvas.
+        /// One canvas have more than one hit.
+        /// </summary>
+        /// <param name="manifestationIdentifier"></param>
+        /// <param name="q"></param>
+        /// <returns></returns>
+        [HttpGet("v1/{manifestationIdentifier}")]
+        public async Task<IActionResult> SearchV1(string manifestationIdentifier, string q)
+        {
+            // https://github.com/wellcomecollection/platform/issues/4740#issuecomment-775035270
+            var text = await searchTextProvider.GetSearchText(manifestationIdentifier);
+            var asAnnotations = iiifBuilder.BuildSearchResultsV1(text, manifestationIdentifier, q);
+            IgnoreParams(asAnnotations.Within);
             return Content(iiifBuilder.Serialise(asAnnotations), "application/json");
         }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/ServiceController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/ServiceController.cs
@@ -14,7 +14,7 @@ namespace Wellcome.Dds.Server.Controllers
         public ServiceController(IDds dds)
         {
             this.dds = dds;
-        }
+        }       
 
         [HttpGet("suggest-b-number")]
         public IActionResult SuggestBNumber(string q)

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/ServiceController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/ServiceController.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Utils;
+
+namespace Wellcome.Dds.Server.Controllers
+{   
+    [Route("[controller]")]
+    [ApiController]
+    public class ServiceController : ControllerBase
+    {
+        private IDds dds;
+        
+        public ServiceController(IDds dds)
+        {
+            this.dds = dds;
+        }
+
+        [HttpGet("suggest-b-number")]
+        public IActionResult SuggestBNumber(string q)
+        {
+            if (!q.HasText()) return Ok(System.Array.Empty<object>());
+            
+            var suggestions = dds.AutoComplete(q);
+            return Ok(suggestions.Select(fm => new AutoCompleteSuggestion
+            {
+                Id = fm.PackageIdentifier,
+                Label = fm.Label
+            }));
+        }
+        
+    }
+    
+    public class AutoCompleteSuggestion
+    {
+        public string Id { get; set; }
+        public string Label { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/TextController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/TextController.cs
@@ -64,8 +64,8 @@ namespace Wellcome.Dds.Server.Controllers
         public async Task<IActionResult> Alto(string manifestationIdentifier, string assetIdentifier)
         {
             var metsManifestation = await metsRepository.GetAsync(manifestationIdentifier) as IManifestation;
-            var asset = metsManifestation.Sequence.Single(pf => pf.StorageIdentifier == assetIdentifier);
-            if (asset.RelativeAltoPath.HasText())
+            var asset = metsManifestation?.Sequence.SingleOrDefault(pf => pf.StorageIdentifier == assetIdentifier);
+            if (asset != null && asset.RelativeAltoPath.HasText())
             {
                 var stream = await asset.WorkStore.GetStreamForPathAsync(asset.RelativeAltoPath);
                 return File(stream, "text/xml");

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/TextController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/TextController.cs
@@ -1,7 +1,10 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Utils;
 using Utils.Storage;
+using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.Common;
 
 namespace Wellcome.Dds.Server.Controllers
@@ -15,19 +18,23 @@ namespace Wellcome.Dds.Server.Controllers
     {
         private readonly IStorage storage;
         private readonly DdsOptions ddsOptions;
-        
+        private readonly IMetsRepository metsRepository;
+
         /// <summary>
         /// ctor
         /// </summary>
         /// <param name="storage">Provides S3 locations</param>
         /// <param name="options">DDS Options</param>
+        /// <param name="metsRepository"></param>
         public TextController(
             IStorage storage,
-            IOptions<DdsOptions> options
+            IOptions<DdsOptions> options,
+            IMetsRepository metsRepository
         )
         {
             this.storage = storage;
             ddsOptions = options.Value;
+            this.metsRepository = metsRepository;
         }
 
 
@@ -45,6 +52,25 @@ namespace Wellcome.Dds.Server.Controllers
                 return NotFound($"No text resource found for {id}");
             }
             return File(stream, "text/plain");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="manifestationIdentifier"></param>
+        /// <param name="assetIdentifier"></param>
+        /// <returns></returns>
+        [HttpGet("alto/{manifestationIdentifier}/{assetIdentifier}")]
+        public async Task<IActionResult> Alto(string manifestationIdentifier, string assetIdentifier)
+        {
+            var metsManifestation = await metsRepository.GetAsync(manifestationIdentifier) as IManifestation;
+            var asset = metsManifestation.Sequence.Single(pf => pf.StorageIdentifier == assetIdentifier);
+            if (asset.RelativeAltoPath.HasText())
+            {
+                var stream = await asset.WorkStore.GetStreamForPathAsync(asset.RelativeAltoPath);
+                return File(stream, "text/xml");
+            }
+            return NotFound($"No ALTO file for {manifestationIdentifier}/{assetIdentifier}");
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -30,6 +30,7 @@ using Wellcome.Dds.Repositories;
 using Wellcome.Dds.Repositories.Catalogue;
 using Wellcome.Dds.Server.Auth;
 using Wellcome.Dds.Server.Conneg;
+using Wellcome.Dds.Server.Controllers;
 using Wellcome.Dds.Server.Infrastructure;
 
 namespace Wellcome.Dds.Server
@@ -119,6 +120,7 @@ namespace Wellcome.Dds.Server
             services.AddHttpClient<ICatalogue, WellcomeCollectionCatalogue>();
             
             services.AddSingleton<UriPatterns>();
+            services.AddSingleton<Helpers>();
 
             // should cover all the resolved type usages...
             services.AddSingleton(typeof(IBinaryObjectCache<>), typeof(BinaryObjectCache<>));

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -146,8 +146,8 @@ namespace Wellcome.Dds.Server
                 .AddScoped<IIIIFBuilder, IIIFBuilder>()
                 .AddScoped<IMetsRepository, MetsRepository>()
                 .AddScoped<IDashboardRepository, DashboardRepository>()
-                .AddScoped<ISearchTextProvider, AltoSearchTextProvider>()
-                .AddScoped<CachingAltoSearchTextProvider>(); // mmm
+                .AddScoped<ISearchTextProvider, CachingAltoSearchTextProvider>()
+                .AddScoped<AltoSearchTextProvider>(); 
 
             services.AddSingleton<IAuthenticationService, SierraRestPatronApi>();
             // services.AddSingleton<IAuthenticationService, AllowAllAuthenticator>();

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -80,7 +80,14 @@ namespace Wellcome.Dds.Server
             });
 
             services.AddSwagger();
-            services.AddCors();
+            services.AddCors(options =>
+            {
+                options.AddPolicy("CorsPolicy",
+                    builder => builder
+                        .AllowAnyOrigin()
+                        .AllowAnyMethod()
+                        .AllowAnyHeader()); // we might need to customise CORS handling for IIIF Auth...
+            });
             services.AddMvc(options =>
             {
                 var jsonFormatter = options.OutputFormatters.OfType<SystemTextJsonOutputFormatter>().FirstOrDefault();
@@ -130,6 +137,8 @@ namespace Wellcome.Dds.Server
             // This is the one that needs an IAmazonS3 with the storage profile
             services.AddHttpClient<OAuth2ApiConsumer>();
             services.AddScoped<IWorkStorageFactory, ArchiveStorageServiceWorkStorageFactory>()
+                .AddScoped<Synchroniser>()
+                .AddScoped<IDds, Repositories.Dds>()
                 .AddScoped<StorageServiceClient>()
                 .AddScoped<IMetsRepository, MetsRepository>()
                 .AddScoped<IDashboardRepository, DashboardRepository>();
@@ -154,7 +163,7 @@ namespace Wellcome.Dds.Server
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseCors();
+            app.UseCors("CorsPolicy");
             app.SetupSwagger();
             app.UseStaticFiles();
             app.UseRouting();

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -28,10 +28,13 @@ using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
 using Wellcome.Dds.Repositories;
 using Wellcome.Dds.Repositories.Catalogue;
+using Wellcome.Dds.Repositories.Presentation;
+using Wellcome.Dds.Repositories.WordsAndPictures;
 using Wellcome.Dds.Server.Auth;
 using Wellcome.Dds.Server.Conneg;
 using Wellcome.Dds.Server.Controllers;
 using Wellcome.Dds.Server.Infrastructure;
+using Wellcome.Dds.WordsAndPictures;
 
 namespace Wellcome.Dds.Server
 {
@@ -140,8 +143,11 @@ namespace Wellcome.Dds.Server
                 .AddScoped<Synchroniser>()
                 .AddScoped<IDds, Repositories.Dds>()
                 .AddScoped<StorageServiceClient>()
+                .AddScoped<IIIIFBuilder, IIIFBuilder>()
                 .AddScoped<IMetsRepository, MetsRepository>()
-                .AddScoped<IDashboardRepository, DashboardRepository>();
+                .AddScoped<IDashboardRepository, DashboardRepository>()
+                .AddScoped<ISearchTextProvider, AltoSearchTextProvider>()
+                .AddScoped<CachingAltoSearchTextProvider>(); // mmm
 
             services.AddSingleton<IAuthenticationService, SierraRestPatronApi>();
             // services.AddSingleton<IAuthenticationService, AllowAllAuthenticator>();

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
@@ -76,6 +76,22 @@
       "Container": "wellcomecollection-stage-iiif-storagemaps",
       "Prefix": "stgmap-",
       "MemoryCacheSeconds": 180
+    },
+    "Wellcome.Dds.WordsAndPictures.Text": {
+      "AvoidCaching": false,
+      "AvoidSaving": false,
+      "WriteFailThrowsException": true,
+      "Container": "wellcomecollection-stage-iiif-text",
+      "Prefix": "stgtext-",
+      "MemoryCacheSeconds": 180
+    },
+    "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
+      "AvoidCaching": false,
+      "AvoidSaving": false,
+      "WriteFailThrowsException": true,
+      "Container": "wellcomecollection-stage-iiif-annotations",
+      "Prefix": "stgannos-",
+      "MemoryCacheSeconds": 180
     }
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
@@ -66,7 +66,8 @@
     "DlcsReturnUrl": "https://dlcs.io/auth/2/fromcas",
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
-    "AnnotationContainer": "wellcomecollection-stage-iiif-annotations"
+    "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
+    "ReferenceV0SearchService": true
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/AltoAnnotationBuildResult.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/AltoAnnotationBuildResult.cs
@@ -1,3 +1,4 @@
+using IIIF.LegacyInclusions;
 using IIIF.Presentation.Annotation;
 using Wellcome.Dds.AssetDomain.Mets;
 
@@ -10,17 +11,28 @@ namespace Wellcome.Dds.IIIFBuilding
             Manifestation = manifestation;
         }
         
+        // W3C (IIIF 3) Annotations
         // keys
         // - v3/{identifier}/all/line
         // - v3/{identifier}/images
         // - v3/{identifier}/{assetIdentifier}/line
-        
         public AnnotationPage AllContentAnnotations { get; set; }
-        public string AllContentAnnotationsKey { get; set; }
+        //public string AllContentAnnotationsKey { get; set; }
         public AnnotationPage ImageAnnotations { get; set; }
-        public string ImageAnnotationsKey { get; set; }
+        //public string ImageAnnotationsKey { get; set; }
         public AnnotationPage[] PageAnnotations { get; set; }
-        public string[] PageAnnotationsKeys { get; set; }
+        //public string[] PageAnnotationsKeys { get; set; }
+        
+        // Open Annotation (IIIF 2) Annotations
+        // keys
+        // - v2/{identifier}/all/line
+        // - v2/{identifier}/images
+        // We won't create page-level OA annotations.
+        // DDS.Server will transform them on the fly from the v3 W3C version.
+        public AnnotationList OpenAnnotationAllContentAnnotations { get; set; }
+        //public string OpenAnnotationAllContentAnnotationsKey { get; set; }
+        public AnnotationList OpenAnnotationImageAnnotations { get; set; }
+        //public string OpenAnnotationImageAnnotationsKey { get; set; }
         
         public IManifestation Manifestation { get; set; }
     }

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/AltoAnnotationBuildResult.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/AltoAnnotationBuildResult.cs
@@ -1,0 +1,27 @@
+using IIIF.Presentation.Annotation;
+using Wellcome.Dds.AssetDomain.Mets;
+
+namespace Wellcome.Dds.IIIFBuilding
+{
+    public class AltoAnnotationBuildResult
+    {
+        public AltoAnnotationBuildResult(IManifestation manifestation)
+        {
+            Manifestation = manifestation;
+        }
+        
+        // keys
+        // - v3/{identifier}/all/line
+        // - v3/{identifier}/images
+        // - v3/{identifier}/{assetIdentifier}/line
+        
+        public AnnotationPage AllContentAnnotations { get; set; }
+        public string AllContentAnnotationsKey { get; set; }
+        public AnnotationPage ImageAnnotations { get; set; }
+        public string ImageAnnotationsKey { get; set; }
+        public AnnotationPage[] PageAnnotations { get; set; }
+        public string[] PageAnnotationsKeys { get; set; }
+        
+        public IManifestation Manifestation { get; set; }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/AltoAnnotationBuildResult.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/AltoAnnotationBuildResult.cs
@@ -17,11 +17,8 @@ namespace Wellcome.Dds.IIIFBuilding
         // - v3/{identifier}/images
         // - v3/{identifier}/{assetIdentifier}/line
         public AnnotationPage AllContentAnnotations { get; set; }
-        //public string AllContentAnnotationsKey { get; set; }
         public AnnotationPage ImageAnnotations { get; set; }
-        //public string ImageAnnotationsKey { get; set; }
         public AnnotationPage[] PageAnnotations { get; set; }
-        //public string[] PageAnnotationsKeys { get; set; }
         
         // Open Annotation (IIIF 2) Annotations
         // keys
@@ -30,9 +27,7 @@ namespace Wellcome.Dds.IIIFBuilding
         // We won't create page-level OA annotations.
         // DDS.Server will transform them on the fly from the v3 W3C version.
         public AnnotationList OpenAnnotationAllContentAnnotations { get; set; }
-        //public string OpenAnnotationAllContentAnnotationsKey { get; set; }
         public AnnotationList OpenAnnotationImageAnnotations { get; set; }
-        //public string OpenAnnotationImageAnnotationsKey { get; set; }
         
         public IManifestation Manifestation { get; set; }
     }

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using IIIF;
+using IIIF.Search.V1;
 using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.Catalogue;
+using Wellcome.Dds.WordsAndPictures;
 using Wellcome.Dds.WordsAndPictures.Search;
 using Wellcome.Dds.WordsAndPictures.SimpleAltoServices;
 
@@ -43,6 +45,9 @@ namespace Wellcome.Dds.IIIFBuilding
         AltoAnnotationBuildResult BuildW3CAnnotations(IManifestation manifestation, AnnotationPageList annotationPages);
         
         IIIF.Search.V1.TermList BuildTermListV1(string manifestationIdentifier, string q, string[] suggestions);
-        IIIF.Search.V1.SearchResultAnnotationList BuildSearchResultsV1(IEnumerable<SearchResult> results, string manifestationIdentifier, string s);
+        SearchResultAnnotationList BuildSearchResultsV0(Text text, IEnumerable<SearchResult> results,
+            string manifestationIdentifier, string s);
+
+        SearchResultAnnotationList BuildSearchResultsV1(Text text, string manifestationIdentifier, string s);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading.Tasks;
-using IIIF.Presentation;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using IIIF;
 using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.Catalogue;
+using Wellcome.Dds.WordsAndPictures.Search;
 using Wellcome.Dds.WordsAndPictures.SimpleAltoServices;
 
 namespace Wellcome.Dds.IIIFBuilding
@@ -20,7 +22,7 @@ namespace Wellcome.Dds.IIIFBuilding
         /// <param name="work">If you already have a work, the class will use it, otherwise it will acquire it from the catalogue</param>
         /// <returns></returns>
         public Task<MultipleBuildResult> Build(string identifier, Work work = null);
-        
+
         /// <summary>
         /// Builds ALL Manifests and Collections for the given bNumber.
         /// For a single volume work this does the same as Build(..),
@@ -35,9 +37,12 @@ namespace Wellcome.Dds.IIIFBuilding
         /// <param name="work">If you already have a work, the class will use it, otherwise it will acquire it from the catalogue</param>
         /// <returns></returns>
         public Task<MultipleBuildResult> BuildAllManifestations(string bNumber, Work work = null);
+        
+        string Serialise(JsonLdBase iiifResource);
 
- 
-        string Serialise(ResourceBase iiifResource);
         AltoAnnotationBuildResult BuildW3CAnnotations(IManifestation manifestation, AnnotationPageList annotationPages);
+        
+        IIIF.Search.V1.TermList BuildTermListV1(string manifestationIdentifier, string q, string[] suggestions);
+        IIIF.Search.V1.SearchResultAnnotationList BuildSearchResultsV1(IEnumerable<SearchResult> results, string manifestationIdentifier, string s);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using IIIF.Presentation;
+using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.Catalogue;
+using Wellcome.Dds.WordsAndPictures.SimpleAltoServices;
 
 namespace Wellcome.Dds.IIIFBuilding
 {
@@ -35,6 +37,7 @@ namespace Wellcome.Dds.IIIFBuilding
         public Task<MultipleBuildResult> BuildAllManifestations(string bNumber, Work work = null);
 
  
-        string Serialise(StructureBase iiifResource);
+        string Serialise(ResourceBase iiifResource);
+        AltoAnnotationBuildResult BuildW3CAnnotations(IManifestation manifestation, AnnotationPageList annotationPages);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
@@ -42,7 +42,7 @@ namespace Wellcome.Dds.IIIFBuilding
         
         string Serialise(JsonLdBase iiifResource);
 
-        AltoAnnotationBuildResult BuildW3CAnnotations(IManifestation manifestation, AnnotationPageList annotationPages);
+        AltoAnnotationBuildResult BuildW3CAndOaAnnotations(IManifestation manifestation, AnnotationPageList annotationPages);
         
         IIIF.Search.V1.TermList BuildTermListV1(string manifestationIdentifier, string q, string[] suggestions);
         SearchResultAnnotationList BuildSearchResultsV0(Text text, IEnumerable<SearchResult> results,

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using IIIF;
+using IIIF.LegacyInclusions;
 using IIIF.Search.V1;
+using Newtonsoft.Json.Linq;
 using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.Catalogue;
 using Wellcome.Dds.WordsAndPictures;
@@ -49,5 +51,13 @@ namespace Wellcome.Dds.IIIFBuilding
             string manifestationIdentifier, string s);
 
         SearchResultAnnotationList BuildSearchResultsV1(Text text, string manifestationIdentifier, string s);
+        
+        /// <summary>
+        /// A dynamically parsed OA anno list.
+        /// TODO: We need to consider this approach (might not be a good idea).
+        /// </summary>
+        /// <param name="v3">A dynamically parsed JSON object</param>
+        /// <returns>A V2 (Open Annotation) AnnotatioList</returns>
+        AnnotationList ConvertW3CAnnoPageJsonToOAAnnoList(JObject v3, string manifestationIdentifier, string assetIdentifier);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -66,11 +66,13 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string CanvasOtherAnnotationFormat =        "/annotations/v3/{identifier}/{assetIdentifier}/line/{annoIdentifier}";
         private const string ManifestAnnotationPageAllFormat =    "/annotations/v3/{identifier}/all/line";
         private const string ManifestAnnotationPageImagesFormat = "/annotations/v3/{identifier}/images"; // not line, obvs.
-        
+
         // IIIF Content Search
-        private const string IIIFContentSearch2Format =           "/search/v2/{identifier}";
-        private const string IIIFAutoComplete2Format =            "/autocomplete/v2/{identifier}";
-        
+        private const string IIIFContentSearch1Format = "/search/v1/{identifier}";
+        private const string IIIFAutoComplete1Format = "/search/autocomplete/v1/{identifier}";
+        private const string IIIFContentSearch2Format = "/search/v2/{identifier}";
+        private const string IIIFAutoComplete2Format = "/search/autocomplete/v2/{identifier}";
+
         // Other resources
         private const string RawTextFormat =                      "/text/v1/{identifier}"; // v1 refers to Wellcome API
         private const string MetsAltoFormat =                     "/text/alto/{identifier}/{assetIdentifier}"; // v1 refers to Wellcome API
@@ -265,10 +267,18 @@ namespace Wellcome.Dds.IIIFBuilding
         {
             return ManifestIdentifier(IIIFContentSearch2Format, identifier);
         }
+        public string IIIFContentSearchService1(string identifier)
+        {
+            return ManifestIdentifier(IIIFContentSearch1Format, identifier);
+        }
 
         public string IIIFAutoCompleteService2(string identifier)
         {
             return ManifestIdentifier(IIIFAutoComplete2Format, identifier);
+        }
+        public string IIIFAutoCompleteService1(string identifier)
+        {
+            return ManifestIdentifier(IIIFAutoComplete1Format, identifier);
         }
 
         private string ManifestIdentifier(string template, string identifier)

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -58,16 +58,19 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string CanvasSuppAnnotationFormat =         "/presentation/{identifier}/canvases/{assetIdentifier}/supplementing/{annoIdentifier}";
         private const string CanvasClassifyingAnnotationFormat =  "/presentation/{identifier}/canvases/{assetIdentifier}/classifying/{annoIdentifier}";
         private const string RangeFormat =                        "/presentation/{identifier}/ranges/{rangeIdentifier}";
+
+        private const string IIIFSearchAnnotationFormat =         "/annotations/{identifier}/{assetIdentifier}/{annoIdentifier}";
         
         // Always versioned - todo... bring version out as parameter? 
         // NB /line/ is reserved for text granularity - can be other granularities later.
-        public const string AnnotationsPathPrefix = "/annotations/"; // This is leaky here. S3 keys intrude on UriPatterns. Revisit.
         private const string CanvasOtherAnnotationPageFormat =    "/annotations/v3/{identifier}/{assetIdentifier}/line";
         private const string CanvasOtherAnnotationFormat =        "/annotations/v3/{identifier}/{assetIdentifier}/line/{annoIdentifier}";
         private const string ManifestAnnotationPageAllFormat =    "/annotations/v3/{identifier}/all/line";
         private const string ManifestAnnotationPageImagesFormat = "/annotations/v3/{identifier}/images"; // not line, obvs.
 
         // IIIF Content Search
+        private const string IIIFContentSearch0Format = "/search/v0/{identifier}";
+        // private const string IIIFAutoComplete0Format = "/search/autocomplete/v0/{identifier}";  // not used - use v1
         private const string IIIFContentSearch1Format = "/search/v1/{identifier}";
         private const string IIIFAutoComplete1Format = "/search/autocomplete/v1/{identifier}";
         private const string IIIFContentSearch2Format = "/search/v2/{identifier}";
@@ -159,7 +162,15 @@ namespace Wellcome.Dds.IIIFBuilding
                 CanvasOtherAnnotationFormat, manifestIdentifier, assetIdentifier)
                 .Replace(AnnoIdentifierToken, annoIdentifier);
         }
-
+        
+        
+        public string IIIFSearchAnnotation(string manifestIdentifier, string assetIdentifier, string annoIdentifier)
+        {
+            return ManifestAndAssetIdentifiers(
+                    IIIFSearchAnnotationFormat, manifestIdentifier, assetIdentifier)
+                .Replace(AnnoIdentifierToken, annoIdentifier);
+        }
+        
         public string ManifestAnnotationPageAll(string identifier)
         {
             return ManifestIdentifier(ManifestAnnotationPageAllFormat, identifier);
@@ -270,6 +281,10 @@ namespace Wellcome.Dds.IIIFBuilding
         public string IIIFContentSearchService1(string identifier)
         {
             return ManifestIdentifier(IIIFContentSearch1Format, identifier);
+        }
+        public string IIIFContentSearchService0(string identifier)
+        {
+            return ManifestIdentifier(IIIFContentSearch0Format, identifier);
         }
 
         public string IIIFAutoCompleteService2(string identifier)

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -22,6 +22,7 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string AssetIdentifierToken = "{assetIdentifier}";
         private const string RangeIdentifierToken = "{rangeIdentifier}";
         private const string AnnoIdentifierToken = "{annoIdentifier}";
+        private const string VersionToken = "{version}";
         private const string FileExtensionToken = "{fileExt}";
         
         // TODO - these constants should be in the IIIF model
@@ -63,10 +64,10 @@ namespace Wellcome.Dds.IIIFBuilding
         
         // Always versioned - todo... bring version out as parameter? 
         // NB /line/ is reserved for text granularity - can be other granularities later.
-        private const string CanvasOtherAnnotationPageFormat =    "/annotations/v3/{identifier}/{assetIdentifier}/line";
-        private const string CanvasOtherAnnotationFormat =        "/annotations/v3/{identifier}/{assetIdentifier}/line/{annoIdentifier}";
-        private const string ManifestAnnotationPageAllFormat =    "/annotations/v3/{identifier}/all/line";
-        private const string ManifestAnnotationPageImagesFormat = "/annotations/v3/{identifier}/images"; // not line, obvs.
+        private const string CanvasOtherAnnotationPageFormat =    "/annotations/v{version}/{identifier}/{assetIdentifier}/line";
+        private const string CanvasOtherAnnotationFormat =        "/annotations/v{version}/{identifier}/{assetIdentifier}/line/{annoIdentifier}";
+        private const string ManifestAnnotationPageAllFormat =    "/annotations/v{version}/{identifier}/all/line";
+        private const string ManifestAnnotationPageImagesFormat = "/annotations/v{version}/{identifier}/images"; // not line, obvs.
 
         // IIIF Content Search
         private const string IIIFContentSearch0Format = "/search/v0/{identifier}";
@@ -138,47 +139,43 @@ namespace Wellcome.Dds.IIIFBuilding
         }    
         public string CanvasSupplementingAnnotation(string manifestIdentifier, string assetIdentifier, string annoIdentifier)
         {
-            return ManifestAndAssetIdentifiers(
-                CanvasSuppAnnotationFormat, manifestIdentifier, assetIdentifier)
-                .Replace(AnnoIdentifierToken, annoIdentifier);
+            return ManifestAndAssetAndAnnoIdentifiers(
+                CanvasSuppAnnotationFormat, manifestIdentifier, assetIdentifier, annoIdentifier);
         }   
         
         public string CanvasClassifyingAnnotation(string manifestIdentifier, string assetIdentifier, string annoIdentifier)
         {
-            return ManifestAndAssetIdentifiers(
-                    CanvasClassifyingAnnotationFormat, manifestIdentifier, assetIdentifier)
-                .Replace(AnnoIdentifierToken, annoIdentifier);
+            return ManifestAndAssetAndAnnoIdentifiers(
+                CanvasClassifyingAnnotationFormat, manifestIdentifier, assetIdentifier, annoIdentifier);
         }   
         
-        public string CanvasOtherAnnotationPage(string manifestIdentifier, string assetIdentifier)
+        public string CanvasOtherAnnotationPageWithVersion(string manifestIdentifier, string assetIdentifier, int version)
         {
-            return ManifestAndAssetIdentifiers(
-                CanvasOtherAnnotationPageFormat, manifestIdentifier, assetIdentifier);
+            return ManifestAndAssetIdentifiersWithVersion(
+                CanvasOtherAnnotationPageFormat, manifestIdentifier, assetIdentifier, version);
         }
 
-        public string CanvasOtherAnnotation(string manifestIdentifier, string assetIdentifier, string annoIdentifier)
+        public string CanvasOtherAnnotationWithVersion(string manifestIdentifier, string assetIdentifier, string annoIdentifier, int version)
         {
-            return ManifestAndAssetIdentifiers(
-                CanvasOtherAnnotationFormat, manifestIdentifier, assetIdentifier)
-                .Replace(AnnoIdentifierToken, annoIdentifier);
+            return ManifestAndAssetAndAnnoIdentifiersWithVersion(
+                CanvasOtherAnnotationFormat, manifestIdentifier, assetIdentifier, annoIdentifier, version);
         }
         
         
         public string IIIFSearchAnnotation(string manifestIdentifier, string assetIdentifier, string annoIdentifier)
         {
-            return ManifestAndAssetIdentifiers(
-                    IIIFSearchAnnotationFormat, manifestIdentifier, assetIdentifier)
-                .Replace(AnnoIdentifierToken, annoIdentifier);
+            return ManifestAndAssetAndAnnoIdentifiers(
+                    IIIFSearchAnnotationFormat, manifestIdentifier, assetIdentifier, annoIdentifier);
         }
         
-        public string ManifestAnnotationPageAll(string identifier)
+        public string ManifestAnnotationPageAllWithVersion(string identifier, int version)
         {
-            return ManifestIdentifier(ManifestAnnotationPageAllFormat, identifier);
+            return ManifestIdentifierWithVersion(ManifestAnnotationPageAllFormat, identifier, version);
         }
         
-        public string ManifestAnnotationPageImages(string identifier)
+        public string ManifestAnnotationPageImagesWithVersion(string identifier, int version)
         {
-            return ManifestIdentifier(ManifestAnnotationPageImagesFormat, identifier);
+            return ManifestIdentifierWithVersion(ManifestAnnotationPageImagesFormat, identifier, version);
         }
 
         public string CollectionForAggregation()
@@ -302,10 +299,34 @@ namespace Wellcome.Dds.IIIFBuilding
             return $"{schemeAndHostValue}{path}";
         }
         
+        private string ManifestIdentifierWithVersion(string template, string identifier, int version)
+        {
+            return ManifestIdentifier(template, identifier)
+                .Replace(VersionToken, version.ToString());
+        }
+        
         private string ManifestAndAssetIdentifiers(string template, string manifestIdentifier, string assetIdentifier)
         {
             return ManifestIdentifier(template, manifestIdentifier)
                 .Replace(AssetIdentifierToken, assetIdentifier);
+        }
+        
+        private string ManifestAndAssetIdentifiersWithVersion(string template, string manifestIdentifier, string assetIdentifier, int version)
+        {
+            return ManifestIdentifierWithVersion(template, manifestIdentifier, version)
+                .Replace(AssetIdentifierToken, assetIdentifier);
+        }
+        
+        private string ManifestAndAssetAndAnnoIdentifiers(string template, string manifestIdentifier, string assetIdentifier, string annoIdentifier)
+        {
+            return ManifestAndAssetIdentifiers(template, manifestIdentifier, assetIdentifier)
+                .Replace(AnnoIdentifierToken, annoIdentifier);
+        }
+        
+        private string ManifestAndAssetAndAnnoIdentifiersWithVersion(string template, string manifestIdentifier, string assetIdentifier, string annoIdentifier, int version)
+        {
+            return ManifestAndAssetIdentifiersWithVersion(template, manifestIdentifier, assetIdentifier, version)
+                .Replace(AnnoIdentifierToken, annoIdentifier);
         }
 
         public string Range(string manifestIdentifier, string rangeIdentifier)

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -55,13 +55,15 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string CanvasPaintingAnnotationPageFormat = "/presentation/{identifier}/canvases/{assetIdentifier}/painting";
         private const string CanvasPaintingAnnotationFormat =     "/presentation/{identifier}/canvases/{assetIdentifier}/painting/anno";
         private const string CanvasSuppAnnotationPageFormat =     "/presentation/{identifier}/canvases/{assetIdentifier}/supplementing";
-        private const string CanvasSuppAnnotationFormat =         "/presentation/{identifier}/canvases/{assetIdentifier}/supplementing/anno";
+        private const string CanvasSuppAnnotationFormat =         "/presentation/{identifier}/canvases/{assetIdentifier}/supplementing/{annoIdentifier}";
+        private const string CanvasClassifyingAnnotationFormat =  "/presentation/{identifier}/canvases/{assetIdentifier}/classifying/{annoIdentifier}";
         private const string RangeFormat =                        "/presentation/{identifier}/ranges/{rangeIdentifier}";
         
         // Always versioned - todo... bring version out as parameter? 
         // NB /line/ is reserved for text granularity - can be other granularities later.
+        public const string AnnotationsPathPrefix = "/annotations/"; // This is leaky here. S3 keys intrude on UriPatterns. Revisit.
         private const string CanvasOtherAnnotationPageFormat =    "/annotations/v3/{identifier}/{assetIdentifier}/line";
-        private const string CanvasOtherAnnotationFormat =        "/annotations/v3/{identifier}/{assetIdentifier}/line/{annoIdentifer}";
+        private const string CanvasOtherAnnotationFormat =        "/annotations/v3/{identifier}/{assetIdentifier}/line/{annoIdentifier}";
         private const string ManifestAnnotationPageAllFormat =    "/annotations/v3/{identifier}/all/line";
         private const string ManifestAnnotationPageImagesFormat = "/annotations/v3/{identifier}/images"; // not line, obvs.
         
@@ -129,11 +131,19 @@ namespace Wellcome.Dds.IIIFBuilding
             return ManifestAndAssetIdentifiers(
                 CanvasSuppAnnotationPageFormat, manifestIdentifier, assetIdentifier);
         }    
-        public string CanvasSupplementingAnnotation(string manifestIdentifier, string assetIdentifier)
+        public string CanvasSupplementingAnnotation(string manifestIdentifier, string assetIdentifier, string annoIdentifier)
         {
             return ManifestAndAssetIdentifiers(
-                CanvasSuppAnnotationFormat, manifestIdentifier, assetIdentifier);
-        }     
+                CanvasSuppAnnotationFormat, manifestIdentifier, assetIdentifier)
+                .Replace(AnnoIdentifierToken, annoIdentifier);
+        }   
+        
+        public string CanvasClassifyingAnnotation(string manifestIdentifier, string assetIdentifier, string annoIdentifier)
+        {
+            return ManifestAndAssetIdentifiers(
+                    CanvasClassifyingAnnotationFormat, manifestIdentifier, assetIdentifier)
+                .Replace(AnnoIdentifierToken, annoIdentifier);
+        }   
         
         public string CanvasOtherAnnotationPage(string manifestIdentifier, string assetIdentifier)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/AnnotationPage.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/AnnotationPage.cs
@@ -15,6 +15,9 @@ namespace Wellcome.Dds.WordsAndPictures.SimpleAltoServices
         {
             return $"Index {Index}; {TextLines?.Length ?? 0} lines";
         }
+        
+        public string ManifestationIdentifier { get; set; }
+        public string AssetIdentifier { get; set; }
     }
 
     [Serializable]

--- a/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/SimpleAltoProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/SimpleAltoProvider.cs
@@ -10,7 +10,11 @@ namespace Wellcome.Dds.WordsAndPictures.SimpleAltoServices
     {
         private static XNamespace ns = "http://www.loc.gov/standards/alto/ns-v2#";
 
-        public AnnotationPage GetAnnotationPage(XElement altoRoot, int actualWidth, int actualHeight, int index)
+        public AnnotationPage GetAnnotationPage(
+            XElement altoRoot,
+            int actualWidth, int actualHeight,
+            string manifestationIdentifier, string assetIdentifier,
+            int index)
         {
             var textLines = new List<TextLine>();
             var illustrations = new List<Illustration>();
@@ -51,6 +55,8 @@ namespace Wellcome.Dds.WordsAndPictures.SimpleAltoServices
                 TextLines = textLines.ToArray(),
                 Illustrations = illustrations.ToArray(),
                 ComposedBlocks = composedBlocks.ToArray(),
+                ManifestationIdentifier = manifestationIdentifier,
+                AssetIdentifier = assetIdentifier,
                 Index = index
             };
         }

--- a/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/Text.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/Text.cs
@@ -90,7 +90,7 @@ namespace Wellcome.Dds.WordsAndPictures
             int hitCounter = 0;
             while ((matchPos = NormalisedFullText.IndexOf(s, startPos, StringComparison.InvariantCultureIgnoreCase)) != -1)
             {
-                // this match might not be on a word boundary, so walk back to find the preceeding space
+                // this match might not be on a word boundary, so walk back to find the preceding space
                 int padding = 0;
                 while (matchPos > 0 && NormalisedFullText[matchPos - 1] != ' ')
                 {
@@ -158,7 +158,7 @@ namespace Wellcome.Dds.WordsAndPictures
                 }
                 else
                 {
-                    // add the previous coaleseced word to the results
+                    // add the previous coalesced word to the results
                     coalescedResults.Add(coalescedWord.ShallowCopy());
                     coalescedWord = ResultRect.FromWord(nextWord, hitMap[nextWord.Wd]);
                 }
@@ -171,7 +171,7 @@ namespace Wellcome.Dds.WordsAndPictures
 
         private void AddContext(List<ResultRect> coalescedResults)
         {
-            const int maxResultsWithContext = 100;
+            const int maxResultsWithContext = 200;
             const int snippetSize = 150;
             if (coalescedResults.Count < maxResultsWithContext)
             {

--- a/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/Text.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/Text.cs
@@ -171,7 +171,8 @@ namespace Wellcome.Dds.WordsAndPictures
 
         private void AddContext(List<ResultRect> coalescedResults)
         {
-            const int maxResultsWithContext = 200;
+            // TODO - these should be configurable - but do we want to be able to allow the caller to specify?
+            const int maxResultsWithContext = 100;
             const int snippetSize = 150;
             if (coalescedResults.Count < maxResultsWithContext)
             {

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowRunner.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowRunner.cs
@@ -213,7 +213,7 @@ namespace WorkflowProcessor
                                     cachingAllAnnotationProvider.ForcePagesRebuild(manifestation.Id, manifestation.Sequence);
                                 // Now convert them to W3C Web Annotations
                                 var result = iiifBuilder.BuildW3CAnnotations(manifestation, annotationPages);
-                                SaveAnnoPagesToS3(result);
+                                await SaveAnnoPagesToS3(result);
                                 logger.LogInformation(
                                     $"Rebuilt annotation pages for {manifestation.Id}: {annotationPages.Count} pages.");
                                 job.AnnosBuilt++;
@@ -269,7 +269,7 @@ namespace WorkflowProcessor
             await amazonS3.PutObjectAsync(put);
         }
 
-        private async void SaveAnnoPagesToS3(AltoAnnotationBuildResult builtAnnotations)
+        private async Task SaveAnnoPagesToS3(AltoAnnotationBuildResult builtAnnotations)
         {
             // Assumption - we save each page individually to S3 (=> 20m pages...)
             // We save the allcontent single list to S3


### PR DESCRIPTION
This ports over significant functionality from dds-ecosystem, but now emits annotations to S3 as W3C annotations.

This means, for every manifest:
- a single S3 resource with all that manifest's annotations (from every canvas, concatenated to a single page)
- a single S3 resource with all that manifest's images, identified from OCR. This is where ALTO identifies a figure, image, or composed block (e.g., a table of data).
- and for each canvas in the manifest, an S3 resource with just that canvas's annotations.

In order for this to work locally, I added a Helpers class to Dds.Server.
This rewrites fully qualified domains in the IIIF JSON response to your localhost address, so you can navigate from manifests to annotation lists.