### PR TITLE
And Dds.Server DI needs an explicit CachingAltoSearchTextProvider dec…

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -147,6 +147,7 @@ namespace Wellcome.Dds.Server
                 .AddScoped<IMetsRepository, MetsRepository>()
                 .AddScoped<IDashboardRepository, DashboardRepository>()
                 .AddScoped<ISearchTextProvider, CachingAltoSearchTextProvider>()
+                .AddScoped<CachingAltoSearchTextProvider>()
                 .AddScoped<AltoSearchTextProvider>(); 
 
             services.AddSingleton<IAuthenticationService, SierraRestPatronApi>();


### PR DESCRIPTION
This looks dumb and needs revisiting:

```
                .AddScoped<ISearchTextProvider, CachingAltoSearchTextProvider>()
                .AddScoped<CachingAltoSearchTextProvider>()
                .AddScoped<AltoSearchTextProvider>(); 
```

AltoSearchTextProvider and CachingAltoSearchTextProvider are both ISearchTextProvider.

CachingAltoSearchTextProvider takes an explicit AltoSearchTextProvider in its constructor (it wraps it, even though on DDS Server we never expect to need to call it - we expect the search text object to exist, always).

SearchController takes an explicit CachingAltoSearchTextProvider in its constructor - Dds.Server never wants to use one that will rebuild in a public facing controller.

This requires all three entries as above. 
