### PR TITLE
Adds trackingLabel and accessHints as plain text services

### DIFF
--- a/src/Wellcome.Dds/IIIF/Presentation/V3/ICollectionItem.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/V3/ICollectionItem.cs
@@ -1,9 +1,12 @@
-﻿namespace IIIF.Presentation.V3
+﻿using System.Collections.Generic;
+
+namespace IIIF.Presentation.V3
 {
     /// <summary>
     /// Marker interface for resources that can be in a Collection's Items property.
     /// </summary>
     public interface ICollectionItem
     {
+        List<IService>? Services { get; set; }
     }
 }

--- a/src/Wellcome.Dds/IIIF/Presentation/V3/ResourceBase.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/V3/ResourceBase.cs
@@ -8,7 +8,7 @@ namespace IIIF.Presentation.V3
     /// <summary>
     /// Base class for all IIIF presentation resources. 
     /// </summary>
-    public abstract class ResourceBase : JsonLdBase
+    public abstract class ResourceBase : JsonLdBase, IService
     {
         /// <summary>
         /// The URI that identifies the resource.

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/BuildExtensions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/BuildExtensions.cs
@@ -162,6 +162,13 @@ namespace Wellcome.Dds.Repositories.Presentation
                 .FirstOrDefault(m => m.Label == "Location");
             return locationOfOriginal?.StringValue;
         }
+        
+        public static IEnumerable<string> GetDigitalCollectionCodes(this List<Metadata> metadata)
+        {
+            return metadata
+                .Where(m => m.Label == "Digitalcollection")
+                .Select(m => m.Identifier);
+        }
 
         public static string WrapSpan(this string s)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -396,7 +396,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             build.HomePage(iiifResource, work);
             build.Metadata(iiifResource, work);
             build.ArchiveCollectionStructure(iiifResource, work);
-            build.AddTrackingLabel(iiifResource, work, manifestationMetadata);
+            build.AddTrackingLabel(iiifResource, manifestationMetadata);
         }
         
         public AltoAnnotationBuildResult BuildW3CAndOaAnnotations(IManifestation manifestation, AnnotationPageList annotationPages)

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -370,6 +370,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             build.ImprovePagingSequence(manifest);
             build.CheckForCopyAndVolumeStructure(digitisedManifestation, state);
             build.ManifestLevelAnnotations(manifest, digitisedManifestation);
+            build.AddAccessHint(manifest, digitisedManifestation);
         }
         
         
@@ -395,6 +396,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             build.HomePage(iiifResource, work);
             build.Metadata(iiifResource, work);
             build.ArchiveCollectionStructure(iiifResource, work);
+            build.AddTrackingLabel(iiifResource, work, manifestationMetadata);
         }
         
         public AltoAnnotationBuildResult BuildW3CAndOaAnnotations(IManifestation manifestation, AnnotationPageList annotationPages)

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -1033,7 +1033,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             }
         }
 
-        public void AddTrackingLabel(ResourceBase iiifResource, Work work, ManifestationMetadata manifestationMetadata)
+        public void AddTrackingLabel(ResourceBase iiifResource, ManifestationMetadata manifestationMetadata)
         {
             var mdFormat = manifestationMetadata.Manifestations.FirstOrDefault()?.RootSectionType;
             var format = mdFormat.HasText() ? mdFormat : "n/a";

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/PartnerAgents.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/PartnerAgents.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using IIIF.Presentation;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Content;
 using Utils;
@@ -92,9 +91,16 @@ namespace Wellcome.Dds.Repositories.Presentation
             }
         };
 
-        public static Agent GetAgent(string repository, string schemeAndHost)
+        public static Agent? GetAgent(string repository, string schemeAndHost)
         {
-            Partner partner = null;
+            var partner = GetPartner(repository);
+
+            return partner != null ? MakeAgent(partner, schemeAndHost) : null;
+        }
+
+        public static Partner? GetPartner(string repository)
+        {
+            Partner? partner = null;
             if (repository.HasText())
             {
                 repository = repository.ToLowerInvariant();
@@ -128,7 +134,8 @@ namespace Wellcome.Dds.Repositories.Presentation
                 {
                     partner = Partners["bristol"];
                 }
-                else if (repository.Contains("london") && repository.Contains("hygiene") && repository.Contains("tropical medicine"))
+                else if (repository.Contains("london") && repository.Contains("hygiene") &&
+                         repository.Contains("tropical medicine"))
                 {
                     partner = Partners["lshtm"];
                 }
@@ -158,7 +165,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                 }
             }
 
-            return partner != null ? MakeAgent(partner, schemeAndHost) : null;
+            return partner;
         }
 
         private static Agent MakeAgent(Partner partner, string schemeAndHost)
@@ -191,10 +198,10 @@ namespace Wellcome.Dds.Repositories.Presentation
     /// <summary>
     /// Keep this to the minimum number of fields for maintenance.
     /// </summary>
-    class Partner
+    public class Partner
     {
-        public string Logo { get; set; }
-        public string HomePage { get; set; }
-        public string Label { get; set; }
+        public string? Logo { get; set; }
+        public string? HomePage { get; set; }
+        public string? Label { get; set; }
     }
 }


### PR DESCRIPTION
These are not both implemented without requiring any new vocabulary:

```
  "services": [
    {
      "type": "Text",
      "profile": "http://universalviewer.io/tracking-extensions-profile",
      "label": { "en": [ "Format: Monograph, Institution: n/a, Identifier: b22674883, Digicode: n/a, Collection code: n/a" ] }
    },
    {
      "type": "Text",
      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
      "label": { "en" :[ "open" ] }
    }
  ],
```
They keep the old profiles, but (unlike contexts) these are opaque to a JSON-LD processor.
A small adjustment to IIIF Library ICollectionItem interface was required, and a refactor of the Partners/Agents code to pull out a Partner label (e.g., University of Glasgow) independently of building the Provider object.