### PR TITLE
Add uv services to p2 manifest

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories.Tests/Presentation/V2/LegacyServiceFactoryTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories.Tests/Presentation/V2/LegacyServiceFactoryTests.cs
@@ -1,0 +1,62 @@
+﻿using FluentAssertions;
+using IIIF.Presentation.V3.Content;
+using Wellcome.Dds.Repositories.Presentation;
+using Wellcome.Dds.Repositories.Presentation.V2;
+using Xunit;
+
+namespace Wellcome.Dds.Repositories.Tests.Presentation.V2
+{
+    public class LegacyServiceFactoryTests
+    {
+        [Fact]
+        public void GetLegacyService_Null_IfProfileUnknown()
+        {
+            // Arrange
+            var resource = new ExternalResource("Test") {Profile = "unknown"};
+            
+            // Act
+            var service = LegacyServiceFactory.GetLegacyService("b19818786", resource);
+            
+            // Assert
+            service.Should().BeNull();
+        } 
+        
+        [Fact]
+        public void GetLegacyService_TrackingExtension()
+        {
+            // Arrange
+            var resource = new ExternalResource("Test")
+            {
+                Profile = Constants.Profiles.TrackingExtension,
+                Label = Lang.Map("Test Label")
+            };
+            
+            // Act
+            var service = LegacyServiceFactory.GetLegacyService("b19818786", resource);
+            
+            // Assert
+            service.Should()
+                .BeOfType<TrackingExtensionsService>()
+                .Which.TrackingLabel.Should().Be("Test Label");
+        }
+        
+        [Fact]
+        public void GetLegacyService_AccessControlHints()
+        {
+            // Arrange
+            var resource = new ExternalResource("Test")
+            {
+                Profile = Constants.Profiles.AccessControlHints,
+                Label = Lang.Map("Test Label")
+            };
+            
+            // Act
+            var service = LegacyServiceFactory.GetLegacyService("b19818786", resource);
+            
+            // Assert
+            service.Should()
+                .BeOfType<AccessControlHints>()
+                .Which.AccessHint.Should().Be("Test Label");
+        }  
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/Constants.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/Constants.cs
@@ -36,5 +36,21 @@
         /// </summary>
         public const string CopyrightNotClearedStatement =
             "The copyright of this item has not been evaluated. Please refer to the original publisher/creator of this item for more information. You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to your use. <br/>See <a target=\"_top\" href=\"http://rightsstatements.org/page/CNE/1.0/?language=en\">rightsstatements.org</a> for more information.";
+
+        /// <summary>
+        /// Profile strings for external services
+        /// </summary>
+        public static class Profiles
+        {
+            /// <summary>
+            /// Profile for tracking-extensions service
+            /// </summary>
+            public const string TrackingExtension = "http://universalviewer.io/tracking-extensions-profile";
+            
+            /// <summary>
+            /// Profile for access-control-hints service
+            /// </summary>
+            public const string AccessControlHints = "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints";
+        }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -1083,7 +1083,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             ((ICollectionItem)iiifResource).Services?.Add(
                 new ExternalResource("Text")
                 {
-                    Profile = "http://universalviewer.io/tracking-extensions-profile",
+                    Profile = Constants.Profiles.TrackingExtension,
                     Label = Lang.Map(trackingLabel)
                 });
         }
@@ -1112,7 +1112,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             manifest.Services?.Add(
                 new ExternalResource("Text")
                 {
-                    Profile = "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+                    Profile = Constants.Profiles.AccessControlHints,
                     Label = Lang.Map(accessHint)
                 });
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/AccessControlHints.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/AccessControlHints.cs
@@ -1,0 +1,27 @@
+﻿using IIIF;
+using IIIF.Presentation.V2;
+using IIIF.Presentation.V3.Strings;
+using Newtonsoft.Json;
+using Wellcome.Dds.Common;
+
+namespace Wellcome.Dds.Repositories.Presentation.V2
+{
+    /// <summary>
+    /// Service user to for by UV for legacy P2 manifests.
+    /// </summary>
+    public class AccessControlHints : ResourceBase, IService
+    {
+        public override string? Type { get; set; } = null;
+        
+        [JsonProperty(Order = 5, PropertyName = "accessHint")]
+        public string AccessHint { get; }
+
+        public AccessControlHints(DdsIdentifier identifier, LanguageMap accessHint)
+        {
+            AccessHint = accessHint.ToString();
+            Id = $"https://wellcomelibrary.org/iiif/{identifier}/access-control-hints-service";
+            Profile = Constants.Profiles.TrackingExtension;
+            Context = "http://wellcomelibrary.org/ld/iiif-ext/0/context.json";
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/LegacyServiceFactory.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/LegacyServiceFactory.cs
@@ -1,0 +1,25 @@
+﻿using IIIF;
+using IIIF.Presentation.V3.Content;
+using Wellcome.Dds.Common;
+
+namespace Wellcome.Dds.Repositories.Presentation.V2
+{
+    /// <summary>
+    /// Helper class for getting legacy services.
+    /// These are non-standard P2 IIIF services required for backwards compatibility
+    /// </summary>
+    public static class LegacyServiceFactory
+    {
+        /// <summary>
+        /// Get <see cref="IService"/> for specified <see cref="ExternalResource"/>
+        /// </summary>
+        public static IService? GetLegacyService(DdsIdentifier identifier, ExternalResource externalResource) =>
+            externalResource.Profile switch
+            {
+                Constants.Profiles.TrackingExtension => new TrackingExtensionsService(identifier,
+                    externalResource.Label!),
+                Constants.Profiles.AccessControlHints => new AccessControlHints(identifier, externalResource.Label!),
+                _ => null
+            };
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/TrackingExtensionsService.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/TrackingExtensionsService.cs
@@ -1,0 +1,27 @@
+﻿using IIIF;
+using IIIF.Presentation.V2;
+using IIIF.Presentation.V3.Strings;
+using Newtonsoft.Json;
+using Wellcome.Dds.Common;
+
+namespace Wellcome.Dds.Repositories.Presentation.V2
+{
+    /// <summary>
+    /// Service user to for tracking information in UV.
+    /// </summary>
+    public class TrackingExtensionsService : ResourceBase, IService
+    {
+        public override string? Type { get; set; } = null;
+        
+        [JsonProperty(Order = 5, PropertyName = "trackingLabel")]
+        public string TrackingLabel { get; }
+
+        public TrackingExtensionsService(DdsIdentifier identifier, LanguageMap trackingLabel)
+        {
+            TrackingLabel = trackingLabel.ToString();
+            Id = $"http://wellcomelibrary.org/service/trackingLabels/{identifier}";
+            Profile = Constants.Profiles.TrackingExtension;
+            Context = "http://universalviewer.io/context.json";
+        }
+    }
+}


### PR DESCRIPTION
Add `TrackingExtension` or `AccessControlHints` to output if present in P3. Only add latter if it there is no `WellcomeAuthService` already as this is how current P2 works.

Added new class to model each and a factory for easy handoff to generate.