### PR TITLE
Library site paths

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/DdsContext.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/DdsContext.cs
@@ -91,6 +91,15 @@ namespace Wellcome.Dds.Repositories
             return Database.MapRawSql(
                 ArchiveCollectionTop.Sql, dr => new ArchiveCollectionTop(dr));
         }
+
+
+
+        public Manifestation? GetManifestationByIndex(string identfier, int index)
+        {
+            return Manifestations.SingleOrDefault(
+                m => m.PackageIdentifier == identfier && m.Index == index);
+        }
+        
     }
 
     public record ValueAggregationResult
@@ -163,4 +172,5 @@ namespace Wellcome.Dds.Repositories
             }
         }
     }
+    
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+using Utils;
 using Wellcome.Dds.Catalogue;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
@@ -23,6 +29,8 @@ namespace Wellcome.Dds.Server.Controllers
         private readonly UriPatterns uriPatterns;
         private readonly DdsContext ddsContext;
         private readonly ICatalogue catalogue;
+        private readonly IMemoryCache memoryCache;
+        private Helpers helpers;
 
         /// <summary>
         /// 
@@ -34,13 +42,17 @@ namespace Wellcome.Dds.Server.Controllers
             UriPatterns uriPatterns,
             IOptions<DdsOptions> options,
             DdsContext ddsContext,
-            ICatalogue catalogue
+            ICatalogue catalogue,
+            IMemoryCache memoryCache,
+            Helpers helpers
             )
         {
             this.uriPatterns = uriPatterns;
             this.ddsOptions = options.Value;
             this.ddsContext = ddsContext;
             this.catalogue = catalogue;
+            this.memoryCache = memoryCache;
+            this.helpers = helpers;
         }
 
         
@@ -53,13 +65,19 @@ namespace Wellcome.Dds.Server.Controllers
         [HttpGet("iiif/{id}/manifest")]
         public IActionResult IIIFManifest(string id)
         {
-            return ManifestIdConversion(id, uriPatterns.Manifest);
+            return ManifestLevelConversion(id, uriPatterns.Manifest);
         }
 
         [HttpGet("annoservices/search/{id}")]
         public IActionResult SearchService(string id)
         {
-            return ManifestIdConversion(id, uriPatterns.IIIFContentSearchService0);
+            return ManifestLevelConversion(id, uriPatterns.IIIFContentSearchService0);
+        }
+        
+        [HttpGet("annoservices/autocomplete/{id}")]
+        public IActionResult AutoCompleteService(string id)
+        {
+            return ManifestLevelConversion(id, uriPatterns.IIIFAutoCompleteService1);
         }
         
         [HttpGet("player/{id}")]
@@ -74,29 +92,168 @@ namespace Wellcome.Dds.Server.Controllers
             return NotFound();
         }
 
-        private IActionResult ManifestIdConversion(string id, Func<string, string> converter)
+        [HttpGet("service/fulltext/{bNumber}/{manifestIndex}")]
+        public IActionResult ManifestFullText(string bNumber, int manifestIndex)
         {
-            if (id.Contains('-'))
+            return ManifestLevelConversion(bNumber, manifestIndex, 
+                uriPatterns.IIIFAutoCompleteService1, string.Empty);
+        }
+        
+        [HttpGet("service/alto/{bNumber}/{manifestIndex}")]
+        public async Task<IActionResult> AltoForCanvas(string bNumber, int manifestIndex, int image)
+        {
+            return await CanvasLevelConversion(bNumber, manifestIndex, image,
+                uriPatterns.MetsAlto, string.Empty);
+        }
+        
+        [HttpGet("iiif/{manifestId}/contentAsText/{image}")]
+        public async Task<IActionResult> ContentAsText(string manifestId, int image)
+        {
+            return await CanvasLevelConversionWithVersion(manifestId, image,
+                uriPatterns.CanvasOtherAnnotationPageWithVersion, string.Empty);
+        }
+        
+        [HttpGet("iiif/{manifestId}/images")]
+        public IActionResult ManifestImageAnnotations(string manifestId)
+        {
+            return ManifestLevelConversionWithVersion(
+                manifestId, uriPatterns.ManifestAnnotationPageImagesWithVersion);
+        }
+        
+        [HttpGet("iiif/{manifestId}/allcontent")]
+        public IActionResult ManifestAllContentAnnotations(string manifestId)
+        {
+            return ManifestLevelConversionWithVersion(
+                manifestId, uriPatterns.ManifestAnnotationPageAllWithVersion);
+        }
+        
+        private IActionResult ManifestLevelConversion(string id, Func<string, string> converter)
+        {
+            var idParts = ManifestIdParts(id);
+            var manifestation = ddsContext.GetManifestationByIndex(idParts.bNumber, idParts.index);
+            if (manifestation == null)
             {
-                var manifestation = GetManifestationFromTwoPartId(id);
-                if (manifestation == null)
-                {
-                    return NotFound();
-                }
-                return BuilderUrl(converter(manifestation.Id));
+                return NotFound();
             }
-            return BuilderUrl(converter(id));
-            
+            return BuilderUrl(converter(manifestation.Id));
+        }
+        
+        private IActionResult ManifestLevelConversionWithVersion(string id, Func<string, int, string> converter)
+        {
+            var idParts = ManifestIdParts(id);
+            var manifestation = ddsContext.GetManifestationByIndex(idParts.bNumber, idParts.index);
+            if (manifestation == null)
+            {
+                return NotFound();
+            }
+            return BuilderUrl(converter(manifestation.Id, 2));
+        }
+        
+        private IActionResult ManifestLevelConversion(string bNumber, int manifestIndex,
+            Func<string, string> converter, string newQueryString)
+        {
+            var manifestation = ddsContext.GetManifestationByIndex(bNumber, manifestIndex);
+            if (manifestation == null)
+            {
+                return NotFound();
+            }
+            return BuilderUrl(converter(manifestation.Id), newQueryString);
         }
 
-        private Manifestation GetManifestationFromTwoPartId(string id)
+        private async Task<IActionResult> CanvasLevelConversion(string bNumber, int manifestIndex, int canvasIndex,
+            Func<string, string, string> converter, string newQueryString)
         {
-            // A multiple-manifestation volume
-            var parts = id.Split('-');
-            var bNumber = parts[0];
-            var index = int.Parse(parts[1]);
-            var manifestation = ddsContext.GetManifestationByIndex(bNumber, index);
-            return manifestation;
+            var manifestation = ddsContext.GetManifestationByIndex(bNumber, manifestIndex);
+            if (manifestation == null)
+            {
+                return NotFound();
+            }
+            var canvasPart = await GetCanvasPart(canvasIndex, manifestation);
+            return BuilderUrl(converter(manifestation.Id, canvasPart), newQueryString);
+        }
+        
+        private async Task<IActionResult> CanvasLevelConversion(string manifestId, int canvasIndex,
+            Func<string, string, string> converter, string newQueryString)
+        {
+            var idParts = ManifestIdParts(manifestId);
+            var manifestation = ddsContext.GetManifestationByIndex(idParts.bNumber, idParts.index);
+            if (manifestation == null)
+            {
+                return NotFound();
+            }
+            var canvasPart = await GetCanvasPart(canvasIndex, manifestation);
+            return BuilderUrl(converter(manifestation.Id, canvasPart), newQueryString);
+        }
+        
+        private async Task<IActionResult> CanvasLevelConversionWithVersion(string manifestId, int canvasIndex,
+            Func<string, string, int, string> converter, string newQueryString)
+        {
+            var idParts = ManifestIdParts(manifestId);
+            var manifestation = ddsContext.GetManifestationByIndex(idParts.bNumber, idParts.index);
+            if (manifestation == null)
+            {
+                return NotFound();
+            }
+            var canvasPart = await GetCanvasPart(canvasIndex, manifestation);
+            return BuilderUrl(converter(manifestation.Id, canvasPart, 2), newQueryString);
+        }
+
+        private async Task<string> GetCanvasPart(int canvasIndex, Manifestation manifestation)
+        {
+            var key = $"canvas_indexes_{manifestation.Id}";
+            var canvasIndexes = memoryCache.Get<Dictionary<int, string>>(key);
+            if (canvasIndexes == null)
+            {
+                canvasIndexes = await MakeCanvasIndexes(manifestation.Id);
+                memoryCache.Set(key, canvasIndexes);
+            }
+
+            var canvasPart = canvasIndexes[canvasIndex];
+            return canvasPart;
+        }
+
+        private async Task<Dictionary<int, string>> MakeCanvasIndexes(string manifestationId)
+        {
+            // what's the best way to find the canvas IDs for a given manifest?
+            // We already have the means of reading from storage, storage maps, etc.
+            // But that's quite heavy and depends on the total size of the work.
+            // This version loads the already-created MANIFEST and finds the canvasIDs
+            // from that.
+            var s3Key = $"v3/{manifestationId}";
+            var jManifest = await helpers.LoadAsJson(ddsOptions.PresentationContainer, s3Key);
+            var dict = new Dictionary<int, string>();
+            if (jManifest != null)
+            {
+                var items = jManifest["items"] as JArray;
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var assetPart = items[i]["id"].Value<string>().Split("/canvases/").Last();
+                    dict.Add(i, assetPart);
+                }
+            }
+
+            return dict;
+        }
+
+
+        private (string bNumber, int index) ManifestIdParts(string id)
+        {
+            string bNumber;
+            int index;
+            if (id.Contains('-'))
+            {
+                // A multiple-manifestation volume
+                var parts = id.Split('-');
+                bNumber = parts[0];
+                index = int.Parse(parts[1]);
+            }
+            else
+            {
+                bNumber = id;
+                index = 0;
+            }
+
+            return (bNumber, index);
         }
 
 
@@ -117,12 +274,15 @@ namespace Wellcome.Dds.Server.Controllers
             {
                 newUrl += Request.QueryString;
             }
+            var versioned = newUrl.ReplaceFirst("/presentation/", "/presentation/v2/");
+            
             if (Request.Path.StartsWithSegments("/wlorgr"))
             {
-                return RedirectPermanent(newUrl);
+                return RedirectPermanent(versioned);
             }
 
-            return Content(newUrl, "text/plain");
+
+            return Content(versioned, "text/plain");
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -69,7 +69,7 @@ namespace Wellcome.Dds.Server.Controllers
             var work = await catalogue.GetWorkByOtherIdentifier(id);
             if (work != null)
             {
-                return ManifestIdConversion(work.Id, uriPatterns.PersistentPlayerUri);
+                return BuilderUrl(uriPatterns.PersistentPlayerUri(work.Id));
             }
             return NotFound();
         }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -96,7 +96,7 @@ namespace Wellcome.Dds.Server.Controllers
         public IActionResult ManifestFullText(string bNumber, int manifestIndex)
         {
             return ManifestLevelConversion(bNumber, manifestIndex, 
-                uriPatterns.IIIFAutoCompleteService1, string.Empty);
+                uriPatterns.RawText, string.Empty);
         }
         
         [HttpGet("service/alto/{bNumber}/{manifestIndex}")]

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -48,21 +48,17 @@ namespace Wellcome.Dds.Server.Controllers
         [HttpGet("iiif/{id}/manifest")]
         public IActionResult IIIFManifest(string id)
         {
-            if (id.Contains('-'))
-            {
-                var manifestation = GetManifestationFromTwoPartId(id);
-                if (manifestation == null)
-                {
-                    return NotFound();
-                }
-                return BuilderUrl(uriPatterns.Manifest(manifestation.Id));
-            }
-            // A regular single manifest
-            return BuilderUrl(uriPatterns.Manifest(id));
+            return ManifestIdConversion(id, uriPatterns.Manifest);
         }
 
         [HttpGet("annoservices/search/{id}")]
         public IActionResult SearchService(string id)
+        {
+            return ManifestIdConversion(id, uriPatterns.IIIFContentSearchService0);
+        }
+
+
+        private IActionResult ManifestIdConversion(string id, Func<string, string> converter)
         {
             if (id.Contains('-'))
             {
@@ -71,9 +67,10 @@ namespace Wellcome.Dds.Server.Controllers
                 {
                     return NotFound();
                 }
-                return BuilderUrl(uriPatterns.IIIFContentSearchService0(manifestation.Id));
+                return BuilderUrl(converter(manifestation.Id));
             }
-            return BuilderUrl(uriPatterns.IIIFContentSearchService0(id));
+            return BuilderUrl(converter(id));
+            
         }
 
         private Manifestation GetManifestationFromTwoPartId(string id)

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -1,0 +1,116 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.Options;
+using Wellcome.Dds.Common;
+using Wellcome.Dds.IIIFBuilding;
+using Wellcome.Dds.Repositories;
+
+#pragma warning disable 1591
+namespace Wellcome.Dds.Server.Controllers
+{
+    /// <summary>
+    /// Provides paths on iiif.wellcomecollection.org, for paths on wellcomelibrary.org.
+    /// </summary>
+    [Route("wlorgp")]
+    [Route("wlorgr")]
+    [ApiController]
+    public class WlOrgController : ControllerBase
+    {
+        private readonly DdsOptions ddsOptions;
+        private readonly UriPatterns uriPatterns;
+        private readonly DdsContext ddsContext;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="uriPatterns"></param>
+        /// <param name="options"></param>
+        /// <param name="ddsContext"></param>
+        public WlOrgController(
+            UriPatterns uriPatterns,
+            IOptions<DdsOptions> options,
+            DdsContext ddsContext
+            )
+        {
+            this.uriPatterns = uriPatterns;
+            this.ddsOptions = options.Value;
+            this.ddsContext = ddsContext;
+        }
+
+        
+        [HttpGet("iiif/collection/{id}")]
+        public IActionResult IIIFCollection(string id)
+        {
+            return BuilderUrl(uriPatterns.CollectionForWork(id));
+        }
+        
+        [HttpGet("iiif/{id}/manifest")]
+        public IActionResult IIIFManifest(string id)
+        {
+            if (id.Contains('-'))
+            {
+                var manifestation = GetManifestationFromTwoPartId(id);
+                if (manifestation == null)
+                {
+                    return NotFound();
+                }
+                return BuilderUrl(uriPatterns.Manifest(manifestation.Id));
+            }
+            // A regular single manifest
+            return BuilderUrl(uriPatterns.Manifest(id));
+        }
+
+        [HttpGet("annoservices/search/{id}")]
+        public IActionResult SearchService(string id)
+        {
+            if (id.Contains('-'))
+            {
+                var manifestation = GetManifestationFromTwoPartId(id);
+                if (manifestation == null)
+                {
+                    return NotFound();
+                }
+                return BuilderUrl(uriPatterns.IIIFContentSearchService0(manifestation.Id));
+            }
+            return BuilderUrl(uriPatterns.IIIFContentSearchService0(id));
+        }
+
+        private Manifestation GetManifestationFromTwoPartId(string id)
+        {
+            // A multiple-manifestation volume
+            var parts = id.Split('-');
+            var bNumber = parts[0];
+            var index = int.Parse(parts[1]);
+            var manifestation = ddsContext.GetManifestationByIndex(bNumber, index);
+            return manifestation;
+        }
+
+
+        /// <summary>
+        /// Redirect to new URL, or return new URL, depending on which path you came in on.
+        /// Try to preserve the querystring, unless a new querystring has been provided.
+        /// </summary>
+        /// <param name="newUrl"></param>
+        /// <param name="updatedQueryString"></param>
+        /// <returns></returns>
+        public IActionResult BuilderUrl(string newUrl, string updatedQueryString = null)
+        {
+            if (updatedQueryString != null)
+            {
+                newUrl += updatedQueryString;
+            } 
+            else if (Request.QueryString.HasValue)
+            {
+                newUrl += Request.QueryString;
+            }
+            if (Request.Path.StartsWithSegments("/wlorgr"))
+            {
+                return RedirectPermanent(newUrl);
+            }
+
+            return Content(newUrl, "text/plain");
+        }
+    }
+}
+#pragma warning restore 1591

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -82,7 +82,7 @@ namespace Wellcome.Dds.IIIFBuilding
 
         // Other resources
         private const string RawTextFormat =                      "/text/v1/{identifier}"; // v1 refers to Wellcome API
-        private const string MetsAltoFormat =                     "/text/alto/{identifier}/{assetIdentifier}"; // v1 refers to Wellcome API
+        private const string MetsAltoFormat =                     "/text/alto/{identifier}/{assetIdentifier}"; // not versioned
         private const string PosterImageFormat =                  "/thumbs/{identifier}";
         private const string PdfThumbnailFormat =                 "/thumbs/{identifier}"; // make these the same for now
         


### PR DESCRIPTION
Adds a new LibrarySiteController, which returns information in two different ways.

`/wlorgp/<old-wl.org-path>`

=> returns the new URL (not path) as a body of `text/plain` in an HTTP 200 response, or an error body in a 404 response.

`/wlorgr/<old-wl.org-path>`

=> REDIRECTS the response to the new URL (301 Moved Permanently)

Examples:

https://iiif-test.wellcomecollection.org/wlorgp/iiif/b28047345/manifest
`https://iiif-test.wellcomecollection.org/presentation/v2/b28047345`

https://iiif-test.wellcomecollection.org/wlorgp/iiif/collection/b18031511
`https://iiif-test.wellcomecollection.org/presentation/v2/b18031511`

We handle manifest-index => METS ID:

https://iiif-test.wellcomecollection.org/wlorgp/iiif/b18031511-2/manifest
`https://iiif-test.wellcomecollection.org/presentation/v2/b18031511_0003`

https://iiif-test.wellcomecollection.org/wlorgp/item/b18031511
`https://wellcomecollection.org/works/ysmqsfhg`

https://iiif-test.wellcomecollection.org/wlorgp/annoservices/search/b28047345
`https://iiif-test.wellcomecollection.org/search/v0/b28047345`

https://iiif-test.wellcomecollection.org/wlorgp/annoservices/autocomplete/b28047345
`https://iiif-test.wellcomecollection.org/search/autocomplete/v1/b28047345`

https://iiif-test.wellcomecollection.org/wlorgp/service/fulltext/b28047345/0?raw=true
`https://iiif-test.wellcomecollection.org/text/v1/b28047345`

https://iiif-test.wellcomecollection.org/wlorgp/service/fulltext/b18031511/3?raw=true
`https://iiif-test.wellcomecollection.org/text/v1/b18031511_0004`

Here's where is starts to get more interesting, asset-level redirects:

https://iiif-test.wellcomecollection.org/wlorgp/service/alto/b29350542/2?image=100
`https://iiif-test.wellcomecollection.org/text/alto/b29350542_0003/b29350542_0003_0101.jp2`

https://iiif-test.wellcomecollection.org/wlorgp/service/alto/b28047345/0?image=400
`https://iiif-test.wellcomecollection.org/text/alto/b28047345/b28047345_0403.jp2`

(note the discrepancies in index and METS-derived IDs)

https://iiif-test.wellcomecollection.org/wlorgp/iiif/b28047345/contentAsText/53
`https://iiif-test.wellcomecollection.org/annotations/v2/b28047345/b28047345_0056.jp2/line`

https://iiif-test.wellcomecollection.org/wlorgp/iiif/b28047345/images
`https://iiif-test.wellcomecollection.org/annotations/v2/b28047345/images`

https://iiif-test.wellcomecollection.org/wlorgp/iiif/b28047345/allcontent
`https://iiif-test.wellcomecollection.org/annotations/v2/b28047345/all/line`


