### PR TITLE
Better handling of RightsState

### DIFF
--- a/src/Wellcome.Dds/IIIF.Tests/Presentation/V3/ManifestXTests.cs
+++ b/src/Wellcome.Dds/IIIF.Tests/Presentation/V3/ManifestXTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using IIIF.Presentation.V3;
+using Xunit;
+
+namespace IIIF.Tests.Presentation.V3
+{
+    public class ManifestXTests
+    {
+        [Fact]
+        public void ContainsAV_False_IfItemsNull()
+        {
+            // Arrange
+            var manifest = new Manifest();
+            
+            // Act
+            var result = manifest.ContainsAV();
+            
+            // Assert
+            result.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void ContainsAV_False_IfItemsEmpty()
+        {
+            // Arrange
+            var manifest = new Manifest {Items = new List<Canvas>()};
+            
+            // Act
+            var result = manifest.ContainsAV();
+            
+            // Assert
+            result.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void ContainsAV_False_IfItemsNullDuration()
+        {
+            // Arrange
+            var manifest = new Manifest
+            {
+                Items = new List<Canvas>
+                {
+                    new() {Id = "test", Duration = null}
+                }
+            };
+            
+            // Act
+            var result = manifest.ContainsAV();
+            
+            // Assert
+            result.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void ContainsAV_False_IfItems0Duration()
+        {
+            // Arrange
+            var manifest = new Manifest
+            {
+                Items = new List<Canvas>
+                {
+                    new() {Id = "test", Duration = 0}
+                }
+            };
+            
+            // Act
+            var result = manifest.ContainsAV();
+            
+            // Assert
+            result.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void ContainsAV_True_IfItemsContainsAbove0Duration()
+        {
+            // Arrange
+            var manifest = new Manifest
+            {
+                Items = new List<Canvas>
+                {
+                    new() {Id = "test", Duration = null},
+                    new() {Id = "test", Duration = 0},
+                    new() {Id = "test", Duration = 1},
+                }
+            };
+            
+            // Act
+            var result = manifest.ContainsAV();
+            
+            // Assert
+            result.Should().BeTrue();
+        }
+    }
+}

--- a/src/Wellcome.Dds/IIIF/Presentation/V3/ManifestX.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/V3/ManifestX.cs
@@ -1,0 +1,16 @@
+﻿namespace IIIF.Presentation.V3
+{
+    /// <summary>
+    /// Extension methods for working with <see cref="Manifest"/> objects.
+    /// </summary>
+    public static class ManifestX
+    {
+        /// <summary>
+        /// Check if this Manifest contains any AV items. 
+        /// </summary>
+        /// <param name="manifest"></param>
+        /// <returns>True if .Items contains a Canvas with a Duration of greater than 0.</returns>
+        public static bool ContainsAV(this Manifest manifest) 
+            => manifest.Items?.Exists(i => (i.Duration ?? 0) > 0) ?? false;
+    }
+}


### PR DESCRIPTION
Handle a collection containing manifests, none of which have state.

Also handle AV collections which may have been reordered to Manifest.