### PR TITLE
Parse duration

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsMetadataTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsMetadataTests.cs
@@ -7,22 +7,13 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Mets
 {
     public class MetsMetadataTests
     {
-        [Fact]
-        public void TestDurationParsing()
+        [Theory]
+        [InlineData("22mn 49s", 1369)]
+        [InlineData("1mn 41s", 101)]
+        [InlineData("9mn 46s", 586)]
+        public void TestDurationParsing(string input, int expected)
         {
-            Dictionary<string,double> tests = new Dictionary<string, double>()
-            {
-                ["22mn 49s"] = 1369,
-                ["1mn 41s"] = 101,
-                ["9mn 46s"] = 586
-            };
-            foreach (var test in tests)
-            {
-                PremisMetadata.ParseDuration(test.Key).Should().Be(test.Value);
-            }
-
+            PremisMetadata.ParseDuration(input).Should().Be(expected);
         }
-        
-        
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsMetadataTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsMetadataTests.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Wellcome.Dds.AssetDomainRepositories.Mets.Model;
+using Xunit;
+
+namespace Wellcome.Dds.AssetDomainRepositories.Tests.Mets
+{
+    public class MetsMetadataTests
+    {
+        [Fact]
+        public void TestDurationParsing()
+        {
+            Dictionary<string,double> tests = new Dictionary<string, double>()
+            {
+                ["22mn 49s"] = 1369,
+                ["1mn 41s"] = 101,
+                ["9mn 46s"] = 586
+            };
+            foreach (var test in tests)
+            {
+                PremisMetadata.ParseDuration(test.Key).Should().Be(test.Value);
+            }
+
+        }
+        
+        
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PremisMetadata.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PremisMetadata.cs
@@ -153,8 +153,19 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
         /// </summary>
         /// <param name="possibleStringLength">the human readable string</param>
         /// <returns>The length in seconds, or 0 if no length obtained.</returns>
-        private double ParseDuration(string possibleStringLength)
+        public static double ParseDuration(string possibleStringLength)
         {
+            // Examples
+            // 22mn 49s
+            // 1mn 41s
+            // 9mn 46s ... this format seems very consistent
+            if (possibleStringLength.Contains("mn"))
+            {
+                var parts = possibleStringLength.Split(' ');
+                int.TryParse(parts[0].ToNumber(), out var mins);
+                int.TryParse(parts[1].ToNumber(), out var secs);
+                return 60 * mins + secs;
+            }
             return 0;
         }
     }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PremisMetadata.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PremisMetadata.cs
@@ -67,12 +67,14 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
         public double GetDuration()
         {
             var possibleStringLength = GetLengthInSeconds();
-            // TODO - this will not work with "2 min 56sec" and whatnot; needs a proper parser
-            // but see if this can be done in Goobi first
-            double.TryParse(possibleStringLength, out var result);
-            return result;
+            if (double.TryParse(possibleStringLength, out var result))
+            {
+                return result;
+            }
+
+            return ParseDuration(possibleStringLength);
         }
-        
+
         public string GetBitrateKbps()
         {
             return GetFilePropertyValue("Bitrate");
@@ -144,6 +146,16 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                 var propValue = sigProp.Element(XNames.PremisSignificantPropertiesValue).Value;
                 significantProperties[propType] = propValue;
             }
+        }
+        
+        /// <summary>
+        /// Attempt to parse a duration in seconds from EXIF-derived values.
+        /// </summary>
+        /// <param name="possibleStringLength">the human readable string</param>
+        /// <returns>The length in seconds, or 0 if no length obtained.</returns>
+        private double ParseDuration(string possibleStringLength)
+        {
+            return 0;
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Migrations/20210302153354_AddFirstFileDuration.Designer.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Migrations/20210302153354_AddFirstFileDuration.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Wellcome.Dds.Repositories;
@@ -9,9 +10,10 @@ using Wellcome.Dds.Repositories;
 namespace Wellcome.Dds.Repositories.Migrations
 {
     [DbContext(typeof(DdsContext))]
-    partial class DdsContextModelSnapshot : ModelSnapshot
+    [Migration("20210302153354_AddFirstFileDuration")]
+    partial class AddFirstFileDuration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Migrations/20210302153354_AddFirstFileDuration.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Migrations/20210302153354_AddFirstFileDuration.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Wellcome.Dds.Repositories.Migrations
+{
+    public partial class AddFirstFileDuration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "first_file_duration",
+                table: "manifestations",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "first_file_duration",
+                table: "manifestations");
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Synchroniser.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Synchroniser.cs
@@ -216,6 +216,7 @@ namespace Wellcome.Dds.Repositories
                             case AssetFamily.TimeBased:
                                 ddsManifestation.FirstFileThumbnailDimensions =
                                     asset.AssetMetadata.GetLengthInSeconds();
+                                ddsManifestation.FirstFileDuration = asset.AssetMetadata.GetDuration();
                                 break;
                         }
                     }

--- a/src/Wellcome.Dds/Wellcome.Dds/Manifestation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/Manifestation.cs
@@ -96,6 +96,12 @@ namespace Wellcome.Dds
         /// </summary>
         public string FirstFileThumbnailDimensions { get; set; }
         
+        /// <summary>
+        /// The length, in seconds, for time-based media
+        /// Only the first asset in the manifestation is recorded here.
+        /// </summary>
+        public double FirstFileDuration { get; set; }
+        
         public string WorkType { get; set; }
         public string PermittedOperations { get; set; }
         public string RootSectionAccessCondition { get; set; }


### PR DESCRIPTION
Attempts to read from EXIF string, e.g., "22mn 23s"

Also saves value to Manifestation in Dds DB for later reporting.

This will need further refinement as we see exceptions.

Still no way to obtain width and height, we'll need to get that from the DLCS.