### PR TITLE
V2 collections

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -127,6 +127,50 @@ namespace Wellcome.Dds.Server.Controllers
                 manifestId, uriPatterns.ManifestAnnotationPageAllWithVersion);
         }
         
+        [HttpGet("service/collections")]
+        public IActionResult TopLevelCollection()
+        {
+            return BuilderUrl(uriPatterns.CollectionForAggregation());
+        }
+        
+        [HttpGet("service/collections/archives/lightweight")]
+        public IActionResult ArchiveCollectionLightweight()
+        {
+            return BuilderUrl(uriPatterns.CollectionForAggregation("archives"));
+        }
+        
+        [HttpGet("service/collections/{aggregator}")]
+        public IActionResult CollectionAggregation(string aggregator)
+        {
+            return BuilderUrl(uriPatterns.CollectionForAggregation(GetNewAggregator(aggregator)));
+        }
+        
+        
+        [HttpGet("service/collections/archives/{*referenceNumber}")]
+        public IActionResult CollectionArchiveRefNumber(string referenceNumber)
+        {
+            return BuilderUrl(uriPatterns.CollectionForAggregation("archives", referenceNumber));
+        }
+
+        
+        [HttpGet("service/collections/{aggregator}/{value}")]
+        public IActionResult CollectionAggregation(string aggregator, string value)
+        {
+            return BuilderUrl(uriPatterns.CollectionForAggregation(GetNewAggregator(aggregator), value));
+        }
+
+        private string GetNewAggregator(string oldAggregator)
+        {
+            return oldAggregator switch
+            {
+                "topics" => "subjects",
+                "authors" => "contributors",
+                "collections" => "digitalcollections",
+                _ => oldAggregator
+            };
+        }
+
+        
         private IActionResult ManifestLevelConversion(string id, Func<string, string> converter)
         {
             var idParts = ManifestIdParts(id);

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,7 +9,6 @@ using IIIF.Serialisation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualBasic;
 using Utils;
 using Utils.Web;
 using Wellcome.Dds.Catalogue;
@@ -152,7 +150,7 @@ namespace Wellcome.Dds.Server.Controllers
 
 
         /// <summary>
-        /// 
+        /// IIIF v3 top level collection for archives, replaces the "lightweight" v2 version
         /// </summary>
         /// <returns></returns>
         [HttpGet("collections/archives")]
@@ -198,8 +196,8 @@ namespace Wellcome.Dds.Server.Controllers
             return Content(coll.AsJson(), IIIFPresentation.ContentTypes.V3);
         }
 
-        /// <summary>
-        /// 
+        /// <summary> 
+        /// IIIF v2 top level collection for archives, replaces the "lightweight" v2 version
         /// </summary>
         /// <returns></returns>
         [HttpGet("v2/collections/archives")]
@@ -245,7 +243,8 @@ namespace Wellcome.Dds.Server.Controllers
         }
         
         /// <summary>
-        /// 
+        /// IIIF 3 - Handles all archive CALM ref numbers.
+        /// If this is actually a manifest it will redirect to the canonical DDS URL
         /// </summary>
         /// <returns></returns>
         [HttpGet("collections/archives/{*referenceNumber}")]
@@ -273,8 +272,9 @@ namespace Wellcome.Dds.Server.Controllers
         }
         
         
-        /// <summary>
-        /// 
+        /// <summary> 
+        /// IIIF 2 - Handles all archive CALM ref numbers.
+        /// If this is actually a manifest it will redirect to the canonical DDS URL
         /// </summary>
         /// <returns></returns>
         [HttpGet("v2/collections/archives/{*referenceNumber}")]
@@ -371,7 +371,7 @@ namespace Wellcome.Dds.Server.Controllers
         }
         
         /// <summary>
-        /// An aggregation
+        /// An aggregation - subjects, contributors etc
         /// </summary>
         /// <returns></returns>
         [HttpGet("collections/{aggregator}")]
@@ -399,7 +399,7 @@ namespace Wellcome.Dds.Server.Controllers
         
         
         /// <summary>
-        /// An aggregation
+        /// An aggregation - subjects, contributors etc
         /// </summary>
         /// <returns></returns>
         [HttpGet("v2/collections/{aggregator}")]

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
@@ -307,7 +307,23 @@ namespace Wellcome.Dds.Server.Controllers
 
         private IIIFPresentationBase ConvertArchiveCollectionMemberToV2(ICollectionItem item)
         {
-            throw new NotImplementedException();
+            switch (item)
+            {
+                case Collection collection:
+                    return new IIIF.Presentation.V2.Collection
+                    {
+                        Id = collection.Id.AsV2(),
+                        Label = new MetaDataValue(collection.Label.ToString())
+                    };
+                case Manifest manifest:
+                    return new IIIF.Presentation.V2.Manifest
+                    {
+                        Id = manifest.Id.AsV2(),
+                        Label = new MetaDataValue(manifest.Label.ToString())
+                    };
+            }
+
+            return null;
         }
 
         private Collection GetNoCollectionArchive()

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
@@ -2,19 +2,26 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using IIIF.Presentation.V2;
+using IIIF.Presentation.V2.Strings;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.VisualBasic;
+using Utils;
 using Utils.Web;
 using Wellcome.Dds.Catalogue;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
 using Wellcome.Dds.Repositories;
 using Wellcome.Dds.Repositories.Presentation;
+using Wellcome.Dds.Repositories.Presentation.V2;
 using Wellcome.Dds.Server.Conneg;
+using Collection = IIIF.Presentation.V3.Collection;
+using Manifest = IIIF.Presentation.V3.Manifest;
 using Version = IIIF.Presentation.Version;
 
 namespace Wellcome.Dds.Server.Controllers
@@ -97,10 +104,11 @@ namespace Wellcome.Dds.Server.Controllers
         }
 
         /// <summary>
-        /// The root IIIF collection.
+        /// The root IIIF collection, IIIF 3.
         /// </summary>
         /// <returns></returns>
         [HttpGet("collections")]
+        [HttpGet("v3/collections")]
         public IActionResult TopLevelCollection()
         {
             var tlc = new Collection
@@ -118,14 +126,37 @@ namespace Wellcome.Dds.Server.Controllers
             };
             return Content(tlc.AsJson(), IIIFPresentation.ContentTypes.V3);
         }
+        
+        /// <summary>
+        /// The root IIIF collection, IIIF 2.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("v2/collections")]
+        public IActionResult TopLevelCollectionV2()
+        {
+            var tlc = new IIIF.Presentation.V2.Collection
+            {
+                Id = uriPatterns.CollectionForAggregation().AsV2(),
+                Label = new MetaDataValue("Wellcome Collection"),
+                Collections = new List<IIIF.Presentation.V2.Collection>
+                {
+                    MakeAggregationCollectionV2("subjects", "Works by subject"),
+                    MakeAggregationCollectionV2("genres", "Works by genre"),
+                    MakeAggregationCollectionV2("contributors", "Works by contributor"),
+                    MakeAggregationCollectionV2("digitalcollections", "Works by digital collection"),
+                    MakeAggregationCollectionV2("archives", "Archive collections")
+                }
+            };
+            return Content(tlc.AsJson(), IIIFPresentation.ContentTypes.V2);
+        }
 
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
         [HttpGet("collections/archives")]
+        [HttpGet("v3/collections/archives")]
         public IActionResult ArchivesTopLevelCollection()
         {
             var archiveRoot = CollectionForAggregationId("archives");
@@ -137,7 +168,9 @@ namespace Wellcome.Dds.Server.Controllers
             };
             archiveRoot += "/";
             ArchiveCollectionTop noCollection = null;
-            foreach (var topLevelArchiveCollection in ddsContext.GetTopLevelArchiveCollections())
+            foreach (var topLevelArchiveCollection in ddsContext
+                .GetTopLevelArchiveCollections()
+                .OrderBy(tla => tla.Title))
             {
                 if (topLevelArchiveCollection.ReferenceNumber == Manifestation.EmptyTopLevelArchiveReference)
                 {
@@ -169,7 +202,54 @@ namespace Wellcome.Dds.Server.Controllers
         /// 
         /// </summary>
         /// <returns></returns>
+        [HttpGet("v2/collections/archives")]
+        public IActionResult ArchivesTopLevelCollectionV2()
+        {
+            var archiveRoot = CollectionForAggregationId("archives").AsV2();
+            var coll = new IIIF.Presentation.V2.Collection
+            {
+                Id = archiveRoot,
+                Label = new MetaDataValue("Archives at Wellcome Collection"),
+                Members = new List<IIIFPresentationBase>()
+            };
+            archiveRoot += "/";
+            ArchiveCollectionTop noCollection = null;
+            foreach (var topLevelArchiveCollection in ddsContext
+                .GetTopLevelArchiveCollections()
+                .OrderBy(tla => tla.Title))
+            {
+                if (topLevelArchiveCollection.ReferenceNumber == Manifestation.EmptyTopLevelArchiveReference)
+                {
+                    noCollection = topLevelArchiveCollection;
+                }
+                else
+                {
+                    coll.Members.Add(new IIIF.Presentation.V2.Collection
+                    {
+                        Id = archiveRoot + topLevelArchiveCollection.ReferenceNumber,
+                        Label = new MetaDataValue(topLevelArchiveCollection.Title)
+                    });
+                }
+            }
+
+            if (noCollection != null)
+            {
+                coll.Members.Add(new IIIF.Presentation.V2.Collection
+                {
+                    Id = archiveRoot + noCollection.ReferenceNumber,
+                    Label = new MetaDataValue(noCollection.Title)
+                });
+            }
+            
+            return Content(coll.AsJson(), IIIFPresentation.ContentTypes.V2);
+        }
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         [HttpGet("collections/archives/{*referenceNumber}")]
+        [HttpGet("v3/collections/archives/{*referenceNumber}")]
         public async Task<IActionResult> ArchivesReference(string referenceNumber)
         {
             Collection collection;
@@ -190,6 +270,44 @@ namespace Wellcome.Dds.Server.Controllers
                 
             }
             return Content(collection.AsJson(), IIIFPresentation.ContentTypes.V3);
+        }
+        
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("v2/collections/archives/{*referenceNumber}")]
+        public async Task<IActionResult> ArchivesReferenceV2(string referenceNumber)
+        {
+            IIIF.Presentation.V2.Collection collection;
+            if (referenceNumber == Manifestation.EmptyTopLevelArchiveReference)
+            {
+                collection = GetNoCollectionArchiveV2();
+            }
+            else
+            {
+                var work = await catalogue.GetWorkByOtherIdentifier(referenceNumber);
+                if (work.HasDigitalLocation())
+                {
+                    var bNumber = work.GetSierraSystemBNumbers().First();
+                    return Redirect(uriPatterns.Manifest(bNumber).AsV2());
+                }
+
+                var v3Coll = iiifBuilder.BuildArchiveNode(work);
+                collection = ConverterHelpers.GetIIIFPresentationBase<IIIF.Presentation.V2.Collection>(v3Coll);
+                collection.Id = v3Coll.Id.AsV2();
+                if (v3Coll.Items.HasItems())
+                {
+                    collection.Members = v3Coll.Items.Select(ConvertArchiveCollectionMemberToV2).ToList();
+                }
+            }
+            return Content(collection.AsJson(), IIIFPresentation.ContentTypes.V2);
+        }
+
+        private IIIFPresentationBase ConvertArchiveCollectionMemberToV2(ICollectionItem item)
+        {
+            throw new NotImplementedException();
         }
 
         private Collection GetNoCollectionArchive()
@@ -214,13 +332,34 @@ namespace Wellcome.Dds.Server.Controllers
 
             return collection;
         }
+        
+        
+        private IIIF.Presentation.V2.Collection GetNoCollectionArchiveV2()
+        {
+            var collection = new IIIF.Presentation.V2.Collection
+            {
+                Id = uriPatterns.CollectionForAggregation("archives", Manifestation.EmptyTopLevelArchiveReference).AsV2(),
+                Label = new MetaDataValue(Manifestation.EmptyTopLevelArchiveTitle),
+                Members = new List<IIIFPresentationBase>()
+            };
+            foreach (var manifestation in ddsContext.Manifestations.Where(m => m.CollectionTitle == "(no-title)"))
+            {
+                collection.Members.Add(new IIIF.Presentation.V2.Manifest
+                {
+                    Id = uriPatterns.Manifest(manifestation.PackageIdentifier).AsV2(),
+                    Label = new MetaDataValue(manifestation.ReferenceNumber + " - " + manifestation.PackageLabel)
+                });
+            }
 
-
+            return collection;
+        }
+        
         /// <summary>
         /// An aggregation
         /// </summary>
         /// <returns></returns>
         [HttpGet("collections/{aggregator}")]
+        [HttpGet("v3/collections/{aggregator}")]
         public IActionResult Aggregation(string aggregator)
         {
             var apiType = Metadata.FromUrlFriendlyAggregator(aggregator);
@@ -241,13 +380,42 @@ namespace Wellcome.Dds.Server.Controllers
             }
             return Content(coll.AsJson(), IIIFPresentation.ContentTypes.V3);
         }
+        
+        
+        /// <summary>
+        /// An aggregation
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("v2/collections/{aggregator}")]
+        public IActionResult AggregationV2(string aggregator)
+        {
+            var apiType = Metadata.FromUrlFriendlyAggregator(aggregator);
+            var coll = new IIIF.Presentation.V2.Collection
+            {
+                Id = CollectionForAggregationId(aggregator).AsV2(),
+                Label = new MetaDataValue("Works by " + apiType),
+                Members = new List<IIIFPresentationBase>()
+            };
+            var aggregation = ddsContext.GetAggregation(apiType);
+            foreach (var aggregationMetadata in aggregation)
+            {
+                coll.Members.Add(new IIIF.Presentation.V2.Collection
+                {
+                    Id = CollectionForAggregationId(aggregator, aggregationMetadata.Identifier).AsV2(),
+                    Label = new MetaDataValue(aggregationMetadata.Label)
+                });
+            }
+            return Content(coll.AsJson(), IIIFPresentation.ContentTypes.V2);
+        }
 
+        
 
         /// <summary>
         /// A Collection of Manifests with the given metadata
         /// </summary>
         /// <returns></returns>
         [HttpGet("collections/{aggregator}/{value}")]
+        [HttpGet("v3/collections/{aggregator}/{value}")]
         public IActionResult ManifestsByAggregationValue(string aggregator, string value)
         {
             const int maxThumbnails = 50; // to avoid huge collections
@@ -276,6 +444,35 @@ namespace Wellcome.Dds.Server.Controllers
             return Content(coll.AsJson(), IIIFPresentation.ContentTypes.V3);
         }
         
+                
+
+        /// <summary>
+        /// A Collection of Manifests with the given metadata
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("v2/collections/{aggregator}/{value}")]
+        public IActionResult ManifestsByAggregationValueV2(string aggregator, string value)
+        {
+            var apiType = Metadata.FromUrlFriendlyAggregator(aggregator);
+            var coll = new IIIF.Presentation.V2.Collection
+            {
+                Id = CollectionForAggregationId(aggregator, value).AsV2(),
+                Members = new List<IIIFPresentationBase>()
+            };
+            foreach (var result in ddsContext.GetAggregation(apiType, value))
+            {
+                var manifest = new IIIF.Presentation.V2.Manifest
+                {
+                    Id = uriPatterns.Manifest(result.Manifestation.PackageIdentifier).AsV2(),
+                    Label = new MetaDataValue(result.Manifestation.PackageLabel)
+                };
+                coll.Members.Add(manifest);
+                coll.Label ??= new MetaDataValue($"{result.CollectionLabel}: {result.CollectionStringValue}");
+            }
+            Response.CacheForDays(30);
+            return Content(coll.AsJson(), IIIFPresentation.ContentTypes.V2);
+        }
+        
         
         private Collection MakeAggregationCollection(string aggregator, string label)
         {
@@ -285,10 +482,21 @@ namespace Wellcome.Dds.Server.Controllers
                 Label = new LanguageMap("en", label)
             };
         }
+        
+        
+        private IIIF.Presentation.V2.Collection MakeAggregationCollectionV2(string aggregator, string label)
+        {
+            return new()
+            {
+                Id = CollectionForAggregationId(aggregator).AsV2(),
+                Label = new MetaDataValue(label)
+            };
+        }
 
         /// <summary>
         /// Allow ID domain to be rewritten for local dev convenience
         /// </summary>
+        /// <param name="version"></param>
         /// <param name="aggregator"></param>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -310,6 +518,14 @@ namespace Wellcome.Dds.Server.Controllers
             }
             return id.Replace(ddsOptions.LinkedDataDomain, ddsOptions.RewriteDomainLinksTo);
 
+        }
+    }
+
+    static class PresentationControllerX
+    {
+        public static string AsV2(this string id)
+        {
+            return id.Replace("/presentation/", "/presentation/v2/");
         }
     }
 }


### PR DESCRIPTION
Adds a set of /v2/ path handlers to the PresentationController to supply archive hierarchy as Presentation 2.

Unlike the main P2 conversion, this does not convert the P3 version into P2; instead it has parallel path handlers that build the P2 objects directly. It does, however, lean on the P2 conversion code where necessary.

I'm not sure about the balance between repetition of v3 building vs just converting the v2. The controller code is reasonably easy to understand for both versions, and I have kept the v2 archive tree more like the current one rather than a direct copy. For example there are no thumbnails.
