### PR TITLE
TargetConverter serialises Canvas as string Id only

### DIFF
--- a/src/Wellcome.Dds/IIIF/Presentation/V3/Annotation/Annotation.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/V3/Annotation/Annotation.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using IIIF.Serialisation;
+using Newtonsoft.Json;
 
 namespace IIIF.Presentation.V3.Annotation
 {
@@ -20,6 +21,7 @@ namespace IIIF.Presentation.V3.Annotation
         /// Note that this is a IIIF-specific use of target; can be anything in W3C
         /// </summary>
         [JsonProperty(Order = 900)]
+        [JsonConverter(typeof(TargetConverter))]
         public IStructuralLocation? Target { get; set; }
     }
 }

--- a/src/Wellcome.Dds/IIIF/Serialisation/TargetConverter.cs
+++ b/src/Wellcome.Dds/IIIF/Serialisation/TargetConverter.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using IIIF.Presentation.V2.Serialisation;
+using IIIF.Presentation.V3;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace IIIF.Serialisation
+{
+    public class TargetConverter : WriteOnlyConverter<IStructuralLocation>
+    {
+        public override void WriteJson(JsonWriter writer, IStructuralLocation? value, JsonSerializer serializer)
+        {
+            if (value is Canvas canvas)
+            {
+                if (canvas.Width == null && canvas.Duration == null && (canvas.Items == null || !canvas.Items.Any()))
+                {
+                    writer.WriteValue(canvas.Id);
+                    return;
+                }
+            }
+            // Default, pass through behaviour:
+            JObject.FromObject(value, serializer).WriteTo(writer);
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -453,6 +453,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                 if (allW3CPageAnnotations.FirstOrDefault()?.Target is Canvas firstAnnoCanvas)
                 {
                     // add a partOf to the first anno for this page, to associate the canvas with the manifest. Nice!
+                    // NB this won't have any effect if the TargetConverter Serialiser is in use
                     firstAnnoCanvas.PartOf = new List<ResourceBase>
                     {
                         new Manifest {Id = uriPatterns.Manifest(manifestation.Id)}
@@ -734,7 +735,9 @@ namespace Wellcome.Dds.Repositories.Presentation
                 var annotation = new IIIF.Presentation.V2.Annotation.Annotation
                 {
                     Id = jItem.Value<string>("id"),
-                    On = jItem["target"]?.Value<string>("id") ?? string.Empty
+                    On = jItem.Value<string>("target") // using the TargetConverter Serializer
+                    // TODO: put this back when better supported in viewers
+                    //On = jItem["target"]?.Value<string>("id") ?? string.Empty
                 };
                 // This will, atm, be either a textual body (line anno) or an image-classifying anno.
                 var body = jItem["body"];

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -35,6 +35,7 @@ namespace Wellcome.Dds.Repositories.Presentation
 {
     public class IIIFBuilder : IIIIFBuilder
     {
+        private const string DcTypesStillImage = "dctypes:StillImage";
         private readonly IDds dds;
         private readonly IMetsRepository metsRepository;
         private readonly IDashboardRepository dashboardRepository;
@@ -506,7 +507,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                 Id = uriPatterns.CanvasClassifyingAnnotation(
                     altoPage.ManifestationIdentifier, altoPage.AssetIdentifier, $"i{index}"),
                 Target = new Canvas { Id = $"{canvasId}#xywh={il.X},{il.Y},{il.Width},{il.Height}" },
-                Body = new ClassifyingBody("dctypes:StillImage")
+                Body = new ClassifyingBody(DcTypesStillImage)
                 {
                     Label = Lang.Map(il.Type) // https://github.com/w3c/web-annotation/issues/437
                 }
@@ -752,7 +753,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                             Format = "text/plain"
                         };
                     }
-                    else if ("Image" == body.Value<string>("id"))
+                    else if (DcTypesStillImage == body.Value<string>("id"))
                     {
                         annotation.Motivation = "oa:classifying";
                         annotation.Resource = new IllustrationAnnotationResource


### PR DESCRIPTION
If you try to do this by writing a custom serialiser for `Canvas` you get stuck in a self-referential hole if you decide you want the regular serialisation to happen (when it's the normal canvas).

But you can apply the converter just to the property `Target`, which avoids this.
