### PR TITLE
Split search

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,10 +50,18 @@ pipeline {
   stage('Bounce') {
    steps {
     sh "curl --data '{\"text\": \"Jenkins bouncing ${REGION}/${CLUSTER}/${SERVICE}...\"}' ${SLACK_WEBHOOK_URL}"
-    sh "aws ecs update-service --force-new-deployment --cluster ${CLUSTER} --service ${SERVICE} --region ${REGION}"
-    sh "aws ecs wait services-stable --cluster ${CLUSTER} --services ${SERVICE} --region ${REGION}"
+    script{
+      for (s in env.SERVICE.split(',')) {
+        bounceService(s)
+      }      
+    }
     sh "curl --data '{\"text\": \"${REGION}/${CLUSTER}/${SERVICE} is now stable\"}' ${SLACK_WEBHOOK_URL}"
    }
   }
  }
+}
+
+def bounceService(String service) {
+    sh "aws ecs update-service --force-new-deployment --cluster ${CLUSTER} --service ${service} --region ${REGION}"
+    sh "aws ecs wait services-stable --cluster ${CLUSTER} --services ${service} --region ${REGION}"
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
@@ -14,6 +14,10 @@ namespace Wellcome.Dds.Server.Controllers
     [ApiController]
     public class AnnotationsController : ControllerBase
     {
+        // NOTE: the paths here take {*id} to allow for handling the various textGranularity levels 
+        // https://iiif.io/api/extension/text-granularity/#2-text-granularity-levels-and-the-textgranularity-property
+        // e.g. /b28047345/all/line, /b28047345/b28047345_0001.jp2/line, /b28047345/images + more in future
+
         private readonly DdsOptions ddsOptions;
         private Helpers helpers;
         private IIIIFBuilder iiifBuilder;

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/AnnotationsController.cs
@@ -1,16 +1,15 @@
-using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using IIIF.Serialisation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Utils.Storage;
+using Microsoft.FeatureManagement.Mvc;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
 using Wellcome.Dds.Server.Conneg;
 
 namespace Wellcome.Dds.Server.Controllers
 {    
+    [FeatureGate(FeatureFlags.PresentationServices)]
     [Route("[controller]")]
     [ApiController]
     public class AnnotationsController : ControllerBase

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
@@ -62,12 +62,6 @@ namespace Wellcome.Dds.Server.Controllers
             return controller.Content(rewritten, contentType);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="container"></param>
-        /// <param name="path"></param>
-        /// <returns></returns>
         public async Task<JObject?> LoadAsJson(string container, string path)
         {
             var stream = await storage.GetStream(container, path);

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -31,13 +31,7 @@ namespace Wellcome.Dds.Server.Controllers
         private readonly ICatalogue catalogue;
         private readonly IMemoryCache memoryCache;
         private Helpers helpers;
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="uriPatterns"></param>
-        /// <param name="options"></param>
-        /// <param name="ddsContext"></param>
+        
         public WlOrgController(
             UriPatterns uriPatterns,
             IOptions<DdsOptions> options,

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -302,6 +302,7 @@ namespace Wellcome.Dds.Server.Controllers
         /// <param name="newUrl"></param>
         /// <param name="updatedQueryString"></param>
         /// <returns></returns>
+        [HttpGet]
         public IActionResult BuilderUrl(string newUrl, string updatedQueryString = null)
         {
             if (updatedQueryString != null)

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
@@ -9,6 +9,7 @@ using IIIF.Serialisation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement.Mvc;
 using Utils;
 using Utils.Web;
 using Wellcome.Dds.Catalogue;
@@ -27,6 +28,7 @@ namespace Wellcome.Dds.Server.Controllers
     /// <summary>
     /// Mostly now just a Proxy to S3 resources made by WorkflowProcessor.
     /// </summary>
+    [FeatureGate(FeatureFlags.PresentationServices)]
     [Route("[controller]")]
     [ApiController]
     public class PresentationController : ControllerBase
@@ -38,15 +40,6 @@ namespace Wellcome.Dds.Server.Controllers
         private IIIIFBuilder iiifBuilder;
         private ICatalogue catalogue;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="options"></param>
-        /// <param name="helpers"></param>
-        /// <param name="uriPatterns"></param>
-        /// <param name="ddsContext"></param>
-        /// <param name="iiifBuilder"></param>
-        /// <param name="catalogue"></param>
         public PresentationController(
             IOptions<DdsOptions> options,
             Helpers helpers,

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SearchController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SearchController.cs
@@ -7,6 +7,8 @@ using IIIF.Search;
 using IIIF.Search.V1;
 using IIIF.Serialisation;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.Mvc;
 using Utils;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
@@ -15,23 +17,21 @@ using Wellcome.Dds.WordsAndPictures.Search;
 
 namespace Wellcome.Dds.Server.Controllers
 {
+    [FeatureGate(FeatureFlags.TextServices)]
     [Route("[controller]")]
     [ApiController]
     public class SearchController : ControllerBase
     {
         private CachingAltoSearchTextProvider searchTextProvider;
         private IIIIFBuilder iiifBuilder;
-        private readonly DdsOptions ddsOptions;
 
         private static readonly string[] SearchParameters = { "motivation", "date", "user", "box" };
 
         public SearchController(
-            IOptions<DdsOptions> options,
             CachingAltoSearchTextProvider searchTextProvider,
             IIIIFBuilder iiifBuilder
-            )
+        )
         {
-            ddsOptions = options.Value;
             this.searchTextProvider = searchTextProvider;
             this.iiifBuilder = iiifBuilder;
         }
@@ -49,7 +49,6 @@ namespace Wellcome.Dds.Server.Controllers
             IgnoreParams(termList);
             return Content(termList.AsJson(), "application/json");
         }
-
 
         /// <summary>
         /// http://localhost:8084/search/v0/b28047345?q=more%20robust
@@ -76,8 +75,7 @@ namespace Wellcome.Dds.Server.Controllers
             IgnoreParams(asAnnotations.Within);
             return Content(asAnnotations.AsJson(), "application/json");
         }
-        
-        
+
         /// <summary> 
         /// http://localhost:8084/search/v1/b28047345?q=more%20robust
         /// Hits are properly distributed.

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/ServiceController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/ServiceController.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Utils;
 using Utils.Web;

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/TextController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/TextController.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement.Mvc;
 using Utils;
 using Utils.Storage;
 using Wellcome.Dds.AssetDomain.Mets;
@@ -12,6 +13,7 @@ namespace Wellcome.Dds.Server.Controllers
     /// <summary>
     /// Provides raw text from S3, generated from ALTO at workflow processing time.
     /// </summary>
+    [FeatureGate(FeatureFlags.TextServices)]
     [Route("[controller]")]
     [ApiController]
     public class TextController : ControllerBase

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/ThumbController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/ThumbController.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Processing;
 using Utils;
@@ -15,6 +16,7 @@ using Wellcome.Dds.Repositories.Presentation;
 
 namespace Wellcome.Dds.Server.Controllers
 {
+    [FeatureGate(FeatureFlags.PresentationServices)]
     [Route("[controller]")]
     public class ThumbController : Controller
     {

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/FeatureFlags.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/FeatureFlags.cs
@@ -1,0 +1,15 @@
+﻿namespace Wellcome.Dds.Server
+{
+    public enum FeatureFlags
+    {
+        /// <summary>
+        /// Feature enabling all text services, including search.
+        /// </summary>
+        TextServices,
+        
+        /// <summary>
+        /// Feature enabling all Presentation services for serving static content.
+        /// </summary>
+        PresentationServices
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.FeatureManagement;
 using OAuth2;
 using Utils.Aws.S3;
 using Utils.Caching;
@@ -160,6 +161,8 @@ namespace Wellcome.Dds.Server
                     options.JsonSerializerOptions.IgnoreNullValues = true;
                     options.JsonSerializerOptions.WriteIndented = true;
                 });
+
+            services.AddFeatureManagement();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -7,6 +7,10 @@
         <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     </PropertyGroup>
 
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+      <NoWarn>1701;1702;1591</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\DlcsWebClient\DlcsWebClient.csproj" />
       <ProjectReference Include="..\IIIF\IIIF.csproj" />

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -27,6 +27,7 @@
       <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.3" />
+      <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.2.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
       <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.3" />

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
@@ -93,5 +93,9 @@
       "Prefix": "stgannos-",
       "MemoryCacheSeconds": 180
     }
+  },
+  "FeatureManagement": {
+    "TextServices": true,
+    "PresentationServices": true
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/Search/SearchConverter.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/Search/SearchConverter.cs
@@ -5,9 +5,11 @@ namespace Wellcome.Dds.WordsAndPictures.Search
 {
     public class SearchConverter
     {
+        /// <summary>
+        /// Convert the results to the simplified player format, just page indexes and rectangles
+        /// </summary>
         public static IEnumerable<SearchResult> ConvertToSimplePlayerResults(List<ResultRect> results)
         {
-            // convert the results to the simplified player format, just page indexes and rectangles
             var playerResults = results
                 .GroupBy(rr => rr.Idx)
                 .Select(gp => new SearchResult


### PR DESCRIPTION
Add `TextServices` and `PresentationServices` feature flags to dds.server. These only enable/disable controllers but could be used to register expensive dependencies etc if required.

Also added [1591](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1591) to ignore list for dds.server.

Added `[HttpGet]` to `BuildUrl` method as this was breaking swagger docs.