### PR TITLE
Ids for pseudo services

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -395,7 +395,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             build.ImprovePagingSequence(manifest);
             build.CheckForCopyAndVolumeStructure(metsManifestation, state);
             build.ManifestLevelAnnotations(manifest, metsManifestation);
-            build.AddAccessHint(manifest, metsManifestation, manifestationMetadata.Identifier.BNumber);
+            build.AddAccessHint(manifest, metsManifestation, manifestationMetadata.Identifier);
         }
         
         

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -395,7 +395,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             build.ImprovePagingSequence(manifest);
             build.CheckForCopyAndVolumeStructure(metsManifestation, state);
             build.ManifestLevelAnnotations(manifest, metsManifestation);
-            build.AddAccessHint(manifest, metsManifestation);
+            build.AddAccessHint(manifest, metsManifestation, manifestationMetadata.Identifier.BNumber);
         }
         
         

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -1106,10 +1106,9 @@ namespace Wellcome.Dds.Repositories.Presentation
             var mdCalmRef = manifestationMetadata.Manifestations.FirstOrDefault()?.ReferenceNumber;
             var collectioncode = mdCalmRef.HasText() ? mdCalmRef : "n/a";
 
-            var bNumber = manifestationMetadata.Identifier.BNumber;
             string trackingLabel = "Format: " + format +
                         ", Institution: " + institution +
-                        ", Identifier: " + bNumber +
+                        ", Identifier: " + manifestationMetadata.Identifier.BNumber +
                         ", Digicode: " + digicode +
                         ", Collection code: " + collectioncode;
 
@@ -1118,7 +1117,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             ((ICollectionItem)iiifResource).Services?.Add(
                 new ExternalResource("Text")
                 {
-                    Id = TrackingExtensionsService.IdTemplate + bNumber,
+                    Id = TrackingExtensionsService.IdTemplate + manifestationMetadata.Identifier,
                     Profile = Constants.Profiles.TrackingExtension,
                     Label = Lang.Map(trackingLabel)
                 });

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -22,6 +22,7 @@ using Wellcome.Dds.Repositories.Presentation.AuthServices;
 using Wellcome.Dds.Repositories.Presentation.LicencesAndRights;
 using Wellcome.Dds.Repositories.Presentation.LicencesAndRights.LegacyConfig;
 using Wellcome.Dds.Repositories.Presentation.SpecialState;
+using Wellcome.Dds.Repositories.Presentation.V2.IXIF;
 using AccessCondition = Wellcome.Dds.Common.AccessCondition;
 using Range = IIIF.Presentation.V3.Range;
 using StringUtils = Utils.StringUtils;
@@ -1105,9 +1106,10 @@ namespace Wellcome.Dds.Repositories.Presentation
             var mdCalmRef = manifestationMetadata.Manifestations.FirstOrDefault()?.ReferenceNumber;
             var collectioncode = mdCalmRef.HasText() ? mdCalmRef : "n/a";
 
+            var bNumber = manifestationMetadata.Identifier.BNumber;
             string trackingLabel = "Format: " + format +
                         ", Institution: " + institution +
-                        ", Identifier: " + manifestationMetadata.Identifier.BNumber +
+                        ", Identifier: " + bNumber +
                         ", Digicode: " + digicode +
                         ", Collection code: " + collectioncode;
 
@@ -1116,6 +1118,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             ((ICollectionItem)iiifResource).Services?.Add(
                 new ExternalResource("Text")
                 {
+                    Id = TrackingExtensionsService.IdTemplate + bNumber,
                     Profile = Constants.Profiles.TrackingExtension,
                     Label = Lang.Map(trackingLabel)
                 });
@@ -1127,12 +1130,13 @@ namespace Wellcome.Dds.Repositories.Presentation
             ((ICollectionItem)iiifResource).Services?.Add(
                 new ExternalResource("Text")
                 {
+                    Id = iiifResource.Id + "#timestamp",
                     Profile = Constants.Profiles.BuilderTime,
                     Label = Lang.Map("none", DateTime.UtcNow.ToString("O"))
                 });
         }
 
-        public void AddAccessHint(Manifest manifest, IManifestation metsManifestation)
+        public void AddAccessHint(Manifest manifest, IManifestation metsManifestation, string identifier)
         {
             var accessConditions = metsManifestation.Sequence
                 .Select(pf => pf.AccessCondition);
@@ -1156,6 +1160,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             manifest.Services?.Add(
                 new ExternalResource("Text")
                 {
+                    Id = AccessControlHints.IdTemplate.Replace("{identifier}", identifier),
                     Profile = Constants.Profiles.AccessControlHints,
                     Label = Lang.Map(accessHint)
                 });

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/AccessControlHints.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/AccessControlHints.cs
@@ -11,6 +11,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
     /// </summary>
     public class AccessControlHints : ResourceBase, IService
     {
+        public const string IdTemplate = "https://wellcomelibrary.org/iiif/{identifier}/access-control-hints-service";
         public override string? Type { get; set; } = null;
         
         [JsonProperty(Order = 5, PropertyName = "accessHint")]
@@ -19,7 +20,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
         public AccessControlHints(DdsIdentifier identifier, LanguageMap accessHint)
         {
             AccessHint = accessHint.ToString();
-            Id = $"https://wellcomelibrary.org/iiif/{identifier}/access-control-hints-service";
+            Id = IdTemplate.Replace("{identifier}", identifier);
             Profile = Constants.Profiles.AccessControlHints;
             Context = "http://wellcomelibrary.org/ld/iiif-ext/0/context.json";
         }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/TrackingExtensionsService.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/TrackingExtensionsService.cs
@@ -1,4 +1,5 @@
-﻿using IIIF;
+﻿using System;
+using IIIF;
 using IIIF.Presentation.V2;
 using IIIF.Presentation.V3.Strings;
 using Newtonsoft.Json;
@@ -11,6 +12,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
     /// </summary>
     public class TrackingExtensionsService : ResourceBase, IService
     {
+        public const string IdTemplate = "http://wellcomelibrary.org/service/trackingLabels/";
         public override string? Type { get; set; } = null;
         
         [JsonProperty(Order = 5, PropertyName = "trackingLabel")]
@@ -19,7 +21,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
         public TrackingExtensionsService(DdsIdentifier identifier, LanguageMap trackingLabel)
         {
             TrackingLabel = trackingLabel.ToString();
-            Id = $"http://wellcomelibrary.org/service/trackingLabels/{identifier}";
+            Id = $"{IdTemplate}{identifier}";
             Profile = Constants.Profiles.TrackingExtension;
             Context = "http://universalviewer.io/context.json";
         }


### PR DESCRIPTION
@stephenwf pointed out that the pseudo-services in the v3 (tracking label, access hints) lack IDs, which is a MUST in the spec.

This gives them IDs for validity, but retains the wl.org URLs for them as a memento (they were never dereferenceable anyway).