### PR TITLE
Some extra args for WorkflowProcessor for our test b numbers

### DIFF
--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using CatalogueClient.ToolSupport;


### PR DESCRIPTION
This is just the ability to use workflowprocessor to reset/create workflow jobs for the special b numbers in https://github.com/wellcomecollection/platform/issues/5032.

Usage:

`--mopup`

`--mopupcd` (with Chemist and Druggist)

`--mopupcd --workflow-options 6` (with specific workflow options)
