### PR TITLE
Pdf coverpage updates

### DIFF
--- a/src/PdfCoverPage/generator.py
+++ b/src/PdfCoverPage/generator.py
@@ -39,7 +39,7 @@ def generate_pdf(identifier: str):
     relevant_fields = extract_required_fields(manifest)
 
     # generate PDF and get bytes
-    pdf_bytes = build_pdf(relevant_fields)
+    pdf_bytes = build_pdf(relevant_fields, identifier)
     pdf_bytes.seek(0)
     print(f"generated PDF cover-page for '{identifier}'")
 
@@ -69,7 +69,7 @@ def extract_required_fields(manifest):
     return relevant_fields
 
 
-def build_pdf(data: dict):
+def build_pdf(data: dict, identifier: str):
     """build pdf and return bytes"""
 
     # configure document
@@ -143,7 +143,7 @@ def build_pdf(data: dict):
     pdf_elements.append(TopPadder(bottom))
 
     pdf_bytes = io.BytesIO()
-    doc = SimpleDocTemplate(pdf_bytes, pagesize=A4, topMargin=30, bottomMargin=30)
+    doc = SimpleDocTemplate(pdf_bytes, pagesize=A4, topMargin=30, bottomMargin=30, title=f"{identifier}.pdf")
     doc.build(pdf_elements)
     return pdf_bytes
 

--- a/src/PdfCoverPage/generator.py
+++ b/src/PdfCoverPage/generator.py
@@ -65,7 +65,7 @@ def extract_required_fields(manifest):
             value = v["value"]
             relevant_fields[k] = v["value"][get_first_lang(value)]
         elif k == "provider":
-            relevant_fields[k] = v[0]
+            relevant_fields[k] = v
     return relevant_fields
 
 
@@ -109,6 +109,17 @@ def build_pdf(data: dict):
             attribution_statement = metadata.get("Attribution and usage", [])
 
     add_pdf_metadata("Persistent URL", data["homepage"])
+
+    # get providers - wellcome will always be first
+    providers = data["provider"]
+    wellcome_provider = providers[0]
+
+    if len(providers) > 1:
+        for additional_provider in providers[1:]:
+            label = additional_provider["label"]
+            add_pdf_metadata("Provider", label[get_first_lang(label)])
+
+    # separator between metadata + rights statement
     pdf_elements.append(Spacer(1, 20))
 
     # take any element from requiredStatement/"Attribution and Usage" that is not "Wellcome Collection"
@@ -116,12 +127,10 @@ def build_pdf(data: dict):
         add_pdf_metadata("License and attribution", required_statement)
 
     # bottom section
-    provider = data["provider"]
-
-    provider_label = provider["label"]
+    provider_label = wellcome_provider["label"]
     address_parts = provider_label[get_first_lang(provider_label)]
 
-    logo_url = provider["logo"][0]["id"]
+    logo_url = wellcome_provider["logo"][0]["id"]
 
     # create a table of 2 columns
     # the first has the image, the seconds has multiple rows - 1 per address part


### PR DESCRIPTION
3 changes to PDF coverpage:

* For `"License and attribution"` output use `requiredStatement` if present. Fallback to `"Attribution and usage"` metadata value if not present.
* Handle multiple `provider` elements. Always output Wellcome logo + address, for any further providers render label as `"Provider"`.
* Set pdf title - this is just to avoid browser rendering as window named `(anonymous)`