### PR TITLE
Add zip text to collections, remove catalogue from UriPatterns

### DIFF
--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.json
@@ -59,8 +59,9 @@
     "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
     "GoobiCall": "DO NOT CALL",
-    "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works",
-    "DlcsReturnUrl": "https://iiif.wellcomecollection.org/auth/fromcas"
+    "DlcsReturnUrl": "https://iiif.wellcomecollection.org/auth/fromcas",
+    "WellcomeCollectionApi": "https://api.wellcomecollection.org",
+    "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works"
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DashboardRepositoryTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DashboardRepositoryTests.cs
@@ -47,7 +47,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
                 LinkedDataDomain = "https://test.com"
             };
             var options = Options.Create(ddsOptions);
-            var uriPatterns = new UriPatterns(options, catalogue);
+            var uriPatterns = new UriPatterns(options);
 
             sut = new DashboardRepository(new NullLogger<DashboardRepository>(), uriPatterns, dlcs, metsRepository,
                 ddsInstrumentationContext);

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -21,6 +21,7 @@
 
         // New, Catalogue
         public string ApiWorkTemplate { get; set; }
+        public string WellcomeCollectionApi { get; set; }
 
         // New, Dds
         public string DlcsOriginUsername { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashController.cs
@@ -236,7 +236,7 @@ namespace Wellcome.Dds.Dashboard.Controllers
                 {
                     // It's OK, in the dashboard, for a Manifestation to not have a corresponding work.
                     // We can't make IIIF for it, though.
-                    model.CatalogueApi = uriPatterns.CatalogueApi(work.Id, null);
+                    model.CatalogueApi = uriPatterns.CatalogueApi(work.Id);
                     model.WorkPage = uriPatterns.PersistentPlayerUri(work.Id);
                 }
                 model.AVDerivatives = dashboardRepository.GetAVDerivatives(dgManifestation);

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
@@ -51,8 +51,9 @@
     "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
     "GoobiCall": "DO NOT CALL",
-    "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works",
-    "DlcsReturnUrl": "https://iiif.wellcomecollection.org/auth/fromcas"
+    "DlcsReturnUrl": "https://iiif.wellcomecollection.org/auth/fromcas",
+    "WellcomeCollectionApi": "https://api.wellcomecollection.org",
+    "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works"
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories.Tests/Presentation/V2/PresentationConverterTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories.Tests/Presentation/V2/PresentationConverterTests.cs
@@ -25,7 +25,7 @@ namespace Wellcome.Dds.Repositories.Tests.Presentation.V2
             {
                 LinkedDataDomain = "http://test.example/"
             });
-            sut = new PresentationConverter(new UriPatterns(options, null), NullLogger.Instance);
+            sut = new PresentationConverter(new UriPatterns(options), NullLogger.Instance);
         }
         
         [Fact]

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -9,6 +9,7 @@ using IIIF.Presentation.V2.Strings;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Constants;
+using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Search.V1;
 using Microsoft.Extensions.Logging;
@@ -305,12 +306,20 @@ namespace Wellcome.Dds.Repositories.Presentation
             ManifestationMetadata manifestationMetadata,
             State? state)
         {
-            // TODO - use of Labels.
             // The work label should be preferred over the METS label,
             // but sometimes there is structural (volume) labelling that the catalogue API won't know about.
             collection.Items = new List<ICollectionItem>();
             collection.Behavior ??= new List<string>();
             collection.Behavior.Add(Behavior.MultiPart);
+            collection.Rendering ??= new List<ExternalResource>()
+            {
+                new("Text")
+                {
+                    Id = uriPatterns.WorkZippedText(manifestationMetadata.Identifier.BNumber),
+                    Label = Lang.Map("en", "Complete text as zip file"),
+                    Format = "application/zip"
+                }
+            };
             if (metsCollection.Collections.HasItems())
             {
                 foreach (var coll in metsCollection.Collections)

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -118,7 +118,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             {
                 new ExternalResource("Dataset")
                 {
-                    Id = uriPatterns.CatalogueApi(work.Id, new string[]{}),
+                    Id = uriPatterns.CatalogueApi(work.Id),
                     Label = Lang.Map("Wellcome Collection Catalogue API"),
                     Format = "application/json",
                     Profile = "https://api.wellcomecollection.org/catalogue/v2/context.json"
@@ -235,7 +235,6 @@ namespace Wellcome.Dds.Repositories.Presentation
                 // At the moment, "Text" is not really a good Type for the PDF - but what else?
                 manifest.Rendering.Add(new ExternalResource("Text")
                 {
-                    // TODO - are space and identifier the right way round, in the new query?
                     Id = uriPatterns.DlcsPdf(dlcsEntryPoint, metsManifestation.Id),
                     Label = Lang.Map("View as PDF"),
                     Format = "application/pdf"
@@ -1117,7 +1116,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             ((ICollectionItem)iiifResource).Services?.Add(
                 new ExternalResource("Text")
                 {
-                    Id = TrackingExtensionsService.IdTemplate + manifestationMetadata.Identifier,
+                    Id = iiifResource.Id + "#tracking",
                     Profile = Constants.Profiles.TrackingExtension,
                     Label = Lang.Map(trackingLabel)
                 });
@@ -1159,7 +1158,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             manifest.Services?.Add(
                 new ExternalResource("Text")
                 {
-                    Id = AccessControlHints.IdTemplate.Replace("{identifier}", identifier),
+                    Id = manifest.Id + "#accesscontrolhints",
                     Profile = Constants.Profiles.AccessControlHints,
                     Label = Lang.Map(accessHint)
                 });

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/AccessControlHints.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/AccessControlHints.cs
@@ -11,7 +11,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
     /// </summary>
     public class AccessControlHints : ResourceBase, IService
     {
-        public const string IdTemplate = "https://wellcomelibrary.org/iiif/{identifier}/access-control-hints-service";
+        private const string IdTemplate = "https://wellcomelibrary.org/iiif/{identifier}/access-control-hints-service";
         public override string? Type { get; set; } = null;
         
         [JsonProperty(Order = 5, PropertyName = "accessHint")]

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/TrackingExtensionsService.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/TrackingExtensionsService.cs
@@ -12,7 +12,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
     /// </summary>
     public class TrackingExtensionsService : ResourceBase, IService
     {
-        public const string IdTemplate = "http://wellcomelibrary.org/service/trackingLabels/";
+        private const string IdTemplate = "http://wellcomelibrary.org/service/trackingLabels/";
         public override string? Type { get; set; } = null;
         
         [JsonProperty(Order = 5, PropertyName = "trackingLabel")]

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
@@ -61,12 +61,13 @@
     "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
     "GoobiCall": "DO NOT CALL",
-    "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works",
     "DlcsReturnUrl": "https://iiif.wellcomecollection.org/auth/fromcas",
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
-    "ReferenceV0SearchService": true
+    "ReferenceV0SearchService": true,
+    "WellcomeCollectionApi": "https://api.wellcomecollection.org",
+    "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works"
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
@@ -65,6 +65,7 @@
     "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",
     "GoobiCall": "DO NOT CALL",
+    "WellcomeCollectionApi": "https://api.wellcomecollection.org",
     "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works"
   },
   "BinaryObjectCache": {


### PR DESCRIPTION
Took the opportunity to remove ICatalogue dependency from UriPatterns, as well as added an additional host for UriPatterns to use - api.wc.org - and updated the existing /text paths to use this new host.

Tidied up some of the pseudo-service Ids.