### PR TITLE
Add --offset and --catalogue-dump params

### DIFF
--- a/src/Wellcome.Dds/CatalogueClient/Program.cs
+++ b/src/Wellcome.Dds/CatalogueClient/Program.cs
@@ -31,10 +31,11 @@ namespace CatalogueClient
         {
             var sw = new Stopwatch();
             sw.Start();
+            var dumpUtils = new DumpUtils();
             if (update)
             {
-                await DumpUtils.DownloadDump();
-                DumpUtils.UnpackDump();
+                await dumpUtils.DownloadDump();
+                dumpUtils.UnpackDump();
             }
             
             if (id != null)
@@ -63,7 +64,7 @@ namespace CatalogueClient
             switch (bulkop)
             {
                 case "count-digitised-locations":
-                    foreach (var line in DumpUtils.ReadLines(dumpLoopInfo))
+                    foreach (var line in dumpUtils.ReadLines(dumpLoopInfo))
                     {
                         if (dumpLoopInfo.TotalCount % 1000 == 0)
                         {
@@ -74,7 +75,7 @@ namespace CatalogueClient
                     break;
                 case "display-bnumber":
                     var catalogue = GetCatalogue();
-                    DumpUtils.FindDigitisedBNumbers(dumpLoopInfo, catalogue);
+                    dumpUtils.FindDigitisedBNumbers(dumpLoopInfo, catalogue);
                     break;
                 default:
                     Console.WriteLine("(No bulk operation specified)");

--- a/src/Wellcome.Dds/CatalogueClient/ToolSupport/DumpLoopInfo.cs
+++ b/src/Wellcome.Dds/CatalogueClient/ToolSupport/DumpLoopInfo.cs
@@ -6,6 +6,7 @@ namespace CatalogueClient.ToolSupport
     {
         public string Filter;
         public int Skip = 1;
+        public int Offset = 0;
         public int TotalCount;
         public int MatchCount;
         public int UsedLines;

--- a/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "WorkflowProcessor": {
       "commandName": "Project",
       "launchBrowser": false,
-      "commandLineArgs": "--populate-slice 100 --catalogue-dump C:\\Users\\DonaldGray\\AppData\\Local\\Temp\\dump.txt",
+      "commandLineArgs": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "WorkflowProcessor": {
       "commandName": "Project",
       "launchBrowser": false,
-      "commandLineArgs": "",
+      "commandLineArgs": "--populate-slice 100 --catalogue-dump C:\\Users\\DonaldGray\\AppData\\Local\\Temp\\dump.txt",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/Wellcome.Dds/WorkflowProcessor/README.md
+++ b/src/Wellcome.Dds/WorkflowProcessor/README.md
@@ -29,4 +29,18 @@ This flags integer can be obtained by creating a new RunnerOptions instance and 
 There is also a helper RunnerOptions.AllButDlcsSync() call for large-scale operations.
 
 `--workflow-options 30`
+
 This is (currently) the all-but-DLCS flags value.
+
+`--offset {offset}`
+
+Create workflow jobs from a subset of all possible digitised b numbers.
+This will produce a list of b numbers that have digital locations, ignoring the first {offset} entries that
+have digitised b numbers (NOT skipping first X lines).
+Used alongside `--populate-slice`
+
+`--catalogue-dump {path}`
+
+Specify the catalogue dump file to use, this will NOT download a fresh copy of catalogue.
+If specified file is not found, program will throw an exception.
+Used alongside `--populate-slice`


### PR DESCRIPTION
Added `--catalogue-dump {path}` and `--offset {offset}` params to workflow processor as this enables greater control over processing and allows stop/start.

To handle this made `DumpUtils` non-static as it now stores dump file location.

Also added handling for cancellationToken.