### PR TITLE
Use PrettyCamelCaseResolver in ThumbnailConverter

### DIFF
--- a/src/Wellcome.Dds/IIIF/Serialisation/ThumbnailConverter.cs
+++ b/src/Wellcome.Dds/IIIF/Serialisation/ThumbnailConverter.cs
@@ -29,7 +29,8 @@ namespace IIIF.Serialisation
                     new JsonSerializerSettings
                     {
                         NullValueHandling = NullValueHandling.Ignore,
-                        ContractResolver = new CamelCasePropertyNamesContractResolver()
+                        ContractResolver = new PrettyIIIFContractResolver(),
+                        Formatting = Formatting.Indented,
                     }));
             }
         }


### PR DESCRIPTION
Missing this meant that `[ObjectIfSingle]` was not honoured in serialization