### PR TITLE
Pass RunnerOptions to WorkflowJobPostProcessor

### DIFF
--- a/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowJobPostProcessorTests.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowJobPostProcessorTests.cs
@@ -41,7 +41,7 @@ namespace WorkflowProcessor.Tests
             var workflowJob = new WorkflowJob {FlushCache = false};
             
             // Act
-            await sut.PostProcess(workflowJob);
+            await sut.PostProcess(workflowJob, new RunnerOptions());
             
             // Assert
             A.CallTo(() => sns.PublishAsync(A<PublishRequest>._, A<CancellationToken>._)).MustNotHaveHappened();
@@ -57,14 +57,14 @@ namespace WorkflowProcessor.Tests
             // Arrange
             var workflowJob = new WorkflowJob
             {
-                FlushCache = true, Identifier = "b1231231", WorkflowOptions = options
+                FlushCache = true, Identifier = "b1231231"
             };
             PublishRequest request = null;
             A.CallTo(() => sns.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))
                 .Invokes((PublishRequest pr, CancellationToken ct) => request = pr);
 
             // Act
-            await sut.PostProcess(workflowJob);
+            await sut.PostProcess(workflowJob, RunnerOptions.FromInt32(options));
             
             // Assert
             A.CallTo(() => sns.PublishAsync(A<PublishRequest>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
@@ -84,7 +84,7 @@ namespace WorkflowProcessor.Tests
             // Arrange
             var workflowJob = new WorkflowJob
             {
-                FlushCache = true, Identifier = "b1231231", WorkflowOptions = options
+                FlushCache = true, Identifier = "b1231231"
             };
             PublishRequest requestIiif = null;
             PublishRequest requestApi = null;
@@ -102,7 +102,7 @@ namespace WorkflowProcessor.Tests
                 });
 
             // Act
-            await sut.PostProcess(workflowJob);
+            await sut.PostProcess(workflowJob, RunnerOptions.FromInt32(options));
             
             // Assert
             A.CallTo(() => sns.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowJobPostProcessor.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowJobPostProcessor.cs
@@ -13,7 +13,7 @@ namespace WorkflowProcessor
 {
     public interface IWorkflowJobPostProcessor
     {
-        Task PostProcess(WorkflowJob job);
+        Task PostProcess(WorkflowJob job, RunnerOptions runnerOptions);
     }
 
     public class WorkflowJobPostProcessor : IWorkflowJobPostProcessor
@@ -35,15 +35,13 @@ namespace WorkflowProcessor
             this.logger = logger;
         }
 
-        public async Task PostProcess(WorkflowJob job)
+        public async Task PostProcess(WorkflowJob job, RunnerOptions runnerOptions)
         {
             if (!job.FlushCache) return;
             
             logger.LogInformation("Flushing cache for {Identifier}", job.Identifier);
 
             var cacheInvalidationOptions = options.Value;
-
-            var runnerOptions = RunnerOptions.FromInt32(job.WorkflowOptions ?? 0);
 
             // api.wc.org cache is only invalidated if text has been rebuilt 
             if (runnerOptions.RebuildTextCaches)

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowRunner.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowRunner.cs
@@ -129,7 +129,7 @@ namespace WorkflowProcessor
                     await SetJobErrorMessage(job);
                 }
 
-                await postProcessor.PostProcess(job);
+                await postProcessor.PostProcess(job, jobOptions);
                 job.TotalTime = (long)(DateTime.Now - job.Taken.Value).TotalMilliseconds;
             }
             catch (Exception ex)


### PR DESCRIPTION
This ensures default configured options are used in event of options being null, this logic is already handled by `WorkflowRunner`