### PR TITLE
normalise b numbers in Library redirects and for canonical IIIF

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/LibrarySiteController.cs
@@ -48,18 +48,29 @@ namespace Wellcome.Dds.Server.Controllers
             this.memoryCache = memoryCache;
             this.helpers = helpers;
         }
+        
+        private string Normalise(string bNumber)
+        {
+            // don't normalise b000-000 forms
+            if (bNumber.Contains('-'))
+            {
+                return bNumber;
+            }
 
+            return WellcomeLibraryIdentifiers.GetNormalisedBNumber(bNumber, false);
+        }
         
         [HttpGet("iiif/collection/{id}")]
         public IActionResult IIIFCollection(string id)
         {
-            return BuilderUrl(uriPatterns.CollectionForWork(id));
+            return BuilderUrl(uriPatterns.CollectionForWork(Normalise(id)));
         }
-        
+
+     
         [HttpGet("iiif/{id}/manifest")]
         public IActionResult IIIFManifest(string id)
         {
-            return ManifestLevelConversion(id, uriPatterns.Manifest);
+            return ManifestLevelConversion(Normalise(id), uriPatterns.Manifest);
         }
 
         [HttpGet("annoservices/search/{id}")]
@@ -78,7 +89,7 @@ namespace Wellcome.Dds.Server.Controllers
         [HttpGet("item/{id}")]
         public async Task<IActionResult> ItemPage(string id)
         {
-            var work = await catalogue.GetWorkByOtherIdentifier(id);
+            var work = await catalogue.GetWorkByOtherIdentifier(Normalise(id));
             if (work != null)
             {
                 return BuilderUrl(uriPatterns.PersistentPlayerUri(work.Id));


### PR DESCRIPTION
Fixes https://github.com/wellcomecollection/platform/issues/5128

This is also redirecting iiif.wc.org/presentation/XXX but is a bit more picky about whether it should actually redirect XXX than the old DDS, on the grounds that we shouldn't be getting DIRECT links into the new DDS with b number variants. 