### PR TITLE
Improve wf perf

### DIFF
--- a/src/Wellcome.Dds/Utils.Tests/Threading/AsyncKeyedLockTests.cs
+++ b/src/Wellcome.Dds/Utils.Tests/Threading/AsyncKeyedLockTests.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Utils.Threading;
+using Xunit;
+
+namespace Utils.Tests.Threading
+{
+    public class AsyncKeyedLockTests
+    {
+        private readonly AsyncKeyedLock sut;
+
+        public AsyncKeyedLockTests()
+        {
+            sut = new AsyncKeyedLock();
+        }
+        
+        [Fact]
+        public async Task LockAsync_PreventsItemsWithSameKey_AttainingLockAtSameTime()
+        {
+            const string key = nameof(LockAsync_PreventsItemsWithSameKey_AttainingLockAtSameTime);
+            var calls = new List<string>();
+            bool task1Complete = false;
+
+            await Task.WhenAll(
+                Task.Run(async () =>
+                {
+                    // Task will get lock immediately but wait 400ms to release
+                    using (var theLock = await sut.LockAsync(key))
+                    {
+                        await Task.Delay(400);
+                        calls.Add("Quick attain, run slow");
+                        (theLock as AsyncKeyedLock.Releaser).HaveLock.Should().BeTrue();
+                        task1Complete = true;
+                    }
+                }), 
+                Task.Run(async () =>
+                {
+                    // Task will try get lock after 200ms 
+                    await Task.Delay(200);
+                    using (var theLock = await sut.LockAsync(key))
+                    {
+                        calls.Add("Slow attain, run quick");
+                        (theLock as AsyncKeyedLock.Releaser).HaveLock.Should().BeTrue();
+                        task1Complete.Should().BeTrue();
+                    }
+                }));
+
+            calls.Count.Should().Be(2);
+            calls[0].Should().Be("Quick attain, run slow");
+            calls[1].Should().Be("Slow attain, run quick");
+        }
+        
+        [Fact]
+        public async Task LockAsync_AllowsItemsWithSameKey_AttainingLockAtSameTime()
+        {
+            const string key = nameof(LockAsync_AllowsItemsWithSameKey_AttainingLockAtSameTime);
+            var calls = new List<string>();
+            bool task1Complete = false;
+
+            await Task.WhenAll(
+                Task.Run(async () =>
+                {
+                    // Task will get lock immediately but wait 400ms to release
+                    using (var theLock = await sut.LockAsync(key))
+                    {
+                        await Task.Delay(400);
+                        calls.Add("Quick attain, run slow");
+                        (theLock as AsyncKeyedLock.Releaser).HaveLock.Should().BeTrue();
+                        task1Complete = true;
+                    }
+                }), 
+                Task.Run(async () =>
+                {
+                    // Task will try get lock after 200ms, different key so should get it
+                    await Task.Delay(200);
+                    using (var theLock = await sut.LockAsync($"not{key}"))
+                    {
+                        calls.Add("Slow attain, run quick");
+                        (theLock as AsyncKeyedLock.Releaser).HaveLock.Should().BeTrue();
+                        task1Complete.Should().BeFalse();
+                    }
+                }));
+
+            calls.Count.Should().Be(2);
+            calls[0].Should().Be("Slow attain, run quick");
+            calls[1].Should().Be("Quick attain, run slow");
+        }
+        
+        [Fact]
+        public async Task LockAsyncTimespan_CanAttainingLockAfterTimeout_MarkedAsNotLocked()
+        {
+            const string key = nameof(LockAsyncTimespan_CanAttainingLockAfterTimeout_MarkedAsNotLocked);
+            var calls = new List<string>();
+            bool task1Complete = false;
+            bool task2Complete = false;
+
+            await Task.WhenAll(
+                Task.Run(async () =>
+                {
+                    // Task will get lock immediately but wait 400ms to release
+                    using (var theLock = await sut.LockAsync(key))
+                    {
+                        await Task.Delay(400);
+                        (theLock as AsyncKeyedLock.Releaser).HaveLock.Should().BeTrue();
+                        calls.Add("Quick attain, run slow");
+                        task1Complete = true;
+                    }
+                }), 
+                Task.Run(async () =>
+                {
+                    // Task will try get lock after 200ms, wait 100ms then enter block even if lock not attained
+                    await Task.Delay(200);
+                    using (var theLock = await sut.LockAsync(key, TimeSpan.FromMilliseconds(100)))
+                    {
+                        calls.Add("Slow attain, run quick");
+                        (theLock as AsyncKeyedLock.Releaser).HaveLock.Should().BeFalse();
+                        task1Complete.Should().BeFalse();
+                    }
+                }),
+                Task.Run(async () =>
+                {
+                    // Task will try get lock after 600ms
+                    await Task.Delay(600);
+                    using (var theLock = await sut.LockAsync(key))
+                    {
+                        calls.Add("Verify timeout lock doesn't affect normal process");
+                        (theLock as AsyncKeyedLock.Releaser).HaveLock.Should().BeTrue();
+                        task2Complete.Should().BeFalse();
+                    }
+                }));
+
+            calls.Count.Should().Be(3);
+            calls[0].Should().Be("Slow attain, run quick");
+            calls[1].Should().Be("Quick attain, run slow");
+            calls[2].Should().Be("Verify timeout lock doesn't affect normal process");
+        }
+    }
+}

--- a/src/Wellcome.Dds/Utils.Tests/Threading/AsyncKeyedLockTests.cs
+++ b/src/Wellcome.Dds/Utils.Tests/Threading/AsyncKeyedLockTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Utils.Tests.Threading
 {
+    [Trait("Category", "Manual")]
     public class AsyncKeyedLockTests
     {
         private readonly AsyncKeyedLock sut;

--- a/src/Wellcome.Dds/Utils/Caching/BinaryObjectCacheOptions.cs
+++ b/src/Wellcome.Dds/Utils/Caching/BinaryObjectCacheOptions.cs
@@ -12,5 +12,15 @@ namespace Utils.Caching
         public string Container { get; set; }
         public string Prefix { get; set; }
         public int MemoryCacheSeconds { get; set; }
+
+        /// <summary>
+        /// How long to wait to get critical path lock (ms)
+        /// </summary>
+        public int CriticalPathTimeout { get; set; } = 1000;
+
+        /// <summary>
+        /// Whether to throw an exception if critical path lock times out
+        /// </summary>
+        public bool ThrowOnCriticalPathTimeout { get; set; } = false;
     }
 }

--- a/src/Wellcome.Dds/Utils/Caching/IBinaryObjectCache.cs
+++ b/src/Wellcome.Dds/Utils/Caching/IBinaryObjectCache.cs
@@ -10,6 +10,11 @@ namespace Utils.Caching
 
         Task<T> GetCachedObject(string key, Func<Task<T>> getFromSource, Predicate<T> storedVersionIsStale);
 
+        /// <summary>
+        /// Get cached object from local cache only, do not attempt to read from backing store.
+        /// </summary> 
+        Task<T> GetCachedObjectFromLocal(string key, Func<Task<T>> getFromSource);
+
         ISimpleStoredFileInfo GetCachedFile(string key);
 
         Task DeleteCacheFile(string key);

--- a/src/Wellcome.Dds/Utils/Threading/AsyncKeyedLock.cs
+++ b/src/Wellcome.Dds/Utils/Threading/AsyncKeyedLock.cs
@@ -19,6 +19,18 @@ namespace Utils.Threading
             return new Releaser { Key = key };
         }
         
+        public async Task<IDisposable> LockAsync(object key, TimeSpan timeout, bool throwIfNoLock = false)
+        {
+            var success = await GetOrCreate(key).WaitAsync(timeout);
+            if (!success && throwIfNoLock)
+            {
+                throw new TimeoutException(
+                    $"Unable to attain lock for {key} within timeout of {timeout.TotalMilliseconds}ms");
+            }
+
+            return new Releaser { Key = key, HaveLock = success};
+        }
+        
         private SemaphoreSlim GetOrCreate(object key)
         {
             RefCounted<SemaphoreSlim> item;
@@ -49,15 +61,21 @@ namespace Utils.Threading
             public T Value { get; }
         }
 
-        private static readonly Dictionary<object, RefCounted<SemaphoreSlim>> SemaphoreSlims
-            = new Dictionary<object, RefCounted<SemaphoreSlim>>();
+        private static readonly Dictionary<object, RefCounted<SemaphoreSlim>> SemaphoreSlims = new();
 
-        private sealed class Releaser : IDisposable
+        public sealed class Releaser : IDisposable
         {
             public object Key { get; set; }
 
+            public bool HaveLock { get; set; } = true;
+
             public void Dispose()
             {
+                if (!HaveLock)
+                {
+                    return;
+                }
+                
                 RefCounted<SemaphoreSlim> item;
                 lock (SemaphoreSlims)
                 {

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/CachingAllAnnotationProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/CachingAllAnnotationProvider.cs
@@ -42,7 +42,7 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
             string identifier,
             IEnumerable<IPhysicalFile> physicalFiles)
         {
-            return cache.GetCachedObject(identifier, () => GetPagesInternal(identifier, physicalFiles), x => true);
+            return cache.GetCachedObjectFromLocal(identifier, () => GetPagesInternal(identifier, physicalFiles));
         }
 
         private async Task<AnnotationPageList> GetPagesInternal(

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/CachingAltoSearchTextProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/CachingAltoSearchTextProvider.cs
@@ -10,7 +10,6 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
     {
         private readonly AltoSearchTextProvider altoSearchTextProvider;
         private readonly IBinaryObjectCache<Text> searchTextCache; 
-        // needs options altoCache and httpRuntimeSeconds, prefix "alto_"
         
         public CachingAltoSearchTextProvider(
             AltoSearchTextProvider altoSearchTextProvider,
@@ -28,7 +27,7 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
         public Task<Text> ForceSearchTextRebuild(string identifier)
         {
             Func<Task<Text>> getFromSource = () => altoSearchTextProvider.GetSearchText(identifier);
-            return searchTextCache.GetCachedObject(identifier, getFromSource, t => true);
+            return searchTextCache.GetCachedObjectFromLocal(identifier, getFromSource);
         }
 
         public ISimpleStoredFileInfo GetFileInfo(string identifier)

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
@@ -87,7 +87,8 @@
       "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-text",
       "Prefix": "stgtext-",
-      "MemoryCacheSeconds": 180
+      "MemoryCacheSeconds": 180,
+      "CriticalPathTimeout": 3000
     },
     "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
       "AvoidCaching": false,
@@ -95,7 +96,8 @@
       "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-annotations",
       "Prefix": "stgannos-",
-      "MemoryCacheSeconds": 180
+      "MemoryCacheSeconds": 180,
+      "CriticalPathTimeout": 3000
     }
   },
   "FeatureManagement": {

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
@@ -43,7 +43,7 @@
     "ScopeIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
     "StorageMapCache": "",
     "MemoryCacheSeconds": 3600,
-    "PreferCachedStorageMap": false,
+    "PreferCachedStorageMap": true,
     "MaxAgeStorageMap": 180
   },
   "S3CacheOptions": {
@@ -80,7 +80,9 @@
       "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-storagemaps",
       "Prefix": "stgmap-",
-      "MemoryCacheSeconds": 180
+      "MemoryCacheSeconds": 3600,
+      "CriticalPathTimeout": 10000,
+      "ThrowOnCriticalPathTimeout": true
     },
     "Wellcome.Dds.WordsAndPictures.Text": {
       "AvoidCaching": false,
@@ -88,7 +90,9 @@
       "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-text",
       "Prefix": "stgtext-",
-      "MemoryCacheSeconds": 180
+      "MemoryCacheSeconds": 3600,
+      "CriticalPathTimeout": 10000,
+      "ThrowOnCriticalPathTimeout": true
     },
     "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
       "AvoidCaching": false,
@@ -96,7 +100,9 @@
       "WriteFailThrowsException": true,
       "Container": "wellcomecollection-stage-iiif-annotations",
       "Prefix": "stgannos-",
-      "MemoryCacheSeconds": 180
+      "MemoryCacheSeconds": 3600,
+      "CriticalPathTimeout": 10000,
+      "ThrowOnCriticalPathTimeout": true
     }
   }
 }

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
@@ -81,7 +81,7 @@
       "Container": "wellcomecollection-stage-iiif-storagemaps",
       "Prefix": "stgmap-",
       "MemoryCacheSeconds": 3600,
-      "CriticalPathTimeout": 10000,
+      "CriticalPathTimeout": 60000,
       "ThrowOnCriticalPathTimeout": true
     },
     "Wellcome.Dds.WordsAndPictures.Text": {
@@ -91,7 +91,7 @@
       "Container": "wellcomecollection-stage-iiif-text",
       "Prefix": "stgtext-",
       "MemoryCacheSeconds": 3600,
-      "CriticalPathTimeout": 10000,
+      "CriticalPathTimeout": 60000,
       "ThrowOnCriticalPathTimeout": true
     },
     "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
@@ -101,7 +101,7 @@
       "Container": "wellcomecollection-stage-iiif-annotations",
       "Prefix": "stgannos-",
       "MemoryCacheSeconds": 3600,
-      "CriticalPathTimeout": 10000,
+      "CriticalPathTimeout": 60000,
       "ThrowOnCriticalPathTimeout": true
     }
   }


### PR DESCRIPTION
Couple of different optimisations to try and fix/troubleshoot issues with WF processor:

* Add `AsyncKeyedLock.LockAsync(object key, TimeSpan timeout, bool throwIfNoLock = false)` overload. This is controlled by appSettings. WF processer waits 1 min and throws if it can't get lock, all other apps will wait 1s and _not_ throw. In the case of not throwing the thread is let through to the critical section.
* Add `BinaryObjectCache.GetCachedObjectFromLocal` - this is to replace usages of cache where returned object is always invalid. It has same behaviour as `GetCachedObject` except it doesn't try to read from backing store.
* Increased all memory ttl for workflow processor - `MemoryCache.Compact(100)` is called after each item is processed so no need to have things expire mid-run.