### PR TITLE
5146 works troubleshooting

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
@@ -109,6 +109,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
             external093Service.Id = GetRestrictedLoginServiceId093();
             external093Service.Label = new MetaDataValue(RestrictedHeader);
             external093Service.FailureHeader = new MetaDataValue(RestrictedHeader);
+            external093Service.Description = new MetaDataValue(RestrictedFailureDescription);
             external093Service.FailureDescription = new MetaDataValue(RestrictedFailureDescription);
             external093Service.Service = GetCommonChildAuthServices(tokenServiceId);
             // confirmLabel? Not really appropriate; the client needs to provide the text for "cancel"...

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
@@ -138,13 +138,16 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
             else
             {
                 var externalResource = (ExternalResource)paintable;
+                var copiedServices = externalResource.Service?
+                    .Select(i => ObjectCopier.DeepCopy(i))
+                    .ToList();
                 var avResource = new ExternalResourceForMedia
                 {
                     Id = externalResource.Id,
                     Format = externalResource.Format,
-                    Service = externalResource.Service,
+                    Service = copiedServices,
                 };
-                PopulateAuthServices(authServiceManager, avResource.Service, true, DuplicateAuthServices);
+                PopulateAuthServices(authServiceManager, avResource.Service, true, true);
                 annoListForMedia.Rendering.Add(avResource);
                 annoListForMedia.Service = avResource.Service;
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
@@ -147,7 +147,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
                     Format = externalResource.Format,
                     Service = copiedServices,
                 };
-                PopulateAuthServices(authServiceManager, avResource.Service, true, true);
+                PopulateAuthServices(authServiceManager, avResource.Service, true, DuplicateAuthServices);
                 annoListForMedia.Rendering.Add(avResource);
                 annoListForMedia.Service = avResource.Service;
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
@@ -40,7 +40,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
             presentationBase.NavDate = resourceBase.NavDate;
             presentationBase.Related = resourceBase.Homepage?.Select(ConvertResource).ToList();
             presentationBase.SeeAlso = resourceBase.SeeAlso?.Select(ConvertResource).ToList();
-            presentationBase.Within = resourceBase.PartOf?.FirstOrDefault()?.Id;
+            presentationBase.Within = ToPresentationV2Id(resourceBase.PartOf?.FirstOrDefault()?.Id);
 
             if (resourceBase.Service.HasItems())
             {

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
@@ -24,6 +24,9 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
     /// </summary>
     public class ConverterHelpers
     {
+        // Remove this as soon as we can!
+        const bool DuplicateAuthServices = true;
+        
         public static T GetIIIFPresentationBase<T>(Presi3.StructureBase resourceBase, Func<string, bool>? labelFilter = null)
             where T : IIIFPresentationBase, new()
         {
@@ -141,7 +144,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
                     Format = externalResource.Format,
                     Service = externalResource.Service,
                 };
-                PopulateAuthServices(authServiceManager, avResource.Service, true);
+                PopulateAuthServices(authServiceManager, avResource.Service, true, DuplicateAuthServices);
                 annoListForMedia.Rendering.Add(avResource);
                 annoListForMedia.Service = avResource.Service;
 
@@ -197,8 +200,14 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
                     }
                 }))
                 .ToList();
-            
-            PopulateAuthServices(authServiceManager, imageService.Service, false);
+
+            var addedAuthServices = PopulateAuthServices(authServiceManager, imageService.Service, false, DuplicateAuthServices);
+            // in wl.org manifests, if the image resource's image service has auth services,
+            // then so does the image itself.
+            if (addedAuthServices != null)
+            {
+                services?.AddRange(addedAuthServices);
+            }
 
             var imageAnnotation = new ImageAnnotation();
             imageAnnotation.Id = paintingAnnotation.Id;
@@ -217,36 +226,51 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
         public static bool IsBornDigital(IIIF.Presentation.V3.Manifest p3Manifest) 
             => p3Manifest.Items.HasItems() && p3Manifest.Items!.All(item => item.Items.IsNullOrEmpty());
         
-        private static void PopulateAuthServices(WellcomeAuthServiceManager authServiceManager,
-            List<IService>? candidateServices, bool forceFullService)
+        private static List<IService>? PopulateAuthServices(WellcomeAuthServiceManager authServiceManager,
+            List<IService>? candidateServices, bool forceFullService, bool duplicateAuthServices)
         {
             // If we don't have auth services then bail out..
-            if (!authServiceManager.HasItems) return;
+            if (!authServiceManager.HasItems) return null;
 
             // Get all service references from candidate-services (these will be auth services)
             // for P3 we will _only_ have svc refs, the main Auth services will be in the manifest.Service element 
             var authServiceReferences = candidateServices?.OfType<V2ServiceReference>().ToList();
-            if (!authServiceReferences.HasItems()) return;
+            if (!authServiceReferences.HasItems()) return null;
 
             // Remove these from imageService.Services
             candidateServices?.RemoveAll(s => s is V2ServiceReference);
 
             // Re-add appropriate services. This will be full AuthService if first time it appears,
             // or serviceReference if it is not the first time
+            List<IService> addedAuthServices = new();
             foreach (var authRef in authServiceReferences!)
             {
                 var service = authServiceManager.Get(authRef.Id!, forceFullService);
-                if (service is WellcomeAuthService was)
+                if (service is WellcomeAccessControlHintService was)
                 {
                     // if we have a wellcomeAuthService add the "AuthService" only
                     candidateServices?.AddRange(was.AuthService);
+                    addedAuthServices.AddRange(was.AuthService);
+                    if (duplicateAuthServices)
+                    {
+                        candidateServices?.AddRange(was.AuthService);
+                        addedAuthServices.AddRange(was.AuthService);
+                    }
                 }
                 else
                 {
                     // else just re-add the reference
                     candidateServices?.Add(service);
+                    addedAuthServices.Add(service);
+                    if (duplicateAuthServices)
+                    {
+                        candidateServices?.Add(service);
+                        addedAuthServices.Add(service);
+                    }
                 }
             }
+
+            return addedAuthServices;
         }
         
         private static void AddAttributionAndUsageMetadata<T>(

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/WellcomeAccessControlHintService.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/WellcomeAccessControlHintService.cs
@@ -10,7 +10,7 @@ namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
     /// This is a service that is used by wl.org UV for rendering iiif p2.
     /// This is not valid IIIF service but is required for backward compatibility.
     /// </summary>
-    public class WellcomeAuthService : ResourceBase, IService
+    public class WellcomeAccessControlHintService : ResourceBase, IService
     {
         public override string? Type { get; set; }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/WellcomeAuthServiceManager.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/IXIF/WellcomeAuthServiceManager.cs
@@ -5,11 +5,11 @@ using IIIF;
 namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
 {
     /// <summary>
-    /// Helper class for managing <see cref="WellcomeAuthService"/> when converting to P2
+    /// Helper class for managing <see cref="WellcomeAccessControlHintService"/> when converting to P2
     /// </summary>
     public class WellcomeAuthServiceManager
     {
-        private Dictionary<string, WellcomeAuthService> wellcomeAuthServices = new();
+        private Dictionary<string, WellcomeAccessControlHintService> wellcomeAuthServices = new();
         private Dictionary<string, V2ServiceReference>? requested = new();
         
         /// <summary>
@@ -20,10 +20,10 @@ namespace Wellcome.Dds.Repositories.Presentation.V2.IXIF
         /// <summary>
         /// Add authService to internal collection.
         /// </summary>
-        public void Add(WellcomeAuthService authService)
+        public void Add(WellcomeAccessControlHintService accessControlHintService)
         {
             HasItems = true;
-            wellcomeAuthServices.Add(authService.AuthService!.First().Id, authService);
+            wellcomeAuthServices.Add(accessControlHintService.AuthService!.First().Id, accessControlHintService);
         }
         
         /// <summary>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/PresentationConverter.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/PresentationConverter.cs
@@ -181,19 +181,6 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
                             // I think it's OK to leave the extra labels on
                             manifest.Service.Add(ObjectCopier.DeepCopy(wellcomeAuthService, null)!);
                             
-                            // Add a copy of the wellcomeAuthService to .Service - copy to ensure nulling fields doesn't
-                            // null all references
-                            // manifest.Service.Add(ObjectCopier.DeepCopy(wellcomeAuthService, wellcomeAuth =>
-                            // {
-                            //     foreach (var authCookieService in wellcomeAuth.AuthService.OfType<AuthCookieService>())
-                            //     {
-                            //         authCookieService.ConfirmLabel = null;
-                            //         authCookieService.Header = null;
-                            //         authCookieService.FailureHeader = null;
-                            //         authCookieService.FailureDescription = null;
-                            //     }
-                            // })!);
-
                             // Add to wellcomeAuthServices collection
                             authServiceManager.Add(wellcomeAuthService);
                             haveAuth = true;

--- a/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "WorkflowProcessor": {
       "commandName": "Project",
       "launchBrowser": false,
-      "commandLineArgs": "--process b12811385",
+      "commandLineArgs": "--process b16675150",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "WorkflowProcessor": {
       "commandName": "Project",
       "launchBrowser": false,
-      "commandLineArgs": "",
+      "commandLineArgs": "--process b12811385",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "WorkflowProcessor": {
       "commandName": "Project",
       "launchBrowser": false,
-      "commandLineArgs": "--process b16675150",
+      "commandLineArgs": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
Addresses the non-search problems reported in https://github.com/wellcomecollection/platform/issues/5146

Reproduces duplicate auth services
Reproduces auth services in image resources, as well as on their image services
Fixed a bug where AV resources from v3 manifest were modified in the v2 conversion
v2 `within` property uses a v2 `@id`
Use /0/ service profiles for auth
Missing Description on restricted login service