### PR TITLE
Search troubleshooting

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -610,7 +610,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                 Terms = suggestions.Select(suggestion => new Term
                 {
                         Match = suggestion,
-                        Search = searchUri + "?q=" + q
+                        Search = searchUri + "?q=" + suggestion
                 }).ToArray()
             };
         }


### PR DESCRIPTION
Fixes a bug where autocomplete provides the same link over and over

Allows you to serve a manifest on localhost with the fully qualified DDS links at localhost but the DLCS links to cloudfront proxy paths
