### PR TITLE
Handle parsing errors in ALTO files at the page level

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/AltoSearchTextProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/WordsAndPictures/AltoSearchTextProvider.cs
@@ -83,7 +83,7 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
                             // IF alto file has no margin elements then first lone string that is a number or last lone string that is a number
                             // could be ignored. What to do about running titles?
 
-                            // comment this out for now as it realy should be fixed by providing better ALTO files that have proper PrintSpace,
+                            // comment this out for now as it really should be fixed by providing better ALTO files that have proper PrintSpace,
                             // not trying to outguess the typesetter.
                             //var strings = textBlock.Descendants(ns + "String").ToList();
                             //if (strings.Count() == 1)
@@ -103,9 +103,6 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
                             
                             Word prevWord = null;
                             
-         
-
-
                             bool wordIsHyphenSecondPart = false;
                             foreach (var textLine in textBlock.Descendants(ns + "TextLine"))
                             {
@@ -189,7 +186,7 @@ namespace Wellcome.Dds.Repositories.WordsAndPictures
                     }
                     catch (Exception ex)
                     {
-                        logger.LogError(ex, "Cannot read or parse ALTO");
+                        logger.LogError(ex, "Cannot read or parse ALTO in {relativeAltoPath}", physicalFile.RelativeAltoPath);
                     }
                 }
             }

--- a/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/SimpleAltoProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/SimpleAltoProvider.cs
@@ -2,13 +2,26 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
 using Utils;
 
 namespace Wellcome.Dds.WordsAndPictures.SimpleAltoServices
 {
     public class SimpleAltoProvider
     {
-        private static XNamespace ns = "http://www.loc.gov/standards/alto/ns-v2#";
+        private readonly ILogger logger;
+        private static readonly XNamespace ns = "http://www.loc.gov/standards/alto/ns-v2#";
+
+        public SimpleAltoProvider()
+        {
+            logger = null;
+        }
+        
+        public SimpleAltoProvider(ILogger logger)
+        {
+            this.logger = logger;
+        }
+        
 
         public AnnotationPage GetAnnotationPage(
             XElement altoRoot,
@@ -20,39 +33,49 @@ namespace Wellcome.Dds.WordsAndPictures.SimpleAltoServices
             var illustrations = new List<Illustration>();
             var composedBlocks = new List<Illustration>();
 
-            //var altoRoot = XElement.Load(fullAltoPath);
-            var pageElement = altoRoot.Element(ns + "Layout").Element(ns + "Page");
-            int srcW = Convert.ToInt32(pageElement.GetRequiredAttributeValue("WIDTH"));
-            int srcH = Convert.ToInt32(pageElement.GetRequiredAttributeValue("HEIGHT"));
-            float scaleW = (float)actualWidth / (float)srcW;
-            float scaleH = (float)actualHeight / (float)srcH;
-            // only get strings in textblocks, not page numbers and headers
-            var printSpace = altoRoot.Descendants(ns + "PrintSpace").FirstOrDefault();
-            if (printSpace != null)
+            if (altoRoot != null)
             {
-                foreach (var altoTextLine in printSpace.Descendants(ns + "TextLine"))
+                try
                 {
-                    var textLine = new TextLine();
-                    SetScaledDimensions(altoTextLine, textLine, scaleW, scaleH);
-                    textLine.Text = string.Join(" ", altoTextLine.Descendants(ns + "String")
-                        .Select(s => s.GetRequiredAttributeValue("CONTENT").Trim()));
-                    textLines.Add(textLine);
-                }
+                    var pageElement = altoRoot.Element(ns + "Layout").Element(ns + "Page");
+                    int srcW = Convert.ToInt32(pageElement.GetRequiredAttributeValue("WIDTH"));
+                    int srcH = Convert.ToInt32(pageElement.GetRequiredAttributeValue("HEIGHT"));
+                    float scaleW = (float)actualWidth / (float)srcW;
+                    float scaleH = (float)actualHeight / (float)srcH;
+                    // only get strings in textblocks, not page numbers and headers
+                    var printSpace = altoRoot.Descendants(ns + "PrintSpace").FirstOrDefault();
+                    if (printSpace != null)
+                    {
+                        foreach (var altoTextLine in printSpace.Descendants(ns + "TextLine"))
+                        {
+                            var textLine = new TextLine();
+                            SetScaledDimensions(altoTextLine, textLine, scaleW, scaleH);
+                            textLine.Text = string.Join(" ", altoTextLine.Descendants(ns + "String")
+                                .Select(s => s.GetRequiredAttributeValue("CONTENT").Trim()));
+                            textLines.Add(textLine);
+                        }
 
-                foreach (var altoIllustration in printSpace.Descendants(ns + "Illustration"))
-                {
-                    var illustration = new Illustration();
-                    SetScaledDimensions(altoIllustration, illustration, scaleW, scaleH);
-                    illustration.Type = altoIllustration.GetAttributeValue("TYPE", "Unknown");
-                    illustrations.Add(illustration);
-                }
+                        foreach (var altoIllustration in printSpace.Descendants(ns + "Illustration"))
+                        {
+                            var illustration = new Illustration();
+                            SetScaledDimensions(altoIllustration, illustration, scaleW, scaleH);
+                            illustration.Type = altoIllustration.GetAttributeValue("TYPE", "Unknown");
+                            illustrations.Add(illustration);
+                        }
 
-                foreach (var altoComposedBlock in printSpace.Descendants(ns + "ComposedBlock"))
+                        foreach (var altoComposedBlock in printSpace.Descendants(ns + "ComposedBlock"))
+                        {
+                            var composedBlock = new Illustration();
+                            SetScaledDimensions(altoComposedBlock, composedBlock, scaleW, scaleH);
+                            composedBlock.Type = altoComposedBlock.GetAttributeValue("TYPE", "Unknown");
+                            illustrations.Add(composedBlock);
+                        }
+                    }
+                }
+                catch (Exception ex)
                 {
-                    var composedBlock = new Illustration();
-                    SetScaledDimensions(altoComposedBlock, composedBlock, scaleW, scaleH);
-                    composedBlock.Type = altoComposedBlock.GetAttributeValue("TYPE", "Unknown");
-                    illustrations.Add(composedBlock);
+                    logger.LogError(ex, 
+                        "SimpleAltoProvider cannot extract page from ALTO for {assetIdentifier}", assetIdentifier);
                 }
             }
 

--- a/src/Wellcome.Dds/WorkflowProcessor/AltoDerivedAssetBuilder.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/AltoDerivedAssetBuilder.cs
@@ -62,7 +62,6 @@ namespace WorkflowProcessor
             int wordsCountedOnThisRun = 0;
             bool wordCountInvalid = false;
 
-            // TODO - this needs a load of error handling etc
             try
             {
                 DeleteZipFileIfExists(job.Identifier);
@@ -102,7 +101,19 @@ namespace WorkflowProcessor
                         {
                             if (jobOptions.RebuildAllAnnoPageCaches)
                             {
-                                // These are in our internal text model
+                                // TODO: we can have an implementation of cachingAllAnnotationProvider
+                                // that uses the Text object constructed in RebuildText, rather than
+                                // read the ALTO files again.
+                                // However - we need to consider memory use here. At this point, Text
+                                // is not in scope and can be garbage collected; the cachingAllAnnotationProvider
+                                // reads one ALTO file at a time to construct the annotationPages list.
+                                // We would still need the full Text object in scope to build the annotation pages,
+                                // which might use too much memory.
+                                
+                                // A complete alternative would involve doing the BuildW3CAndOaAnnotations
+                                // during the Text construction, which merges together the responsibilities.
+                                // This would be more efficient but is a substantial change.
+                                
                                 var annotationPages = await
                                     cachingAllAnnotationProvider.ForcePagesRebuild(manifestation.Id,
                                         manifestation.Sequence);


### PR DESCRIPTION
At this stage I decided against reworking this to avoid separate ALTO reads for text building and annotation building.

See comment - https://github.com/wellcomecollection/iiif-builder/blob/a6d58209e4085b5747d2e170e783e16400869899/src/Wellcome.Dds/WorkflowProcessor/AltoDerivedAssetBuilder.cs#L104

We can back to that in later maintenance.