### PR TITLE
Availabilities in api

### DIFF
--- a/src/Wellcome.Dds/CatalogueClient/Program.cs
+++ b/src/Wellcome.Dds/CatalogueClient/Program.cs
@@ -103,7 +103,7 @@ namespace CatalogueClient
                 bool? online = work.IsOnline();
                 if (online == null) continue; // availabilities is NOT present
                 
-                if (work.HasDigitalLocation() != online.Value)
+                if (work.HasIIIFDigitalLocation() != online.Value)
                 {
                     Console.WriteLine("HasDigitalLocation disagrees with IsOnline for " + work.Id);
                 }

--- a/src/Wellcome.Dds/CatalogueClient/Program.cs
+++ b/src/Wellcome.Dds/CatalogueClient/Program.cs
@@ -74,8 +74,10 @@ namespace CatalogueClient
                     Console.Write($"\rIIIF Presentation in {dumpLoopInfo.MatchCount}/{dumpLoopInfo.TotalCount} works.");
                     break;
                 case "display-bnumber":
-                    var catalogue = GetCatalogue();
-                    dumpUtils.FindDigitisedBNumbers(dumpLoopInfo, catalogue);
+                    dumpUtils.FindDigitisedBNumbers(dumpLoopInfo, GetCatalogue());
+                    break;
+                case "compare-availabilities":
+                    CompareAvailabilities(dumpUtils, skip);
                     break;
                 default:
                     Console.WriteLine("(No bulk operation specified)");
@@ -84,6 +86,28 @@ namespace CatalogueClient
             Console.WriteLine();
             sw.Stop();  
             Console.WriteLine($"Finished in {sw.Elapsed.TotalSeconds} seconds.");
+        }
+
+        private static void CompareAvailabilities(DumpUtils dumpUtils, int skip)
+        {
+            var catalogue = GetCatalogue();
+            var options = DumpUtils.GetSerialiserOptions();
+            int counter = 0;
+            foreach (var line in dumpUtils.ReadLines(new DumpLoopInfo {Skip = skip}))
+            {
+                if (counter++ % 100 == 0)
+                {
+                    Console.WriteLine("processing: " + counter);
+                }
+                var work = catalogue.FromDumpLine(line, options);
+                bool? online = work.IsOnline();
+                if (online == null) continue; // availabilities is NOT present
+                
+                if (work.HasDigitalLocation() != online.Value)
+                {
+                    Console.WriteLine("HasDigitalLocation disagrees with IsOnline for " + work.Id);
+                }
+            }
         }
 
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -919,7 +919,7 @@ namespace Wellcome.Dds.Repositories.Presentation
 
         private ICollectionItem? MakePart(Work work, Manifestation? manifestation)
         {
-            if (manifestation != null || work.HasDigitalLocation())
+            if (manifestation != null || work.HasIIIFDigitalLocation())
             {
                 // definitely a manifest
                 return new Manifest

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
@@ -258,7 +258,7 @@ namespace Wellcome.Dds.Server.Controllers
             else
             {
                 var work = await catalogue.GetWorkByOtherIdentifier(referenceNumber);
-                if (work.HasDigitalLocation())
+                if (work.HasIIIFDigitalLocation())
                 {
                     var bNumber = work.GetSierraSystemBNumbers().First();
                     return Redirect(uriPatterns.Manifest(bNumber));
@@ -287,7 +287,7 @@ namespace Wellcome.Dds.Server.Controllers
             else
             {
                 var work = await catalogue.GetWorkByOtherIdentifier(referenceNumber);
-                if (work.HasDigitalLocation())
+                if (work.HasIIIFDigitalLocation())
                 {
                     var bNumber = work.GetSierraSystemBNumbers().First();
                     return Redirect(uriPatterns.Manifest(bNumber).AsV2());

--- a/src/Wellcome.Dds/Wellcome.Dds/Catalogue/Work.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/Catalogue/Work.cs
@@ -26,6 +26,8 @@
         public Work[] PrecededBy { get; set; }
         public Work[] SucceededBy { get; set; }
         
+        public LabelledEntity[] Availabilities { get; set; }
+        
         public int TotalParts { get; set; }
         public int TotalDescendentParts { get; set; }
 

--- a/src/Wellcome.Dds/Wellcome.Dds/Catalogue/WorkExtensions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/Catalogue/WorkExtensions.cs
@@ -121,5 +121,10 @@ namespace Wellcome.Dds.Catalogue
                     location => location.LocationType.Id == "iiif-presentation"));
             return iiifLocations.HasItems();
         }
+
+        public static bool? IsOnline(this Work work)
+        {
+            return work.Availabilities?.Any(a => a.Id == "online");
+        }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds/Catalogue/WorkExtensions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/Catalogue/WorkExtensions.cs
@@ -114,7 +114,7 @@ namespace Wellcome.Dds.Catalogue
             return new string[0];
         }
 
-        public static bool HasDigitalLocation(this Work work)
+        public static bool HasIIIFDigitalLocation(this Work work)
         {
             var iiifLocations = work
                 .Items?.Where(item => item.Locations.Any(


### PR DESCRIPTION
Adds `availabilities` to API (you can tell whether an item is online or not).

But it doesn't tell us whether it's IIIF or not, so not actually useful to DDS. The addition to the CatalogueClient is the test that revealed this.

Still useful to reflect the API, though. And renames the extension method `HasDigitalLocation()` to `HasIIIFDigitalLocation()` which is clearer.
