### PR TITLE
Generate canvas labels from AV logical struct DIV, if present

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,13 @@ pipeline {
     ]
    }
   }
+  stage('Install') {
+     steps {
+      sh "apt-get update"
+      sh "apt install -y python3-pip"
+      sh "pip3 install awscli"
+     }
+    }
   stage('Image') {
    steps {
     sh "docker build -t ${DOCKER_IMAGE}:jenkins -f ${DOCKER_FILE} ."

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsMetadataTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsMetadataTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using Wellcome.Dds.AssetDomainRepositories.Mets.Model;
+using Wellcome.Dds.IIIFBuilding;
 using Xunit;
 
 namespace Wellcome.Dds.AssetDomainRepositories.Tests.Mets

--- a/src/Wellcome.Dds/Wellcome.Dds.Tests/IIIFBuilding/MetsConversionTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Tests/IIIFBuilding/MetsConversionTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Wellcome.Dds.Repositories.Presentation;
+using Xunit;
+
+namespace Wellcome.Dds.Tests.IIIFBuilding
+{
+    public class MetsConversionTests
+    {
+        [Theory]
+        // structDiv  LABEL     TYPE              EXPECTED 
+        [InlineData(  "Tape 1", "Side1",          "Tape 1, Side 1")]
+        [InlineData(  "Tape 1", "Side 1",         "Tape 1, Side 1")]
+        [InlineData(  "Side 1", "Side1",          "Side 1")]
+        [InlineData(  "Side 1", "side 1",         "Side 1")]
+        [InlineData(  "Reel 3", "",               "Reel 3")]
+        [InlineData(  "Reel 3", "Side1",          "Reel 3, Side 1")]
+        [InlineData(  "Part of side 1", "Side1",  "Part of side 1")]
+        [InlineData(  "Disc 1", "A-side",         "Disc 1")]
+        public void TestSyntheticCanvasLabels(string label, string type, string expected)
+        {
+            var betterLabel = IIIFBuilderParts.GetBetterAVCanvasLabel(label, type);
+            betterLabel.Should().Be(expected);
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Tests/Wellcome.Dds.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Tests/Wellcome.Dds.Tests.csproj
@@ -23,6 +23,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Wellcome.Dds.Common\Wellcome.Dds.Common.csproj" />
+      <ProjectReference Include="..\Wellcome.Dds.Repositories\Wellcome.Dds.Repositories.csproj" />
       <ProjectReference Include="..\Wellcome.Dds\Wellcome.Dds.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
Canvases usually take labels from METS physical structure.
This checks to see if there is logical structure, and if so, attempts to generate labels from that.

It will fall back to physical structure label as normal if no label can be deduced.