### PR TITLE
Fix item type to "Sound" for audio files

### DIFF
--- a/src/Wellcome.Dds/IIIF/Presentation/V3/Content/Audio.cs
+++ b/src/Wellcome.Dds/IIIF/Presentation/V3/Content/Audio.cs
@@ -6,6 +6,6 @@ namespace IIIF.Presentation.V3.Content
     {
         public double Duration { get; set; }
 
-        public Audio() : base(nameof(Audio)) { }
+        public Audio() : base("Sound") { }
     }
 }

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
@@ -42,8 +42,4 @@
     <ProjectReference Include="..\Wellcome.Dds\Wellcome.Dds.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Options" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Correct annotation body to be `"type":"Audio"` rather than `"type":"Sound"`

Chose to update ctor parameter, which sets `Type`, rather than make the class `Sound`, as `Audio` makes more sense from api perspective.