### PR TITLE
Update to dotnet 6

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ README.md
 LICENSE
 .idea
 appsettings.Development.Example.json
+appsettings.Development.json

--- a/Dockerfile-dashboard
+++ b/Dockerfile-dashboard
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj Wellcome.Dds.Dashboard/
@@ -34,7 +34,11 @@ WORKDIR "/src/Wellcome.Dds.Dashboard"
 RUN dotnet publish "Wellcome.Dds.Dashboard.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+
+LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
+LABEL org.opencontainers.image.source=https://github.com/wellcomecollection/iiif-builder
+
 WORKDIR /app
 
 EXPOSE 80

--- a/Dockerfile-iiifbuilder
+++ b/Dockerfile-iiifbuilder
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj Wellcome.Dds.Server/
@@ -29,7 +29,11 @@ WORKDIR "/src/Wellcome.Dds.Server"
 RUN dotnet publish "Wellcome.Dds.Server.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+
+LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
+LABEL org.opencontainers.image.source=https://github.com/wellcomecollection/iiif-builder
+
 WORKDIR /app
 
 EXPOSE 80

--- a/Dockerfile-jobprocessor
+++ b/Dockerfile-jobprocessor
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj DlcsJobProcessor/
@@ -27,7 +27,10 @@ WORKDIR "/src/DlcsJobProcessor"
 RUN dotnet publish "DlcsJobProcessor.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+
+LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
+LABEL org.opencontainers.image.source=https://github.com/wellcomecollection/iiif-builder
 
 RUN apt-get update && apt-get install curl -y
 WORKDIR /app

--- a/Dockerfile-workflowprocessor
+++ b/Dockerfile-workflowprocessor
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj WorkflowProcessor/
@@ -31,7 +31,10 @@ WORKDIR "/src/WorkflowProcessor"
 RUN dotnet publish "WorkflowProcessor.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+
+LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
+LABEL org.opencontainers.image.source=https://github.com/wellcomecollection/iiif-builder
 
 RUN apt-get update && apt-get install curl -y
 WORKDIR /app

--- a/src/Wellcome.Dds/CatalogueAPI.Tests/CatalogueAPI.Tests.csproj
+++ b/src/Wellcome.Dds/CatalogueAPI.Tests/CatalogueAPI.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Wellcome.Dds/CatalogueAPI.Tests/CatalogueAPI.Tests.csproj
+++ b/src/Wellcome.Dds/CatalogueAPI.Tests/CatalogueAPI.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>9</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/CatalogueClient/CatalogueClient.csproj
+++ b/src/Wellcome.Dds/CatalogueClient/CatalogueClient.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="ShellProgressBar" Version="5.1.0" />
+      <PackageReference Include="ShellProgressBar" Version="5.2.0" />
       <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
     </ItemGroup>
 

--- a/src/Wellcome.Dds/CatalogueClient/CatalogueClient.csproj
+++ b/src/Wellcome.Dds/CatalogueClient/CatalogueClient.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>9</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj
+++ b/src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1" />
-    <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
+    <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj
+++ b/src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 

--- a/src/Wellcome.Dds/DlcsJobProcessor/Startup.cs
+++ b/src/Wellcome.Dds/DlcsJobProcessor/Startup.cs
@@ -1,4 +1,5 @@
-﻿using DlcsWebClient.Config;
+﻿using System;
+using DlcsWebClient.Config;
 using DlcsWebClient.Dlcs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
@@ -36,6 +37,9 @@ namespace DlcsJobProcessor
         
         public void ConfigureServices(IServiceCollection services)
         {
+            // Use pre-v6 handling of datetimes for npgsql
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+            
             services.AddDbContext<DdsInstrumentationContext>(options => options
                 .UseNpgsql(Configuration.GetConnectionString("DdsInstrumentation"))
                 .UseSnakeCaseNamingConvention());

--- a/src/Wellcome.Dds/DlcsWebClient.Tests/DlcsWebClient.Tests.csproj
+++ b/src/Wellcome.Dds/DlcsWebClient.Tests/DlcsWebClient.Tests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Wellcome.Dds/DlcsWebClient.Tests/DlcsWebClient.Tests.csproj
+++ b/src/Wellcome.Dds/DlcsWebClient.Tests/DlcsWebClient.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>9</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/DlcsWebClient/DlcsWebClient.csproj
+++ b/src/Wellcome.Dds/DlcsWebClient/DlcsWebClient.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/DlcsWebClient/DlcsWebClient.csproj
+++ b/src/Wellcome.Dds/DlcsWebClient/DlcsWebClient.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/IIIF.Tests/IIIF.Tests.csproj
+++ b/src/Wellcome.Dds/IIIF.Tests/IIIF.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>9</LangVersion>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/IIIF.Tests/IIIF.Tests.csproj
+++ b/src/Wellcome.Dds/IIIF.Tests/IIIF.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Wellcome.Dds/IIIF/IIIF.csproj
+++ b/src/Wellcome.Dds/IIIF/IIIF.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>9</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/OAuth2/OAuth2.csproj
+++ b/src/Wellcome.Dds/OAuth2/OAuth2.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Wellcome.Dds/OAuth2/OAuth2.csproj
+++ b/src/Wellcome.Dds/OAuth2/OAuth2.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2ApiConsumerTests.cs
+++ b/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2ApiConsumerTests.cs
@@ -29,7 +29,7 @@ namespace OAuth2Client.Tests
             }
 
             [Fact]
-            public void GetToken_Throws_IfUnsuccessfulCallResult()
+            public async Task GetToken_Throws_IfUnsuccessfulCallResult()
             {
                 // Arrange
                 httpHandler.SetResponse(httpHandler.GetResponseMessage(
@@ -40,7 +40,7 @@ namespace OAuth2Client.Tests
                 Func<Task> action = () => sut.GetToken(clientCredentials);
 
                 // Assert
-                action.Should().Throw<HttpRequestException>();
+                await action.Should().ThrowAsync<HttpRequestException>();
             }
 
             [Fact]
@@ -222,7 +222,7 @@ namespace OAuth2Client.Tests
             }
 
             [Fact]
-            public void GetOAuthedJToken_Throws_CallFailsForNon403Reason()
+            public async Task GetOAuthedJToken_Throws_CallFailsForNon403Reason()
             {
                 // Arrange
                 var tokenResponse = httpHandler.GetResponseMessage(
@@ -248,7 +248,7 @@ namespace OAuth2Client.Tests
                 Func<Task> action = () => sut.GetOAuthedJToken("http://example.org", clientCredentials);
                 
                 // Assert
-                action.Should().Throw<HttpRequestException>();
+                await action.Should().ThrowAsync<HttpRequestException>();
             }
             
             [Fact]

--- a/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2Client.Tests.csproj
+++ b/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2Client.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>9</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2Client.Tests.csproj
+++ b/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2Client.Tests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.0.1" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2TokenTests.cs
+++ b/src/Wellcome.Dds/OAuth2Client.Tests/OAuth2TokenTests.cs
@@ -17,7 +17,7 @@ namespace OAuth2Client.Tests
             var ttl = token.GetTimeToLive();
             
             // Assert
-            ttl.Should().BeCloseTo(TimeSpan.FromSeconds(120));
+            ttl.Should().BeCloseTo(TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/src/Wellcome.Dds/PdfThumbGenerator/PdfThumbGenerator.csproj
+++ b/src/Wellcome.Dds/PdfThumbGenerator/PdfThumbGenerator.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/PdfThumbGenerator/PdfThumbGenerator.csproj
+++ b/src/Wellcome.Dds/PdfThumbGenerator/PdfThumbGenerator.csproj
@@ -6,16 +6,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1" />
-      <PackageReference Include="CsvHelper" Version="26.1.0" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
+      <PackageReference Include="CsvHelper" Version="27.2.1" />
       <PackageReference Include="GhostScript.NetCore" Version="1.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-      <PackageReference Include="ShellProgressBar" Version="5.1.0" />
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+      <PackageReference Include="ShellProgressBar" Version="5.2.0" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
       <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
     </ItemGroup>
 

--- a/src/Wellcome.Dds/Test.Helpers/Test.Helpers.csproj
+++ b/src/Wellcome.Dds/Test.Helpers/Test.Helpers.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>9</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
 </Project>

--- a/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
+++ b/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
@@ -10,10 +10,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-      <PackageReference Include="AWSSDK.S3" Version="3.7.0.13" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-      <PackageReference Include="protobuf-net" Version="3.0.101" />
+      <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
+      <PackageReference Include="AWSSDK.S3" Version="3.7.9.18" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+      <PackageReference Include="protobuf-net" Version="3.1.4" />
     </ItemGroup>
 
 </Project>

--- a/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
+++ b/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>9</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Utils.Tests/Threading/TaskExTests.cs
+++ b/src/Wellcome.Dds/Utils.Tests/Threading/TaskExTests.cs
@@ -44,7 +44,7 @@ namespace Utils.Tests.Threading
         }
 
         [Fact]
-        public void TimeoutAfter_ThrowsTimeoutException_IfTimesOutAndThrowOnTimeout()
+        public async Task TimeoutAfter_ThrowsTimeoutException_IfTimesOutAndThrowOnTimeout()
         {
             // Arrange
             const int timeout = 100;
@@ -58,7 +58,7 @@ namespace Utils.Tests.Threading
             Func<Task> action = async () => await task.TimeoutAfter(timeout, true);
 
             // Assert
-            action.Should().Throw<TimeoutException>();
+            await action.Should().ThrowAsync<TimeoutException>();
         }
     }
 }

--- a/src/Wellcome.Dds/Utils.Tests/Utils.Tests.csproj
+++ b/src/Wellcome.Dds/Utils.Tests/Utils.Tests.csproj
@@ -9,17 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.0.1" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Wellcome.Dds/Utils.Tests/Utils.Tests.csproj
+++ b/src/Wellcome.Dds/Utils.Tests/Utils.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>9</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Utils/Utils.csproj
+++ b/src/Wellcome.Dds/Utils/Utils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>9</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Utils/Utils.csproj
+++ b/src/Wellcome.Dds/Utils/Utils.csproj
@@ -7,11 +7,11 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DashboardRepositoryTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DashboardRepositoryTests.cs
@@ -65,7 +65,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
         }
 
         [Fact]
-        public void GetDigitisedResource_ThrowsArgumentException_IfMetsRepositoryReturnsNull()
+        public async Task GetDigitisedResource_ThrowsArgumentException_IfMetsRepositoryReturnsNull()
         {
             // Arrange
             const string identifier = "b1231231";
@@ -73,7 +73,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
             Func<Task> action = () => sut.GetDigitisedResource(identifier);
 
             // Assert
-            action.Should().Throw<ArgumentException>().And
+            (await action.Should().ThrowAsync<ArgumentException>()).And
                 .Message.Should().Be(
                     "Cannot get a digitised resource from METS for identifier b1231231 (Parameter 'identifier')");
         }
@@ -232,14 +232,14 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
         }
 
         [Fact]
-        public void ExecuteDlcsSyncOperation_Throws_IfDlcsPreventSync()
+        public async Task ExecuteDlcsSyncOperation_Throws_IfDlcsPreventSync()
         {
             // Arrange
             A.CallTo(() => dlcs.PreventSynchronisation).Returns(true);
             Func<Task> action = () => sut.ExecuteDlcsSyncOperation(new SyncOperation(), true);
             
             // Assert
-            action.Should().Throw<InvalidOperationException>();
+            await action.Should().ThrowAsync<InvalidOperationException>();
         }
         
         [Theory]

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DatabaseStatusProviderTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DatabaseStatusProviderTests.cs
@@ -85,7 +85,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
             var sut = GetSut(minimumJobAge: minAge);
             
             // Assert
-            sut.LatestJobToTake.Should().BeCloseTo(expected, 2000);
+            sut.LatestJobToTake.Should().BeCloseTo(expected, TimeSpan.FromSeconds(2));
         }
 
         [Fact]

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DatabaseStatusProviderTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DatabaseStatusProviderTests.cs
@@ -101,7 +101,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
             // Assert
             result.Should().BeTrue();
             var controlFlow = await ddsInstrumentationContext.ControlFlows.OrderByDescending(cf => cf.Id).FirstAsync();
-            controlFlow.CreatedOn.Should().BeCloseTo(DateTime.Now, 2000);
+            controlFlow.CreatedOn.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(2));
             
             var afterCount = await ddsInstrumentationContext.ControlFlows.CountAsync();
             afterCount.Should().Be(beforeCount + 1);
@@ -207,7 +207,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
             
             // Assert
             var updated = await ddsInstrumentationContext.ControlFlows.FindAsync(controlFlow.Id);
-            updated.Heartbeat.Should().BeCloseTo(DateTime.Now, 2000);
+            updated.Heartbeat.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(2));
             updated.Heartbeat.Should().Be(result);
         }
     }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Wellcome.Dds.AssetDomainRepositories.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Wellcome.Dds.AssetDomainRepositories.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>9</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Wellcome.Dds.AssetDomainRepositories.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Wellcome.Dds.AssetDomainRepositories.Tests.csproj
@@ -9,18 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.0.13" />
-    <PackageReference Include="FakeItEasy" Version="7.0.1" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.18" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DashboardRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DashboardRepository.cs
@@ -318,18 +318,18 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
             foreach (var batch in dlcsImagesToPatch.Batch(dlcs.BatchSize))
             {
                 var imagePatches = batch.ToArray();
-                logger.LogInformation("Batch of {0}", imagePatches.Length);
+                logger.LogInformation("Batch of {BatchLength}", imagePatches.Length);
 
                 if (imagePatches.Length == 0)
                 {
-                    logger.LogInformation("zero length - abandoning.");
+                    logger.LogInformation("zero length - abandoning");
                     continue;
                 }
 
                 DlcsBatch dbBatchPatch = new DlcsBatch
                 {
                     BatchSize = imagePatches.Length,
-                    RequestSent = DateTime.Now
+                    RequestSent = DateTime.UtcNow
                 };
 
                 var imageRegistrationsAsHydraCollection = new HydraImageCollection
@@ -337,7 +337,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                     Members = imagePatches
                 };
                 var registrationOperation = await dlcs.PatchImages(imageRegistrationsAsHydraCollection);
-                dbBatchPatch.Finished = DateTime.Now;
+                dbBatchPatch.Finished = DateTime.UtcNow;
                 dbBatchPatch.RequestBody = registrationOperation.RequestJson;
                 dbBatchPatch.ResponseBody = registrationOperation.ResponseJson;
                 if (registrationOperation.Error != null)
@@ -356,18 +356,18 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
             foreach (var batch in dlcsImagesToIngest.Batch(dlcs.BatchSize))
             {
                 var imageRegistrations = batch.ToArray();
-                logger.LogInformation("Batch of {batchLength}", imageRegistrations.Length);
+                logger.LogInformation("Batch of {BatchLength}", imageRegistrations.Length);
 
                 if (imageRegistrations.Length == 0)
                 {
-                    logger.LogInformation("zero length - abandoning.");
+                    logger.LogInformation("zero length - abandoning");
                     continue;
                 }
 
                 DlcsBatch dbDlcsBatch = new DlcsBatch
                 {
                     BatchSize = imageRegistrations.Length,
-                    RequestSent = DateTime.Now
+                    RequestSent = DateTime.UtcNow
                 };
 
                 var imageRegistrationsAsHydraCollection = new HydraImageCollection
@@ -375,7 +375,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                     Members = imageRegistrations
                 };
                 var registrationOperation = await dlcs.RegisterImages(imageRegistrationsAsHydraCollection, priority);
-                dbDlcsBatch.Finished = DateTime.Now;
+                dbDlcsBatch.Finished = DateTime.UtcNow;
                 dbDlcsBatch.RequestBody = registrationOperation.RequestJson;
                 dbDlcsBatch.ResponseBody = registrationOperation.ResponseJson;
                 if (registrationOperation.Error != null)
@@ -694,7 +694,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                 Description = description,
                 JobId = jobId,
                 ManifestationId = manifestationId,
-                Performed = DateTime.Now,
+                Performed = DateTime.UtcNow,
                 Username = userName
             };
             ddsInstrumentationContext.IngestActions.Add(ia);
@@ -718,7 +718,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
         public AVDerivative[] GetAVDerivatives(IDigitisedManifestation digitisedManifestation)
         {
             var derivs = new List<AVDerivative>();
-            if (digitisedManifestation.MetsManifestation.Type == "Video" || digitisedManifestation.MetsManifestation.Type == "Audio")
+            if (digitisedManifestation.MetsManifestation.Type is "Video" or "Audio")
             {
                 foreach (var asset in digitisedManifestation.DlcsImages)
                 {

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DashboardRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Dashboard/DashboardRepository.cs
@@ -329,7 +329,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                 DlcsBatch dbBatchPatch = new DlcsBatch
                 {
                     BatchSize = imagePatches.Length,
-                    RequestSent = DateTime.UtcNow
+                    RequestSent = DateTime.Now
                 };
 
                 var imageRegistrationsAsHydraCollection = new HydraImageCollection
@@ -337,7 +337,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                     Members = imagePatches
                 };
                 var registrationOperation = await dlcs.PatchImages(imageRegistrationsAsHydraCollection);
-                dbBatchPatch.Finished = DateTime.UtcNow;
+                dbBatchPatch.Finished = DateTime.Now;
                 dbBatchPatch.RequestBody = registrationOperation.RequestJson;
                 dbBatchPatch.ResponseBody = registrationOperation.ResponseJson;
                 if (registrationOperation.Error != null)
@@ -367,7 +367,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                 DlcsBatch dbDlcsBatch = new DlcsBatch
                 {
                     BatchSize = imageRegistrations.Length,
-                    RequestSent = DateTime.UtcNow
+                    RequestSent = DateTime.Now
                 };
 
                 var imageRegistrationsAsHydraCollection = new HydraImageCollection
@@ -375,7 +375,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                     Members = imageRegistrations
                 };
                 var registrationOperation = await dlcs.RegisterImages(imageRegistrationsAsHydraCollection, priority);
-                dbDlcsBatch.Finished = DateTime.UtcNow;
+                dbDlcsBatch.Finished = DateTime.Now;
                 dbDlcsBatch.RequestBody = registrationOperation.RequestJson;
                 dbDlcsBatch.ResponseBody = registrationOperation.ResponseJson;
                 if (registrationOperation.Error != null)
@@ -694,7 +694,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Dashboard
                 Description = description,
                 JobId = jobId,
                 ManifestationId = manifestationId,
-                Performed = DateTime.UtcNow,
+                Performed = DateTime.Now,
                 Username = userName
             };
             ddsInstrumentationContext.IngestActions.Add(ia);

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Ingest/DashboardCloudServicesJobProcessor.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Ingest/DashboardCloudServicesJobProcessor.cs
@@ -77,11 +77,11 @@ namespace Wellcome.Dds.AssetDomainRepositories.Ingest
 
             if (filter.HasText())
             {
-                logger.LogInformation("Only processing identifiers that end with one of '{filter}'", filter);
+                logger.LogInformation("Only processing identifiers that end with one of '{Filter}'", filter);
                 var endings = filter.ToCharArray();
-                logger.LogInformation("before filter, jobsToProcess has {jobCount} jobs.", jobsToProcess.Count);
+                logger.LogInformation("before filter, jobsToProcess has {JobCount} jobs", jobsToProcess.Count);
                 jobsToProcess = jobsToProcess.Where(j => endings.Contains(j.Identifier[j.Identifier.Length - 1])).ToList();
-                logger.LogInformation("After filter, jobsToProcess has {jobCount} jobs.", jobsToProcess.Count);
+                logger.LogInformation("After filter, jobsToProcess has {JobCount} jobs", jobsToProcess.Count);
             }
             if (maxJobs > -1)
             {

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Wellcome.Dds.AssetDomainRepositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Wellcome.Dds.AssetDomainRepositories.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Wellcome.Dds.AssetDomainRepositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Wellcome.Dds.AssetDomainRepositories.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.0.13" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.5" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.18" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.6" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web.Tests/Wellcome.Dds.Auth.Web.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web.Tests/Wellcome.Dds.Auth.Web.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>9</LangVersion>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web.Tests/Wellcome.Dds.Auth.Web.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web.Tests/Wellcome.Dds.Auth.Web.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Wellcome.Dds.Auth.Web.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Auth.Web/Wellcome.Dds.Auth.Web.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/Wellcome.Dds.Common.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/Wellcome.Dds.Common.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>9</LangVersion>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/Wellcome.Dds.Common.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/Wellcome.Dds.Common.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/Wellcome.Dds.Common.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/Wellcome.Dds.Common.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>9</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Properties/launchSettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:8085",
+      "applicationUrl": "https://localhost:8085",
       "launchUrl": "dash/"
     }
   }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
@@ -51,6 +51,9 @@ namespace Wellcome.Dds.Dashboard
         
         public void ConfigureServices(IServiceCollection services)
         {
+            // Use pre-v6 handling of datetimes for npgsql
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+            
             services.AddDbContext<DdsInstrumentationContext>(options => options
                 .UseNpgsql(Configuration.GetConnectionString("DdsInstrumentation"))
                 .UseSnakeCaseNamingConvention());

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
@@ -1,16 +1,17 @@
 using System;
 using DlcsWebClient.Config;
 using DlcsWebClient.Dlcs;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Identity.Web;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Web.UI;
 using OAuth2;
 using Utils.Aws.Options;
 using Utils.Aws.S3;
@@ -62,8 +63,8 @@ namespace Wellcome.Dds.Dashboard
                 .UseNpgsql(Configuration.GetConnectionString("Dds"))
                 .UseSnakeCaseNamingConvention());
 
-            services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
-                .AddAzureAD(opts => Configuration.Bind("AzureAd", opts));
+            services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+                .AddMicrosoftIdentityWebApp(Configuration);
 
             var factory = services.AddNamedS3Clients(Configuration, NamedClient.All);
             
@@ -125,7 +126,8 @@ namespace Wellcome.Dds.Dashboard
 
             services.AddControllersWithViews(
                 opts => opts.Filters.Add(typeof(DashGlobalsActionFilter)))
-                .AddRazorRuntimeCompilation();
+                .AddRazorRuntimeCompilation()
+                .AddMicrosoftIdentityUI();
 
             services.AddHealthChecks()
                 .AddDbContextCheck<DdsInstrumentationContext>("DdsInstrumentation-db")

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="5.0.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1" />
-    <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="5.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
+    <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.5" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
@@ -10,13 +10,14 @@
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.25.1" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.25.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
   </ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
@@ -84,7 +84,7 @@
   },
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "Domain": "wellcomecloud.onmicrosoft.com",
+    "Domain": "Wellcomecloud.onmicrosoft.com",
     "CallbackPath": "/signin-oidc"
   }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Data/Wellcome.Dds.Data.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Data/Wellcome.Dds.Data.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Data/Wellcome.Dds.Data.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Data/Wellcome.Dds.Data.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
   </ItemGroup>
 
 </Project>

--- a/src/Wellcome.Dds/Wellcome.Dds.MillenniumClient/Wellcome.Dds.MillenniumClient.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.MillenniumClient/Wellcome.Dds.MillenniumClient.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.8.1" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.8.1" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.MillenniumClient/Wellcome.Dds.MillenniumClient.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.MillenniumClient/Wellcome.Dds.MillenniumClient.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories.Tests/Wellcome.Dds.Repositories.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories.Tests/Wellcome.Dds.Repositories.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories.Tests/Wellcome.Dds.Repositories.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories.Tests/Wellcome.Dds.Repositories.Tests.csproj
@@ -7,15 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="DeepCopy" Version="1.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/RoleProviderControllerTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/RoleProviderControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
             var response = await client.GetAsync(requestUri);
             
             // Assert
-            response.StatusCode.Should().Be(401);
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             var authenticationHeaderValue = response.Headers.WwwAuthenticate.FirstOrDefault();
             
             authenticationHeaderValue.Parameter.Should().Be("realm=\"Wellcome\"");
@@ -51,7 +52,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
             var response = await client.SendAsync(request);
             
             // Assert
-            response.StatusCode.Should().Be(401, "unexpected status code for {0}", clearValue);
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized, "unexpected status code for {0}", clearValue);
         }
         
         [Fact]
@@ -66,7 +67,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
             var response = await client.SendAsync(request);
             
             // Assert
-            response.StatusCode.Should().Be(404);
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/WorkflowControllerTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/WorkflowControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -47,7 +48,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
             var response = await client.GetAsync(requestUri);
             
             // Assert
-            response.StatusCode.Should().Be(202);
+            response.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
             var actual = await response.Content.ReadAsAsync<WorkflowJob>();
             actual.Should().BeEquivalentTo(expected, opts => 
@@ -93,7 +94,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
             await dbFixture.DdsInstrumentationContext.WorkflowJobs.AddAsync(new WorkflowJob
             {
                 Identifier = bnumber,
-                Created = DateTime.Today.AddYears(-1),
+                Created = DateTime.UtcNow.AddYears(-1),
                 Waiting = false
             });
             await dbFixture.DdsInstrumentationContext.SaveChangesAsync();
@@ -102,7 +103,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
             var response = await client.GetAsync(requestUri);
             
             // Assert
-            response.StatusCode.Should().Be(202);
+            response.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
             var actual = await response.Content.ReadAsAsync<WorkflowJob>();
             actual.Should().BeEquivalentTo(expected, opts => 
@@ -125,7 +126,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
                     .Including(job => job.WorkflowOptions)
                     .Including(job => job.Expedite)
                     .Including(job => job.FlushCache));
-            fromDatabase.Created.Should().BeCloseTo(DateTime.Now, 5000);
+            fromDatabase.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/WorkflowControllerTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Controllers/WorkflowControllerTests.cs
@@ -94,7 +94,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
             await dbFixture.DdsInstrumentationContext.WorkflowJobs.AddAsync(new WorkflowJob
             {
                 Identifier = bnumber,
-                Created = DateTime.UtcNow.AddYears(-1),
+                Created = DateTime.Now.AddYears(-1),
                 Waiting = false
             });
             await dbFixture.DdsInstrumentationContext.SaveChangesAsync();
@@ -126,7 +126,7 @@ namespace Wellcome.Dds.Server.Tests.Controllers
                     .Including(job => job.WorkflowOptions)
                     .Including(job => job.Expedite)
                     .Including(job => job.FlushCache));
-            fromDatabase.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+            fromDatabase.Created.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(5));
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Integration/DatabaseFixture.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Integration/DatabaseFixture.cs
@@ -10,7 +10,7 @@ namespace Wellcome.Dds.Server.Tests.Integration
 {
     public class DatabaseFixture : IAsyncLifetime
     {
-        protected static string DdsConnectionString { get; } = $"host=localhost;port=5430;database=ddsinstrtest;username=ddsinstrumentation_user;password=ddsinstrumentation";
+        protected static string DdsConnectionString { get; } = "host=localhost;port=5430;database=ddsinstrtest;username=ddsinstrumentation_user;password=ddsinstrumentation";
         
         public DdsInstrumentationContext DdsInstrumentationContext { get; private set; }
 
@@ -73,9 +73,9 @@ namespace Wellcome.Dds.Server.Tests.Integration
             }
 
             var processStop = Process.Start("docker", "stop dds-server-test");
-            processStop.WaitForExit();
+            await processStop.WaitForExitAsync();
             var processRm = Process.Start("docker", "rm dds-server-test");
-            processRm.WaitForExit();
+            await processRm.WaitForExitAsync();
         }
         
         public void CleanUp()

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>9</LangVersion>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
@@ -9,15 +9,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -53,6 +53,9 @@ namespace Wellcome.Dds.Server
         
         public void ConfigureServices(IServiceCollection services)
         {
+            // Use pre-v6 handling of datetimes for npgsql
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+            
             // Temporarily here to demonstrate IIIFPrecursor - should not be required in production DDS.Server
             services.AddDbContext<DdsInstrumentationContext>(options => options
                 .UseNpgsql(Configuration.GetConnectionString("DdsInstrumentation"))

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <LangVersion>9</LangVersion>
+        <LangVersion>latestmajor</LangVersion>
         <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     </PropertyGroup>
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -22,16 +22,16 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1" />
-      <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="3.0.2" />
-      <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.5" />
-      <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.2.0" />
-      <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
+      <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="3.1.2" />
+      <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.6" />
+      <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.5.1" />
+      <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Tests/Wellcome.Dds.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Tests/Wellcome.Dds.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Tests/Wellcome.Dds.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Tests/Wellcome.Dds.Tests.csproj
@@ -7,15 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="3.0.101" />
+    <PackageReference Include="protobuf-net" Version="3.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowProcessor.Tests.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowProcessor.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>9</LangVersion>
+        <LangVersion>latestmajor</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowProcessor.Tests.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowProcessor.Tests.csproj
@@ -9,16 +9,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FakeItEasy" Version="7.0.1" />
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="FakeItEasy" Version="7.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowRunnerTests.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor.Tests/WorkflowRunnerTests.cs
@@ -76,7 +76,7 @@ namespace WorkflowProcessor.Tests
             await sut.ProcessJob(job);
             
             // Assert
-            job.Taken.Should().BeCloseTo(DateTime.Now, 2000);
+            job.Taken.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(2));
             job.TotalTime.Should().BeGreaterThan(0);
         }
         

--- a/src/Wellcome.Dds/WorkflowProcessor/Startup.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.SimpleNotificationService;
+﻿using System;
+using Amazon.SimpleNotificationService;
 using DlcsWebClient.Config;
 using DlcsWebClient.Dlcs;
 using Microsoft.AspNetCore.Builder;
@@ -44,6 +45,9 @@ namespace WorkflowProcessor
         
         public void ConfigureServices(IServiceCollection services)
         {
+            // Use pre-v6 handling of datetimes for npgsql
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+            
             services.AddDbContext<DdsInstrumentationContext>(options => options
                 .UseNpgsql(Configuration.GetConnectionString("DdsInstrumentation"))
                 .UseSnakeCaseNamingConvention());

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.0.12" />
-    <PackageReference Include="CsvHelper" Version="26.0.1" />
-    <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.74" />
+    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latestmajor</LangVersion>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 

--- a/src/Wellcome.Dds/global.json
+++ b/src/Wellcome.Dds/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
Update all projects to dotnet 6 and `latestmajor` language version (previously 5 and 9 respectively).

Update all nuget packages to latest versions, 3 packages required code changes:
* `Npgsql.EntityFrameworkCore.PostgreSQL` changes how DateTime's are handled. This would require wide ranging changes to opted to enable legacy behaviour for now and will open a ticket to handle later.
* `Microsoft.AspNetCore.Authentication.AzureAD.UI` is now obsolete, replaced with `Microsoft.Identity.Web` and `Microsoft.Identity.Web.UI`.
* `FluentAssertions` v6 had some slight changes to API for verifying DateTime objects and `Throw` assertions for asynchronous methods.