### PR TITLE
Iiif controllers handle calm ids

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/WellcomeLibraryIdentifiersTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/WellcomeLibraryIdentifiersTests.cs
@@ -74,5 +74,34 @@ namespace Wellcome.Dds.Common.Tests
         [InlineData("1847424", 'x')]
         public void GetExpectedBNumberCheckDigit_Correct(string number, char checkDigit) 
             => WellcomeLibraryIdentifiers.GetExpectedBNumberCheckDigit(number).Should().Be(checkDigit);
+
+        
+        [Theory]
+        [InlineData("hqxrz7dq")]
+        [InlineData("drvfa8hy")]
+        [InlineData("fdgm6279")]
+        [InlineData("xf54ua4z")]
+        [InlineData("trzsg9gu")]
+        [InlineData("teq32cjd")]
+        [InlineData("shfw74xb")]
+        [InlineData("qmu9be6d")]
+        [InlineData("cuw9y9vp")]
+        [InlineData("acrxt93t")]
+        [InlineData("b1234567")] // 
+        public void WorkIdentifiers_Recognised(string s)
+        {
+            WellcomeLibraryIdentifiers.MayBeWorkIdentifier(s).Should().BeTrue();
+        }
+        
+        
+        [Theory]
+        [InlineData("acr0t93t")]
+        [InlineData("uw9y9vp")]
+        [InlineData("acrxt93ta")]
+        [InlineData("b12345672")]
+        public void Non_WorkIdentifiers_Recognised(string s)
+        {
+            WellcomeLibraryIdentifiers.MayBeWorkIdentifier(s).Should().BeFalse();
+        }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/WellcomeLibraryIdentifiers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/WellcomeLibraryIdentifiers.cs
@@ -162,5 +162,15 @@ namespace Wellcome.Dds.Common
             var asString = idWithoutCheckDigit.ToString(CultureInfo.InvariantCulture);
             return Convert.ToInt64($"{idWithoutCheckDigit}{GetExpectedBNumberCheckDigit(asString)}");
         }
+
+        public static bool MayBeWorkIdentifier(string s)
+        {
+            if (s.IsNullOrWhiteSpace() || s.Length != 8)
+            {
+                return false;
+            }
+
+            return Regex.IsMatch(s, "^[a-z1-9]*$");
+        }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/DdsContext.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/DdsContext.cs
@@ -99,6 +99,15 @@ namespace Wellcome.Dds.Repositories
             return Manifestations.SingleOrDefault(
                 m => m.PackageIdentifier == identifier && m.Index == index);
         }
+
+        public Manifestation? GetManifestationByAnyIdentifier(string identifier)
+        {
+            return Manifestations.FirstOrDefault(mf => 
+                mf.ManifestationIdentifier == identifier ||
+                mf.WorkId == identifier ||
+                mf.CalmRef == identifier ||
+                mf.CalmAltRef == identifier);
+        }
         
     }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/DdsContext.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/DdsContext.cs
@@ -12,8 +12,12 @@ namespace Wellcome.Dds.Repositories
 {
     public class DdsContext : DbContext
     {
+        private readonly string[] PermittedAggregations;
+
         public DdsContext(DbContextOptions<DdsContext> options) : base(options)
-        { }
+        {
+            PermittedAggregations = new[] { "Genre", "Subject", "Contributor", "Digitalcollection" };
+        }
 
         public DbSet<Manifestation> Manifestations { get; set; }
         public DbSet<Metadata> Metadata { get; set; }
@@ -62,9 +66,40 @@ namespace Wellcome.Dds.Repositories
 
         public IEnumerable<AggregationMetadata> GetAggregation(string aggregator)
         {
-            var query = String.Format(AggregationMetadata.Sql, aggregator.ToAlphanumeric());
-            return Database
-                .MapRawSql<AggregationMetadata>(query, dr => new AggregationMetadata(dr));
+            var aggregatorValue = aggregator.ToAlphanumeric();
+            if (PermittedAggregations.Contains(aggregatorValue))
+            {
+                var query = String.Format(AggregationMetadata.Sql, aggregatorValue);
+                return Database
+                    .MapRawSql<AggregationMetadata>(query, dr => new AggregationMetadata(dr));
+            }
+
+            return new List<AggregationMetadata>();
+        }
+
+        public char[] GetChunkInitials(string aggregator)
+        {
+            var aggregatorValue = aggregator.ToAlphanumeric();
+            if (PermittedAggregations.Contains(aggregatorValue))
+            {
+                var query = String.Format(AggregationMetadata.InitialsSql, aggregatorValue);
+                return Database.MapRawSql(query, dr => ((string)dr[0])[0]).ToArray();
+            }
+
+            return Array.Empty<char>();
+        }
+        
+        public IEnumerable<AggregationMetadata> GetChunkedAggregation(string aggregator, char chunk)
+        {
+            var aggregatorValue = aggregator.ToAlphanumeric();
+            if (PermittedAggregations.Contains(aggregatorValue))
+            {
+                var query = String.Format(AggregationMetadata.ChunkSql, aggregatorValue, chunk);
+                return Database
+                    .MapRawSql<AggregationMetadata>(query, dr => new AggregationMetadata(dr));
+            }
+
+            return new List<AggregationMetadata>();
         }
 
         public IEnumerable<ValueAggregationResult> GetAggregation(string aggregator, string value)
@@ -148,8 +183,15 @@ namespace Wellcome.Dds.Repositories
 
     public class AggregationMetadata
     {
+        // Don't use this, too many!
         public const string Sql =
             "select distinct identifier, string_value from metadata where label='{0}' order by string_value";
+
+        public const string InitialsSql =
+            "select distinct substring(string_value, 1, 1) as initial from metadata where label='{0}' order by initial";
+        
+        public const string ChunkSql =
+            "select distinct identifier, string_value from metadata where label='{0}' and string_value like '{1}%' order by string_value";
 
         public readonly string Identifier;
         public readonly string Label;

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Utils;
 using Utils.Storage;
 using Wellcome.Dds.Common;
 
@@ -69,6 +68,12 @@ namespace Wellcome.Dds.Server.Controllers
             var pass2 = pass1.Replace(ddsOptions.LinkedDataDomain, ddsOptions.RewriteDomainLinksTo);
             var rewritten = pass2.Replace(placeholder, ddsOptions.LinkedDataDomain);
             return controller.Content(rewritten, contentType);
+        }
+
+        public async Task<bool> ExistsInStorage(string container, string path)
+        {
+            var file = storage.GetCachedFileInfo(container, path);
+            return await file.DoesExist();
         }
 
         private string GetRegexPattern(string domainPart)

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/PresentationController.cs
@@ -581,8 +581,6 @@ namespace Wellcome.Dds.Server.Controllers
 
         /// <summary>
         /// A Collection of Manifests with the given metadata
-        ///
-        /// No longer explicitly linked but still available
         /// </summary>
         /// <returns></returns>
         [HttpGet("collections/{aggregator}/{value}")]
@@ -620,8 +618,6 @@ namespace Wellcome.Dds.Server.Controllers
 
         /// <summary>
         /// A Collection of Manifests with the given metadata
-        /// 
-        /// No longer explicitly linked but still available
         /// </summary>
         /// <returns></returns>
         [HttpGet("v2/collections/{aggregator}/{value}")]

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -180,6 +180,11 @@ namespace Wellcome.Dds.IIIFBuilding
         public string CollectionForAggregation(string aggregator, string value)
         {
             return $"{schemeAndHostValue}{AggregationFormat}/{aggregator}/{value}";
+        }        
+        
+        public string CollectionForAggregation(string aggregator, char chunk)
+        {
+            return $"{schemeAndHostValue}{AggregationFormat}/chunked/{aggregator}/{chunk}";
         }
         
         // TODO - rename to Work page

--- a/src/Wellcome.Dds/Wellcome.Dds/Metadata.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/Metadata.cs
@@ -47,6 +47,7 @@ namespace Wellcome.Dds
             // subjects, genres, contributor all work simply for now
             var initial = pathElement[0].ToString();
             return pathElement.Chomp("s").ReplaceFirst(initial, initial.ToUpperInvariant());
+            
         }
     }
 }


### PR DESCRIPTION
This addresses the following issues:

https://github.com/wellcomecollection/platform/issues/5500
https://github.com/wellcomecollection/platform/issues/5506
https://github.com/wellcomecollection/platform/issues/5505
https://github.com/wellcomecollection/platform/issues/5503

and, in passing, 
https://github.com/wellcomecollection/platform/issues/5534

It allows the path /presentation/{identifier} to handle b numbers, CALM IDs and work identifiers, and redirect to the canonical version if not already. This allows people to insert identifiers into URLs without having to know where each form of identifier is valid.

Even if just for developer convenience, it's worth doing.

It also attempts a short term solution to a problem with https://iiif.wellcomecollection.org/presentation/collections.

The next level down of some of these categories has far too many items to be useful.
This PR introduces an intermediate set of collections that just split them up by initial. That's not a very good solution to the problem because there is a lot of non-English text. So this needs to be revisited some other time.