### PR TITLE
side-by-side Auth services v1 and v2

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/PeekController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/PeekController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using IIIF.Presentation;
 using IIIF.Serialisation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -41,6 +42,7 @@ namespace Wellcome.Dds.Dashboard.Controllers
         {
             var ddsId = new DdsIdentifier(id); // full manifestation id, e.g., b19974760_233_0024
             var build = await BuildResult(ddsId, all);
+            build.IIIFResource.EnsurePresentation3Context();
             return Content(build.IIIFResource.AsJson(), "application/json");
         }
         
@@ -57,6 +59,7 @@ namespace Wellcome.Dds.Dashboard.Controllers
         {
             var ddsId = new DdsIdentifier(id); // full manifestation id, e.g., b19974760_233_0024
             var build = await BuildResult(ddsId, all);
+            build.IIIFResource.EnsurePresentation3Context();
             var model = new CodeModel
             {
                 Title = "IIIF Resource Preview",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/PeekController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/PeekController.cs
@@ -50,9 +50,13 @@ namespace Wellcome.Dds.Dashboard.Controllers
         {
             var ddsId = new DdsIdentifier(id); // full manifestation id, e.g., b19974760_233_0024
             var build = await BuildResult(ddsId, all);
+            if (build.MayBeConvertedToV2)
+            {
+                var iiif2 = iiifBuilder.BuildLegacyManifestations(id, new[] { build });
+                return Content(iiif2[id]?.IIIFResource.AsJson() ?? string.Empty, "application/json");
+            }
 
-            var iiif2 = iiifBuilder.BuildLegacyManifestations(id, new[] {build});
-            return Content(iiif2[id]?.IIIFResource.AsJson() ?? string.Empty, "application/json");
+            return Content("Contains AV, not going to convert to V2", "text/plain");
         }
 
         public async Task<ActionResult> IIIF(string id, bool all = false)

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/DlcsIIIFAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/DlcsIIIFAuthServiceProvider.cs
@@ -2,31 +2,36 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
 {
     public class DlcsIIIFAuthServiceProvider : IIIFAuthServiceProvider
     {
-        const string BaseUri = "https://iiif.wellcomecollection.org";
+        private readonly string dlcsEntryPoint;
+        
+        public DlcsIIIFAuthServiceProvider(string dlcsEntryPoint)
+        {
+            this.dlcsEntryPoint = dlcsEntryPoint;
+        }
         
         protected override string GetClickthroughLoginServiceId()
         {
-            return BaseUri + "/auth/clickthrough";
+            return $"{dlcsEntryPoint}auth/clickthrough";
         }
 
         protected override string GetLogoutServiceId()
         {
-            return BaseUri + "/auth/clickthrough/logout";
+            return $"{dlcsEntryPoint}auth/clickthrough/logout";
         }
 
         protected override string GetClinicalLoginServiceId()
         {
-            return BaseUri + "/auth/clinicallogin";
+            return $"{dlcsEntryPoint}auth/clinicallogin";
         }
 
         protected override string GetTokenServiceId()
         {
-            return BaseUri + "/auth/token";
+            return $"{dlcsEntryPoint}auth/token";
         }
 
         protected override string GetRestrictedLoginServiceId()
         {
-            return BaseUri + "/auth/restrictedlogin";
+            return $"{dlcsEntryPoint}auth/restrictedlogin";
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/DlcsIIIFAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/DlcsIIIFAuthServiceProvider.cs
@@ -4,22 +4,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
     {
         const string BaseUri = "https://iiif.wellcomecollection.org";
         
-        protected override string GetAccessTokenServiceId()
-        {
-            return BaseUri + "/auth/token";
-        }
-
-        protected override string GetAcceptTermsAccessTokenServiceId()
-        {
-            return BaseUri + "/auth/token";
-        }
-
-
-        protected override string GetClickthroughLoginServiceId090()
-        {
-            return BaseUri + "/auth/clickthrough";
-        }
-        protected override string GetClickthroughLoginServiceId093()
+        protected override string GetClickthroughLoginServiceId()
         {
             return BaseUri + "/auth/clickthrough";
         }
@@ -34,16 +19,12 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
             return BaseUri + "/auth/clinicallogin";
         }
 
-        protected override string GetCASTokenServiceId()
+        protected override string GetTokenServiceId()
         {
             return BaseUri + "/auth/token";
         }
 
-        protected override string GetRestrictedLoginServiceId090()
-        {
-            return BaseUri + "/auth/restrictedlogin";
-        }
-        protected override string GetRestrictedLoginServiceId093()
+        protected override string GetRestrictedLoginServiceId()
         {
             return BaseUri + "/auth/restrictedlogin";
         }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IAuthServiceProvider.cs
@@ -1,13 +1,18 @@
-using System.Collections.Generic;
 using IIIF;
-using IIIF.Auth;
 
 namespace Wellcome.Dds.Repositories.Presentation.AuthServices
 {
     public interface IAuthServiceProvider
     {
-        List<IService> GetAcceptTermsAuthServices();
-        List<IService> GetClinicalLoginServices();
-        List<IService> GetRestrictedLoginServices();
+        // original implementation (renamed ..V1)
+        IService GetAcceptTermsAuthServicesV1();
+        IService GetClinicalLoginServicesV1();
+        IService GetRestrictedLoginServicesV1();
+        
+        // Auth V2 providers
+        // Later we can reorganise this and support more variety in auth services
+        IService GetAcceptTermsAuthServicesV2();
+        IService GetClinicalLoginServicesV2();
+        IService GetRestrictedLoginServicesV2();
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
 using IIIF;
-using IIIF.Auth;
 using IIIF.Auth.V1;
-using IIIF.Presentation.V2;
+using IIIF.Auth.V2;
 using IIIF.Presentation.V2.Strings;
+using IIIF.Presentation.V3.Strings;
+using Utils;
 
 namespace Wellcome.Dds.Repositories.Presentation.AuthServices
 {
@@ -41,90 +42,107 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
         public const string LogoutLabel = "Log out of Wellcome Collection";
 
 
-        protected abstract string GetAccessTokenServiceId();
-        protected abstract string GetAcceptTermsAccessTokenServiceId();
-        protected abstract string GetClickthroughLoginServiceId090();
-        protected abstract string GetClickthroughLoginServiceId093();
+        protected abstract string GetClickthroughLoginServiceId();
         protected abstract string GetLogoutServiceId();
         protected abstract string GetClinicalLoginServiceId();
-        protected abstract string GetRestrictedLoginServiceId090();
-        protected abstract string GetRestrictedLoginServiceId093();
-        protected abstract string GetCASTokenServiceId();
+        protected abstract string GetRestrictedLoginServiceId();
+        protected abstract string GetTokenServiceId();
 
-        public List<IService> GetAcceptTermsAuthServices()
+        public IService GetAcceptTermsAuthServicesV1()
         {
-            var tokenServiceId = GetAcceptTermsAccessTokenServiceId();
-            var services = new List<IService>();
-            
-            // Lets skip this for now...
-            // for compatibility with current UV
-            // var clickthrough090Service = AuthCookieService1.NewClickthroughInstance();
-            // clickthrough090Service.Id = GetClickthroughLoginServiceId090();
-            // clickthrough090Service.Label = new MetaDataValue(ClickthroughHeader);
-            // clickthrough090Service.Description = new MetaDataValue(ClickthroughLoginDescription);
-            // clickthrough090Service.Service = GetCommonChildAuthServices(tokenServiceId);
-            // services.Add(clickthrough090Service);
-
             // for UV compliant with 0.9.3
-            var clickthrough093Service = AuthCookieService.NewClickthroughInstance();
-            clickthrough093Service.Id = GetClickthroughLoginServiceId093();
-            clickthrough093Service.Label = new MetaDataValue(ClickthroughHeader);
-            clickthrough093Service.Header = new MetaDataValue(ClickthroughHeader);
-            clickthrough093Service.Description = new MetaDataValue(ClickthroughLoginDescription);
-            clickthrough093Service.ConfirmLabel = new MetaDataValue(ClickthroughConfirmlabel);
-            clickthrough093Service.FailureHeader = new MetaDataValue(ClickthroughFailureHeader);
-            clickthrough093Service.FailureDescription = new MetaDataValue(ClickthroughFailureDescription);
-            clickthrough093Service.Service = GetCommonChildAuthServices(tokenServiceId);
-            services.Add(clickthrough093Service);
-
-            return services;
-        }
-        public List<IService> GetClinicalLoginServices()
-        {
-            var clinicalLogin = AuthCookieService.NewLoginInstance();
-            clinicalLogin.Id = GetClinicalLoginServiceId();
-            clinicalLogin.ConfirmLabel = new MetaDataValue("LOGIN");
-            clinicalLogin.Label = new MetaDataValue(ClinicalHeader);
-            clinicalLogin.Header = new MetaDataValue(ClinicalHeader);
-            clinicalLogin.Description = new MetaDataValue(ClinicalLoginDescription);
-            clinicalLogin.FailureHeader = new MetaDataValue(ClinicalFailureHeader);
-            clinicalLogin.FailureDescription = new MetaDataValue(ClinicalFailureDescription);
-            clinicalLogin.Service = GetCommonChildAuthServices(GetCASTokenServiceId());
-            return new List<IService>() {clinicalLogin};
+            var clickthroughV1Service = AuthCookieService.NewClickthroughInstance();
+            clickthroughV1Service.Id = GetClickthroughLoginServiceId();
+            clickthroughV1Service.Label = new MetaDataValue(ClickthroughHeader);
+            clickthroughV1Service.Header = new MetaDataValue(ClickthroughHeader);
+            clickthroughV1Service.Description = new MetaDataValue(ClickthroughLoginDescription);
+            clickthroughV1Service.ConfirmLabel = new MetaDataValue(ClickthroughConfirmlabel);
+            clickthroughV1Service.FailureHeader = new MetaDataValue(ClickthroughFailureHeader);
+            clickthroughV1Service.FailureDescription = new MetaDataValue(ClickthroughFailureDescription);
+            clickthroughV1Service.Service = GetCommonChildAuthServicesV1();
+            return clickthroughV1Service;
         }
 
-        public List<IService> GetRestrictedLoginServices()
+        public IService GetAcceptTermsAuthServicesV2()
         {
-            var tokenServiceId = GetCASTokenServiceId();
-            var services = new List<IService>();
+            return new AuthAccessService2
+            {
+                Id = AsV2(GetClickthroughLoginServiceId()),
+                Profile = AuthAccessService2.InteractiveProfile,
+                Label = new LanguageMap("en", ClickthroughHeader),
+                Header = new LanguageMap("en", ClickthroughHeader),
+                Description = new LanguageMap("en", ClickthroughLoginDescription),
+                ConfirmLabel = new LanguageMap("en", ClickthroughConfirmlabel),
+                FailureHeader = new LanguageMap("en", ClickthroughFailureHeader),
+                FailureDescription = new LanguageMap("en", ClickthroughFailureDescription),
+                Service = GetCommonChildAuthServicesV2()
+            };
+        }
+        
+        public IService GetClinicalLoginServicesV1()
+        {
+            var clinicalLoginV1Service = AuthCookieService.NewLoginInstance();
+            clinicalLoginV1Service.Id = GetClinicalLoginServiceId();
+            clinicalLoginV1Service.ConfirmLabel = new MetaDataValue("LOGIN");
+            clinicalLoginV1Service.Label = new MetaDataValue(ClinicalHeader);
+            clinicalLoginV1Service.Header = new MetaDataValue(ClinicalHeader);
+            clinicalLoginV1Service.Description = new MetaDataValue(ClinicalLoginDescription);
+            clinicalLoginV1Service.FailureHeader = new MetaDataValue(ClinicalFailureHeader);
+            clinicalLoginV1Service.FailureDescription = new MetaDataValue(ClinicalFailureDescription);
+            clinicalLoginV1Service.Service = GetCommonChildAuthServicesV1();
+            return clinicalLoginV1Service;
+        }
 
-            // var external090Service = AuthCookieService1.NewExternalInstance();
-            // external090Service.Id = GetRestrictedLoginServiceId090();
-            // external090Service.Label = new MetaDataValue(RestrictedHeader);
-            // external090Service.Description = new MetaDataValue(RestrictedFailureDescription);
-            // external090Service.Service = GetCommonChildAuthServices(tokenServiceId);
-            // services.Add(external090Service);
-
-            var external093Service = AuthCookieService.NewExternalInstance();
-            external093Service.Id = GetRestrictedLoginServiceId093();
-            external093Service.Label = new MetaDataValue(RestrictedHeader);
-            external093Service.FailureHeader = new MetaDataValue(RestrictedHeader);
-            external093Service.Description = new MetaDataValue(RestrictedFailureDescription);
-            external093Service.FailureDescription = new MetaDataValue(RestrictedFailureDescription);
-            external093Service.Service = GetCommonChildAuthServices(tokenServiceId);
+        public IService GetClinicalLoginServicesV2()
+        {
+            return new AuthAccessService2
+            {
+                Id = AsV2(GetClinicalLoginServiceId()),
+                Profile = AuthAccessService2.InteractiveProfile,
+                Label = new LanguageMap("en", ClinicalHeader),
+                Header = new LanguageMap("en", ClinicalHeader),
+                Description = new LanguageMap("en", ClinicalLoginDescription),
+                ConfirmLabel = new LanguageMap("en", "LOGIN"),
+                FailureHeader = new LanguageMap("en", ClinicalFailureDescription),
+                FailureDescription = new LanguageMap("en", ClinicalFailureDescription),
+                Service = GetCommonChildAuthServicesV2()
+            };
+        }
+        
+        public IService GetRestrictedLoginServicesV1()
+        {
+            var externalServiceV1 = AuthCookieService.NewExternalInstance();
+            externalServiceV1.Id = GetRestrictedLoginServiceId();
+            externalServiceV1.Label = new MetaDataValue(RestrictedHeader);
+            externalServiceV1.FailureHeader = new MetaDataValue(RestrictedHeader);
+            externalServiceV1.Description = new MetaDataValue(RestrictedFailureDescription);
+            externalServiceV1.FailureDescription = new MetaDataValue(RestrictedFailureDescription);
+            externalServiceV1.Service = GetCommonChildAuthServicesV1();
             // confirmLabel? Not really appropriate; the client needs to provide the text for "cancel"...
-            services.Add(external093Service);
-
-            return services;
+            return externalServiceV1;
         }
 
-        private List<IService> GetCommonChildAuthServices(string tokenServiceId)
+        public IService GetRestrictedLoginServicesV2()
         {
-            var commonChildServices = new List<IService>
+            return new AuthAccessService2
+            {
+                Id = AsV2(GetRestrictedLoginServiceId()),
+                Profile = AuthAccessService2.ExternalProfile,
+                Label = new LanguageMap("en", RestrictedHeader),
+                FailureHeader = new LanguageMap("en", RestrictedHeader),
+                Description = new LanguageMap("en", RestrictedFailureDescription),
+                FailureDescription = new LanguageMap("en", RestrictedFailureDescription),
+                Service = GetCommonChildAuthServicesV2()
+            };
+        }
+
+        private List<IService> GetCommonChildAuthServicesV1()
+        {
+            return new List<IService>
             {
                 new AuthTokenService
                 {
-                    Id = tokenServiceId
+                    Id = GetTokenServiceId()
                 },           
                 new AuthLogoutService
                 {
@@ -132,9 +150,27 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
                     Label = new MetaDataValue(LogoutLabel)
                 }
             };
-            return commonChildServices;
         }
 
+        private List<IService> GetCommonChildAuthServicesV2()
+        {
+            return new List<IService>
+            {
+                new AuthTokenService2
+                {
+                    Id = AsV2(GetTokenServiceId())
+                },
+                new AuthLogoutService2
+                {
+                    Id = AsV2(GetLogoutServiceId()),
+                    Label = new LanguageMap("en", LogoutLabel)
+                }
+            };
+        }
 
+        private string AsV2(string originalUrl)
+        {
+            return originalUrl.ReplaceFirst("/auth/", "/auth/v2/");
+        }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
@@ -10,11 +10,12 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
 {
     public abstract class IIIFAuthServiceProvider : IAuthServiceProvider
     {
-        public const string ClickthroughHeader = "Content advisory";
-        public const string ClickthroughConfirmlabel = "Accept Terms and Open";
+        // TODO: https://github.com/wellcomecollection/platform/issues/5634
+        private const string ClickthroughHeader = "Content advisory";
+        private const string ClickthroughConfirmlabel = "Accept Terms and Open";
 
         // this can be a @lang multi-metadata value
-        public const string ClickthroughLoginDescription =
+        private const string ClickthroughLoginDescription =
             "<p>This digitised material is free to access, but contains information or visuals that may:</p><ul>" +
             "<li>include personal details of living individuals</li>" +
             "<li>be upsetting or distressing</li>" +
@@ -24,22 +25,22 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
             "By viewing this material, we ask that you use the content lawfully, ethically and responsibly under the conditions set out in our " +
             "<a href=\"https://wellcomecollection.cdn.prismic.io/wellcomecollection/d4817da5-c71a-4151-81c4-83e39ad4f5b3_Wellcome+Collection_Access+Policy_Aug+2020.pdf\">Access Policy</a>.";
 
-        public const string ClickthroughFailureHeader = "Terms not accepted";
-        public const string ClickthroughFailureDescription = "You must accept the terms to view the content.";
+        private const string ClickthroughFailureHeader = "Terms not accepted";
+        private const string ClickthroughFailureDescription = "You must accept the terms to view the content.";
 
-        public const string ClinicalHeader = "Clinical material";
+        private const string ClinicalHeader = "Clinical material";
 
-        public const string ClinicalLoginDescription =
+        private const string ClinicalLoginDescription =
             "<p>Online access to clinical content is restricted to healthcare professionals. Please contact the Collections team for further information: <a href='mailto:collections@wellcome.ac.uk'>collections@wellcome.ac.uk</a>.</p> <p>If you are a healthcare professional and already have a Wellcome Collection account, please log in.</p>";
-        public const string ClinicalFailureHeader = "Login failed";
-        public const string ClinicalFailureDescription = "Your login attempt did not appear to be successful. Please try again.";
+        private const string ClinicalFailureHeader = "Login failed";
+        private const string ClinicalFailureDescription = "Your login attempt did not appear to be successful. Please try again.";
 
-        public const string RestrictedHeader = "Restricted material";
+        private const string RestrictedHeader = "Restricted material";
 
-        public const string RestrictedFailureDescription =
+        private const string RestrictedFailureDescription =
             "<p>This image cannot be viewed online.</p><p>Wellcome Collection members can request access to restricted materials for viewing in the Library.</p>";
 
-        public const string LogoutLabel = "Log out of Wellcome Collection";
+        private const string LogoutLabel = "Log out of Wellcome Collection";
 
 
         protected abstract string GetClickthroughLoginServiceId();

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -78,7 +78,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             this.referenceV0SearchService = referenceV0SearchService;
             this.extraAccessConditions = extraAccessConditions;
             manifestStructureHelper = new ManifestStructureHelper();
-            IAuthServiceProvider authServiceProvider = new DlcsIIIFAuthServiceProvider();
+            IAuthServiceProvider authServiceProvider = new DlcsIIIFAuthServiceProvider(dlcsEntryPoint);
 
             clickthroughServiceV1 = authServiceProvider.GetAcceptTermsAuthServicesV1();
             clickthroughServiceReferenceV1 = new V2ServiceReference(clickthroughServiceV1);
@@ -608,6 +608,8 @@ namespace Wellcome.Dds.Repositories.Presentation
             {
                 manifest.Services ??= new List<IService>();
                 manifest.Services.AddRange(foundAuthServices.Values);
+                // A point release of Presentation 3 could add Auth2 services to the context
+                manifest.EnsureContext(IIIF.Auth.V2.Constants.IIIFAuth2Context);
             }
         }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/ConverterHelpers.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using IIIF;
+using IIIF.Auth.V2;
 using IIIF.ImageApi.V2;
 using IIIF.Presentation;
 using IIIF.Presentation.V2;
@@ -198,6 +199,9 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
                         imageService2.EnsureContext(ImageService2.Image2Context);
                         imageService2.Type = null;
                         imageService2.Protocol = ImageService2.Image2Protocol;
+                        // Remove the Auth2 services
+                        imageService2.Service?.RemoveAll(ss => ss is AuthProbeService2);
+                        imageService2.Service?.RemoveAll(ss => ss is AuthAccessService2);
                         imageService = imageService2;
                     }
                 }))

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/PresentationConverter.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/V2/PresentationConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using IIIF;
 using IIIF.Auth.V1;
+using IIIF.Auth.V2;
 using IIIF.Presentation;
 using IIIF.Presentation.V2;
 using IIIF.Presentation.V2.Annotation;
@@ -176,8 +177,11 @@ namespace Wellcome.Dds.Repositories.Presentation.V2
                 {
                     switch (service)
                     {
-                        case ResourceBase authService:
-                            var wellcomeAuthService = GetWellcomeAuthService(identifier, authService);
+                        case AuthAccessService2:
+                            logger.LogDebug("Skipping V2 Auth Service");
+                            break;
+                        case ResourceBase legacyAuthService:
+                            var wellcomeAuthService = GetWellcomeAuthService(identifier, legacyAuthService);
                             
                             // I think it's OK to leave the extra labels on
                             manifest.Service.Add(ObjectCopier.DeepCopy(wellcomeAuthService, null)!);

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
-    <PackageReference Include="iiif-net" Version="0.1.5" />
+    <PackageReference Include="iiif-net" Version="0.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="iiif-net" Version="0.1.5" />
+        <PackageReference Include="iiif-net" Version="0.1.6" />
         <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.1.5" />
+      <PackageReference Include="iiif-net" Version="0.1.6" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
       <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="3.1.2" />
       <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/BuildResult.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/BuildResult.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using IIIF;
 using Version = IIIF.Presentation.Version;
 
@@ -14,6 +15,8 @@ namespace Wellcome.Dds.IIIFBuilding
             Id = id;
             IIIFVersion = version;
         }
+        
+        public bool MayBeConvertedToV2 => TimeBasedCount <= 0 && FileCount <= 0;
 
         public string Id { get; set; }
         
@@ -69,14 +72,7 @@ namespace Wellcome.Dds.IIIFBuilding
         {
             get
             {
-                foreach (var buildResult in this)
-                {
-                    if (buildResult.TimeBasedCount > 0 || buildResult.FileCount > 0)
-                    {
-                        return false;
-                    }
-                }
-                return true;
+                return this.All(buildResult => buildResult.MayBeConvertedToV2);
             }
         }
 

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -79,6 +79,7 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string DlcsVideoTemplate        = "{dlcsEntryPoint}av/{assetIdentifier}/full/full/max/max/0/default.{fileExt}";
         private const string DlcsAudioTemplate        = "{dlcsEntryPoint}av/{assetIdentifier}/full/max/default.{fileExt}";
         private const string DlcsFileTemplate         = "{dlcsEntryPoint}file/{assetIdentifier}";
+        private const string DlcsProbeServiceTemplate = "{dlcsEntryPoint}auth/v2/probe/{assetIdentifier}";
 
         public UriPatterns(IOptions<DdsOptions> ddsOptions)
         {
@@ -241,6 +242,11 @@ namespace Wellcome.Dds.IIIFBuilding
         public string DlcsFile(string dlcsEntryPoint, string assetIdentifier)
         {
             return DlcsIdentifier(DlcsFileTemplate, dlcsEntryPoint, assetIdentifier);
+        }
+        
+        public string DlcsProbeService(string dlcsEntryPoint, string assetIdentifier)
+        {
+            return DlcsIdentifier(DlcsProbeServiceTemplate, dlcsEntryPoint, assetIdentifier);
         }
 
         private string DlcsIdentifier(string template, string dlcsEntryPointToken, string assetIdentifier)

--- a/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="3.1.4" />
-    <PackageReference Include="iiif-net" Version="0.1.5" />
+    <PackageReference Include="iiif-net" Version="0.1.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR results in IIIF Manifests having Auth v1 and v2 services present in the manifests.

In the end I did this in a way that duplicates code a bit - but it IS temporary and is also obvious, so when the auth 1 is removed it should look simple again. e.g., https://github.com/wellcomecollection/iiif-builder/pull/195/files#diff-00f349415d5559a7fbfea6b31968f083bd9d13dc61020f8e7daad96aa498cb7eR966

The Auth1 services come first so are in the same position in `services` and on each resource. 
The probe service is not in the `services` block - see https://digirati.slack.com/archives/CBT40CMKQ/p1669291274284069?thread_ts=1669126836.251469&cid=CBT40CMKQ

I'd like to come back to do https://github.com/wellcomecollection/platform/issues/5634 later.
`IIIFAuthServicesProvider` has hard-coded UI strings and retains them for now.

I have removed some old UV-specific variant services. We don't need them.

Emit v2 auth context when auth services present in manifest
Use UriPatterns and configured DLCS root for auth services (previously were hard-coded so couldn't have staging route to DLCS)
