### PR TITLE
BD manifest debugging

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -45,5 +45,7 @@
         public bool BuildWholeManifestLineAnnotations { get; set; }
         
         public string IncludeExtraAccessConditionsInManifest { get; set; }
+        
+        public int PlaceholderCanvasCacheTimeDays { get; set; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/PeekController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/PeekController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using IIIF.Presentation;
 using IIIF.Serialisation;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -38,14 +39,17 @@ namespace Wellcome.Dds.Dashboard.Controllers
             this.iiifBuilder = iiifBuilder;
         }
 
+        [AllowAnonymous]
         public async Task<ContentResult> IIIFRaw(string id, bool all = false)
         {
             var ddsId = new DdsIdentifier(id); // full manifestation id, e.g., b19974760_233_0024
             var build = await BuildResult(ddsId, all);
             build.IIIFResource.EnsurePresentation3Context();
+            Response.Headers["Access-Control-Allow-Origin"] = "*";
             return Content(build.IIIFResource.AsJson(), "application/json");
         }
         
+        [AllowAnonymous]
         public async Task<ContentResult> IIIF2Raw(string id, bool all = false)
         {
             var ddsId = new DdsIdentifier(id); // full manifestation id, e.g., b19974760_233_0024
@@ -56,6 +60,7 @@ namespace Wellcome.Dds.Dashboard.Controllers
                 return Content(iiif2[id]?.IIIFResource.AsJson() ?? string.Empty, "application/json");
             }
 
+            Response.Headers["Access-Control-Allow-Origin"] = "*";
             return Content("Contains AV, not going to convert to V2", "text/plain");
         }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -224,14 +224,14 @@
             <ul class="list-group">
                 <li class="list-group-item">
                     <ul class="list-unstyled">
+                        <li><a href="@Model.ManifestUrl">Live IIIF Manifest</a></li>
+                        <li>@Html.ActionLink("Live IIIF 3 in UV", "UV", "Dash", new {id = Model.DdsIdentifier.PathElementSafe, version=3}, new {target="_blank"}) </li>
+                        <li>@Html.ActionLink("Live IIIF 2/3 in Mirador", "Mirador", "Dash", new {id = Model.DdsIdentifier.PathElementSafe}, new {target="_blank"}) </li>
                         @if (Model.DdsIdentifier.StorageSpace != DdsIdentifier.BornDigital)
                         {
-                            <li>@Html.ActionLink("View IIIF 2 in Library UV", "UV", "Dash", new {id = @Model.DdsIdentifier.PathElementSafe, version=2}, new {target="_blank"}) </li>
-                            <li>@Html.ActionLink("View IIIF 2 in Mirador", "Mirador", "Dash", new {id = @Model.DdsIdentifier.PathElementSafe, version=2}, new {target="_blank"}) </li>
+                            <li>@Html.ActionLink("Live IIIF 2 in UV", "UV", "Dash", new {id = Model.DdsIdentifier.PathElementSafe, version=2}, new {target="_blank"}) </li>
                         }
-                        <li>@Html.ActionLink("View IIIF 3 in Universal Viewer", "UV", "Dash", new {id = @Model.DdsIdentifier.PathElementSafe, version=3}, new {target="_blank"}) </li>
-                        <li>@Html.ActionLink("View IIIF 3 in Mirador", "Mirador", "Dash", new {id = @Model.DdsIdentifier.PathElementSafe, version=3}, new {target="_blank"}) </li>
-                        <li>@Html.ActionLink("IIIF Validator", "Validator", "Dash", new {id = @Model.DdsIdentifier.PathElementSafe}, new {target="_blank"}) </li>
+                        <li>@Html.ActionLink("IIIF Validator", "Validator", "Dash", new {id = Model.DdsIdentifier.PathElementSafe}, new {target="_blank"}) </li>
                     </ul>
                 </li>
                 <li class="list-group-item">
@@ -244,8 +244,9 @@
                     <ul class="list-unstyled">
                         <li><a href="@Model.DlcsSkeletonManifest">DLCS Preview Manifest</a></li>
                         <li><a href="http://universalviewer.io/uv.html?manifest=@Model.DlcsSkeletonManifest">DLCS Preview Manifest in UV</a></li>
-                        <li><a href="@Url.Action("IIIF", "Peek", new {id = Model.DdsIdentifier.PathElementSafe})">IIIF Manifest (preview)</a></li>
-                        <li><a href="@Model.ManifestUrl">IIIF Manifest (live)</a></li>
+                        <li><a href="@Url.Action("IIIF", "Peek", new {id = Model.DdsIdentifier.PathElementSafe})">DDS Preview IIIF Manifest</a></li>
+                        <li class="needsOrigin">@Html.ActionLink("Preview IIIF 3 in UV", "UVPreview", "Dash", new {id = Model.DdsIdentifier.PathElementSafe, version=3}, new {target="_blank"}) </li>
+                        <li class="needsOrigin">@Html.ActionLink("Preview IIIF 2/3 in Mirador", "MiradorPreview", "Dash", new {id = Model.DdsIdentifier.PathElementSafe}, new {target="_blank"}) </li>
                     </ul>
                 </li>
                 @if (metsManifestation.Type == "Video" || metsManifestation.Type == "Audio")

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -244,9 +244,12 @@
                     <ul class="list-unstyled">
                         <li><a href="@Model.DlcsSkeletonManifest">DLCS Preview Manifest</a></li>
                         <li><a href="http://universalviewer.io/uv.html?manifest=@Model.DlcsSkeletonManifest">DLCS Preview Manifest in UV</a></li>
-                        <li><a href="@Url.Action("IIIF", "Peek", new {id = Model.DdsIdentifier.PathElementSafe})">DDS Preview IIIF Manifest</a></li>
-                        <li class="needsOrigin">@Html.ActionLink("Preview IIIF 3 in UV", "UVPreview", "Dash", new {id = Model.DdsIdentifier.PathElementSafe, version=3}, new {target="_blank"}) </li>
-                        <li class="needsOrigin">@Html.ActionLink("Preview IIIF 2/3 in Mirador", "MiradorPreview", "Dash", new {id = Model.DdsIdentifier.PathElementSafe}, new {target="_blank"}) </li>
+                        <li>
+                            <a href="@Url.Action("IIIF", "Peek", new { id = Model.DdsIdentifier.PathElementSafe })">DDS Preview IIIF Manifest</a>
+                             | <a href="@Url.Action("IIIFRaw", "Peek", new { id = Model.DdsIdentifier.PathElementSafe })">Raw</a>
+                        </li>
+                        <li class="needsOrigin">@Html.ActionLink("DDS Preview IIIF 3 in UV", "UVPreview", "Dash", new {id = Model.DdsIdentifier.PathElementSafe, version=3}, new {target="_blank"})</li>
+                        <li class="needsOrigin">@Html.ActionLink("DDS Preview IIIF 2/3 in Mirador", "MiradorPreview", "Dash", new {id = Model.DdsIdentifier.PathElementSafe}, new {target="_blank"})</li>
                     </ul>
                 </li>
                 @if (metsManifestation.Type == "Video" || metsManifestation.Type == "Audio")

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Mirador.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Mirador.cshtml
@@ -1,4 +1,4 @@
-@model string[]
+@model List<string>
 @{
     Layout = null;
 }
@@ -22,11 +22,17 @@ var mirador = Mirador.viewer({
       "loadedManifest": "@Model[0]",
       "thumbnailNavigationPosition": 'far-bottom',
       "view": "single"
-    },    
+    }
+    @if (Model.Count > 1)
     {
-      "loadedManifest": "@Model[1]",
-      "thumbnailNavigationPosition": 'far-bottom',
-      "view": "single"
+        <text>
+        ,    
+        {
+            "loadedManifest": "@Model[1]",
+            "thumbnailNavigationPosition": 'far-bottom',
+            "view": "single"
+        }
+        </text>
     }
   ]
 });

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/UV.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/UV.cshtml
@@ -4,6 +4,8 @@
     ViewBag.Title = "UV: " + Model;
 }
 
+<!-- This template is no longer used from the dash - don't need to view things in the wl.org UV any more -->
+<!-- keep for reference though - this is how you would get that last version up for comparison -->
 <div class="row" style="margin-top: 1.5em;">
     <div class="col-sm-12">
         <a href="#" onclick="window.history.go(-1); return false;">Back to previous page</a>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Production.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Production.json
@@ -17,7 +17,8 @@
     "PresentationContainer": "wellcomecollection-iiif-presentation",
     "TextContainer": "wellcomecollection-iiif-text",
     "AnnotationContainer": "wellcomecollection-iiif-annotations",
-    "MinimumJobAgeMinutes": 10
+    "MinimumJobAgeMinutes": 10,
+    "PlaceholderCanvasCacheTimeDays": 28
   },
   "Dash": {
     "JobProcessorName": "job-processor-prod",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
@@ -21,7 +21,8 @@
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
-    "IncludeExtraAccessConditionsInManifest": "Missing,Unknown"
+    "IncludeExtraAccessConditionsInManifest": "Missing,Unknown",
+    "PlaceholderCanvasCacheTimeDays": 0
   },
   "Dash": {
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
@@ -21,7 +21,8 @@
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
-    "IncludeExtraAccessConditionsInManifest": "Missing,Unknown"
+    "IncludeExtraAccessConditionsInManifest": "Missing,Unknown",
+    "PlaceholderCanvasCacheTimeDays": 0
   },
   "Dash": {
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
@@ -63,7 +63,8 @@
     "ApiWorkTemplate": "https://api.wellcomecollection.org/catalogue/v2/works",
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
-    "AnnotationContainer": "wellcomecollection-stage-iiif-annotations"
+    "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
+    "PlaceholderCanvasCacheTimeDays": 28
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/wwwroot/js/dash.js
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/wwwroot/js/dash.js
@@ -46,6 +46,16 @@ $(document).ready(function () {
     bindPreview();
     
     $("img.iiifpreview").unveil(300);
+    
+    var loc = window.location;
+    var origin = loc.protocol + "//" + loc.hostname + (loc.port ? ':' + loc.port: '');
+    $(".needsOrigin a").each(function(){
+        if(this.search){
+            this.href += "&origin=" + origin;
+        } else {
+            this.href += "?origin=" + origin;
+        }
+    });
 });
 
 // So that the toolbar doesn't hide links to named anchors.

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -630,7 +630,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             var pronomKey = physicalFile.AssetMetadata.GetPronomKey();
             if (pronomKey.IsNullOrEmpty())
             {
-                pronomKey = "fmt/unknown";
+                pronomKey = "fmt/0";
             }
             canvas.Width = PlaceholderCanvasSize.Width;
             canvas.Height = PlaceholderCanvasSize.Height;                        

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/BornDigitalExtensionsController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/BornDigitalExtensionsController.cs
@@ -129,7 +129,7 @@ public class BornDigitalExtensionsController : ControllerBase
                 throw new FormatException("Invalid placeholder format");
             }
 
-            if (!Int32.TryParse(PromomNumber, out _))
+            if (!Int32.TryParse(PromomNumber, out pronomNumber))
             {
                 throw new FormatException("Invalid placeholder format");
             }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/BornDigitalExtensionsController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/BornDigitalExtensionsController.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement.Mvc;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
@@ -10,6 +13,7 @@ using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Processing;
 using Utils;
 using Utils.Web;
+using Wellcome.Dds.Common;
 
 namespace Wellcome.Dds.Server.Controllers;
 
@@ -18,10 +22,14 @@ namespace Wellcome.Dds.Server.Controllers;
 public class BornDigitalExtensionsController : ControllerBase
 {
     private string WebRootPath { get; }
+    private DdsOptions DdsOptions { get; }
     
-    public BornDigitalExtensionsController(IWebHostEnvironment environment)
+    public BornDigitalExtensionsController(
+        IWebHostEnvironment environment,
+        IOptions<DdsOptions> options)
     {
         WebRootPath = environment.WebRootPath;
+        DdsOptions = options.Value;
     }
     
     [HttpGet("placeholder-canvas/{*pathParts}")]
@@ -48,7 +56,10 @@ public class BornDigitalExtensionsController : ControllerBase
             smallFont, Color.Black, new PointF(20, 165)));
         
         Response.ContentType = "image/png";
-        Response.CacheForDays(28);
+        if (DdsOptions.PlaceholderCanvasCacheTimeDays > 0)
+        {
+            Response.CacheForDays(DdsOptions.PlaceholderCanvasCacheTimeDays);
+        }
         await img.SaveAsync(Response.Body, new PngEncoder());
         return new EmptyResult();
     }
@@ -68,7 +79,10 @@ public class BornDigitalExtensionsController : ControllerBase
 
     private VirtualFileResult ServeThumb(string name)
     {
-        Response.CacheForDays(28);
+        if (DdsOptions.PlaceholderCanvasCacheTimeDays > 0)
+        {
+            Response.CacheForDays(DdsOptions.PlaceholderCanvasCacheTimeDays);
+        }
         return File($"~/born-digital/{name}.png", "image/png");
     }
 
@@ -80,11 +94,21 @@ public class BornDigitalExtensionsController : ControllerBase
 
     class PlaceholderParts
     {
+        private int pronomNumber;
         // parts is like fmt/123/audio/mp3
         public string PromomPrefix { get; }
         public string PromomNumber { get; }
-        public string PromomKey => $"{PromomPrefix}/{PromomNumber}";
-        
+        public string PromomKey
+        {
+            get {
+                if (pronomNumber <= 0)
+                {
+                    return "[Unknown format]";
+                }
+
+                return $"{PromomPrefix}/{PromomNumber}";}
+        }
+
         public string MimeMainType { get; }
         public string MimeSubType { get; }
         public string MimeType => $"{MimeMainType}/{MimeSubType}";
@@ -92,10 +116,34 @@ public class BornDigitalExtensionsController : ControllerBase
         public PlaceholderParts(string pathParts)
         {
             var parts = pathParts.SplitByDelimiterIntoArray('/');
+            if (parts.Length != 4)
+            {
+                throw new FormatException("Invalid placeholder format");
+            }
             PromomPrefix = parts[0];
             PromomNumber = parts[1];
             MimeMainType = parts[2];
             MimeSubType = parts[3];
+            if (PromomPrefix is not ("fmt" or "x-fmt"))
+            {
+                throw new FormatException("Invalid placeholder format");
+            }
+
+            if (!Int32.TryParse(PromomNumber, out _))
+            {
+                throw new FormatException("Invalid placeholder format");
+            }
+
+            const int maxLength = 127; // according to RFC, but we might want to make this shorter
+            if (MimeMainType.Length > maxLength || MimeSubType.Length > maxLength)
+            {
+                throw new FormatException("Invalid placeholder format");
+            }
+            if (MimeMainType.Contains(' ') || MimeSubType.Contains(' '))
+            {
+                throw new FormatException("Invalid placeholder format");
+            }
+            
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.sln.DotSettings
+++ b/src/Wellcome.Dds/Wellcome.Dds.sln.DotSettings
@@ -1,9 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UV/@EntryIndexedValue">UV</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Anno/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dlcs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Goobi/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IIIF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mets/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mirador/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=paintable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=premis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Promom/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Adds much more flexible previewing for manifests in UV and Mirador.
Also allows previewing the dynamically generated dashboard manifest from PeekController, which means allowing anonymous access to those two IIIFRaw actions.

Improve the generation of the placeholder canvas and add some cache settings to avoid cloudfront caching it for weeks on stage.