### PR TITLE
LinkRewriter and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 mono_crash.*
 
 appsettings.Development.json
+appsettings.Development-Alt.json
+appsettings.Development-Original.json
 
 # Build results
 [Dd]ebug/

--- a/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/LinkRewriterTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/LinkRewriterTests.cs
@@ -1,0 +1,193 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Wellcome.Dds.Common.Tests;
+
+public class LinkWriterTests
+{
+    private const string InitialDomain = "https://iiif.wellcomecollection.org";
+    private const string NewDdsDomain = "https://rewritten-dds.org";
+    private const string NewDlcsDomain = "https://rewritten-dlcs.org";
+    private const int NewDlcsSpace = 6;
+
+    private static readonly Dictionary<string, string> TestData;
+    private static readonly string TestDataString;
+    
+    static LinkWriterTests()
+    {
+        TestData = new Dictionary<string, string>
+        {
+            ["manifest-id"] = $"{InitialDomain}/presentation/manifest",
+            ["image-service-1"] = $"{InitialDomain}/image/image1.jp2",
+            ["image-params-1"] = $"{InitialDomain}/image/image1.jp2/full/max/0/default.jpg",
+            ["text-resource"] = "https://api.wellcomecollection.org/text/v1/text-resource",
+            ["alto-resource"] = "https://api.wellcomecollection.org/text/alto/alto-resource",
+            ["other-wc-api-link"] = "https://api.wellcomecollection.org/catalogue/v2/works/xxynxjmp",
+            ["other-wc-link"] = "https://wellcomecollection.org/",
+            ["other-external-link"] = "https://example.org/hello",
+            ["image-service-2"] = $"{InitialDomain}/image/image2.jp2",
+            ["image-params-2"] = $"{InitialDomain}/image/image2.jp2/full/max/0/default.jpg",
+            ["canvas-id"] = $"{InitialDomain}/presentation/image1/canvases/canvas1",
+            ["video-resource"] = $"{InitialDomain}/av/video.mp4",
+            ["audio-resource"] = $"{InitialDomain}/av/sound.mp3",
+            ["file-resource"] = $"{InitialDomain}/file/my-file",
+            ["pdf-derivative"] = $"{InitialDomain}/pdf/my-book",
+            ["auth-service"] = $"{InitialDomain}/auth/clickthrough",
+            ["auth-logout"] = $"{InitialDomain}/auth/clickthrough/logout",
+            ["thumb-service-1"] = $"{InitialDomain}/thumbs/image1.jp2",
+            ["thumb-params-1"] = $"{InitialDomain}/thumbs/image1.jp2/full/max/0/default.jpg",
+            ["other-dds"] = $"{InitialDomain}/x/y/z"
+        };
+        TestDataString = JsonSerializer.Serialize(TestData);
+    }
+
+    [Fact]
+    public static void DDS_Only_Links_Rewritten()
+    {
+        // arrange
+        var ddsOnlyOptions = new DdsOptions
+        {
+            LinkedDataDomain = InitialDomain,
+            RewriteDomainLinksTo = NewDdsDomain
+        };
+        var ddsOnlyLinkRewriter = new LinkRewriter(Options.Create(ddsOnlyOptions));
+        
+        // act
+        var rewritten = ddsOnlyLinkRewriter.RewriteLinks(TestDataString);
+        
+        // assert
+        ddsOnlyLinkRewriter.RequiresRewriting().Should().BeTrue();
+        var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(rewritten);
+        
+        // expected to be transformed:
+        dict["manifest-id"].Should().Be($"{NewDdsDomain}/presentation/manifest");
+        dict["text-resource"].Should().Be($"{NewDdsDomain}/text/v1/text-resource");
+        dict["alto-resource"].Should().Be($"{NewDdsDomain}/text/alto/alto-resource");
+        dict["canvas-id"].Should().Be($"{NewDdsDomain}/presentation/image1/canvases/canvas1");
+        dict["other-dds"].Should().Be($"{NewDdsDomain}/x/y/z");
+        
+        // expected to stay the same:
+        dict["image-service-1"].Should().Be(TestData["image-service-1"]);
+        dict["image-service-2"].Should().Be(TestData["image-service-2"]);
+        dict["image-params-2"].Should().Be(TestData["image-params-2"]);
+        dict["other-wc-link"].Should().Be(TestData["other-wc-link"]);
+        dict["other-wc-api-link"].Should().Be(TestData["other-wc-api-link"]);
+        dict["other-external-link"].Should().Be(TestData["other-external-link"]);
+        dict["video-resource"].Should().Be(TestData["video-resource"]);
+        dict["audio-resource"].Should().Be(TestData["audio-resource"]);
+        dict["file-resource"].Should().Be(TestData["file-resource"]);
+        dict["pdf-derivative"].Should().Be(TestData["pdf-derivative"]);
+        dict["auth-service"].Should().Be(TestData["auth-service"]);
+        dict["auth-logout"].Should().Be(TestData["auth-logout"]);
+        dict["thumb-service-1"].Should().Be(TestData["thumb-service-1"]);
+        dict["thumb-params-1"].Should().Be(TestData["thumb-params-1"]);
+    }
+
+    [Fact]
+    public static void DLCS_Only_Links_rewritten()
+    {
+        var dlcsOnlyOptions = new DdsOptions
+        {
+            LinkedDataDomain = InitialDomain,
+            RewriteDlcsLinksHostTo = NewDlcsDomain,
+            RewriteDlcsLinksSpaceTo = NewDlcsSpace
+        };
+        var dlcsOnlyLinkRewriter = new LinkRewriter(Options.Create(dlcsOnlyOptions));
+        
+        // act
+        var rewritten = dlcsOnlyLinkRewriter.RewriteLinks(TestDataString);
+        
+        // assert
+        dlcsOnlyLinkRewriter.RequiresRewriting().Should().BeTrue();
+        var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(rewritten);
+        
+        // expected to be transformed
+        dict["image-service-1"].Should().Be($"{NewDlcsDomain}/iiif-img/2/6/image1.jp2");
+        dict["image-service-2"].Should().Be($"{NewDlcsDomain}/iiif-img/2/6/image2.jp2");
+        dict["image-params-1"].Should().Be($"{NewDlcsDomain}/iiif-img/2/6/image1.jp2/full/max/0/default.jpg");
+        dict["image-params-2"].Should().Be($"{NewDlcsDomain}/iiif-img/2/6/image2.jp2/full/max/0/default.jpg");
+        dict["video-resource"].Should().Be($"{NewDlcsDomain}/iiif-av/2/6/video.mp4");
+        dict["audio-resource"].Should().Be($"{NewDlcsDomain}/iiif-av/2/6/sound.mp3");
+        dict["file-resource"].Should().Be($"{NewDlcsDomain}/file/2/6/my-file");
+        dict["pdf-derivative"].Should().Be($"{NewDlcsDomain}/pdf/2/pdf/6/my-book");
+        dict["auth-service"].Should().Be($"{NewDlcsDomain}/auth/2/clickthrough");
+        dict["auth-logout"].Should().Be($"{NewDlcsDomain}/auth/2/clickthrough/logout");
+        dict["thumb-service-1"].Should().Be($"{NewDlcsDomain}/thumbs/2/6/image1.jp2");
+        dict["thumb-params-1"].Should().Be($"{NewDlcsDomain}/thumbs/2/6/image1.jp2/full/max/0/default.jpg");
+        
+        // expected to stay the same:
+        dict["manifest-id"].Should().Be(TestData["manifest-id"]);
+        dict["text-resource"].Should().Be(TestData["text-resource"]);
+        dict["alto-resource"].Should().Be(TestData["alto-resource"]);
+        dict["canvas-id"].Should().Be(TestData["canvas-id"]);
+        dict["other-wc-link"].Should().Be(TestData["other-wc-link"]);
+        dict["other-wc-api-link"].Should().Be(TestData["other-wc-api-link"]);
+        dict["other-external-link"].Should().Be(TestData["other-external-link"]);
+        dict["other-dds"].Should().Be(TestData["other-dds"]);
+    }
+
+    [Fact]
+    public static void DDS_And_DLCS_Links_Rewritten()
+    {
+        var ddsAndDlcsOptions = new DdsOptions
+        {
+            LinkedDataDomain = InitialDomain,
+            RewriteDomainLinksTo = NewDdsDomain,
+            RewriteDlcsLinksHostTo = NewDlcsDomain,
+            RewriteDlcsLinksSpaceTo = NewDlcsSpace
+        };
+        var ddsAndDlcsLinkRewriter = new LinkRewriter(Options.Create(ddsAndDlcsOptions));
+        // act
+        var rewritten = ddsAndDlcsLinkRewriter.RewriteLinks(TestDataString);
+        
+        // assert
+        ddsAndDlcsLinkRewriter.RequiresRewriting().Should().BeTrue();
+        var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(rewritten);
+        
+        // expected to be transformed
+        dict["image-service-1"].Should().Be($"{NewDlcsDomain}/iiif-img/2/6/image1.jp2");
+        dict["image-service-2"].Should().Be($"{NewDlcsDomain}/iiif-img/2/6/image2.jp2");
+        dict["image-params-1"].Should().Be($"{NewDlcsDomain}/iiif-img/2/6/image1.jp2/full/max/0/default.jpg");
+        dict["image-params-2"].Should().Be($"{NewDlcsDomain}/iiif-img/2/6/image2.jp2/full/max/0/default.jpg");
+        dict["video-resource"].Should().Be($"{NewDlcsDomain}/iiif-av/2/6/video.mp4");
+        dict["audio-resource"].Should().Be($"{NewDlcsDomain}/iiif-av/2/6/sound.mp3");
+        dict["file-resource"].Should().Be($"{NewDlcsDomain}/file/2/6/my-file");
+        dict["pdf-derivative"].Should().Be($"{NewDlcsDomain}/pdf/2/pdf/6/my-book");
+        dict["auth-service"].Should().Be($"{NewDlcsDomain}/auth/2/clickthrough");
+        dict["auth-logout"].Should().Be($"{NewDlcsDomain}/auth/2/clickthrough/logout");
+        dict["thumb-service-1"].Should().Be($"{NewDlcsDomain}/thumbs/2/6/image1.jp2");
+        dict["thumb-params-1"].Should().Be($"{NewDlcsDomain}/thumbs/2/6/image1.jp2/full/max/0/default.jpg");
+        
+        dict["other-dds"].Should().Be($"{NewDdsDomain}/x/y/z");
+        dict["manifest-id"].Should().Be($"{NewDdsDomain}/presentation/manifest");
+        dict["text-resource"].Should().Be($"{NewDdsDomain}/text/v1/text-resource");
+        dict["alto-resource"].Should().Be($"{NewDdsDomain}/text/alto/alto-resource");
+        dict["canvas-id"].Should().Be($"{NewDdsDomain}/presentation/image1/canvases/canvas1");
+        
+        // expected to stay the same:
+        dict["other-wc-link"].Should().Be(TestData["other-wc-link"]);
+        dict["other-wc-api-link"].Should().Be(TestData["other-wc-api-link"]);
+        dict["other-external-link"].Should().Be(TestData["other-external-link"]);
+    }
+
+    [Fact]
+    public static void NoOp_Links_Not_Rewritten()
+    {
+        var noopOptions = new DdsOptions
+        {
+            LinkedDataDomain = InitialDomain
+        };
+        var noopDlcsLinkRewriter = new LinkRewriter(Options.Create(noopOptions));
+        
+        // act
+        var rewritten = noopDlcsLinkRewriter.RewriteLinks(TestDataString);
+        
+        // assert
+        noopDlcsLinkRewriter.RequiresRewriting().Should().BeFalse();
+        var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(rewritten);
+        dict.Should().BeEquivalentTo(TestData);
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/LinkRewriterTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common.Tests/LinkRewriterTests.cs
@@ -128,6 +128,49 @@ public class LinkWriterTests
         dict["other-external-link"].Should().Be(TestData["other-external-link"]);
         dict["other-dds"].Should().Be(TestData["other-dds"]);
     }
+    
+    
+    [Fact]
+    public static void DLCS_Host_Only_Links_rewritten()
+    {
+        var dlcsHostOnlyOptions = new DdsOptions
+        {
+            LinkedDataDomain = InitialDomain,
+            RewriteDlcsLinksHostTo = NewDlcsDomain // but no space specified
+        };
+        var dlcsHostOnlyLinkRewriter = new LinkRewriter(Options.Create(dlcsHostOnlyOptions));
+        
+        // act
+        var rewritten = dlcsHostOnlyLinkRewriter.RewriteLinks(TestDataString);
+        
+        // assert
+        dlcsHostOnlyLinkRewriter.RequiresRewriting().Should().BeTrue();
+        var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(rewritten);
+        
+        // expected to be transformed
+        dict["image-service-1"].Should().Be($"{NewDlcsDomain}/image/image1.jp2");
+        dict["image-service-2"].Should().Be($"{NewDlcsDomain}/image/image2.jp2");
+        dict["image-params-1"].Should().Be($"{NewDlcsDomain}/image/image1.jp2/full/max/0/default.jpg");
+        dict["image-params-2"].Should().Be($"{NewDlcsDomain}/image/image2.jp2/full/max/0/default.jpg");
+        dict["video-resource"].Should().Be($"{NewDlcsDomain}/av/video.mp4");
+        dict["audio-resource"].Should().Be($"{NewDlcsDomain}/av/sound.mp3");
+        dict["file-resource"].Should().Be($"{NewDlcsDomain}/file/my-file");
+        dict["pdf-derivative"].Should().Be($"{NewDlcsDomain}/pdf/my-book");
+        dict["auth-service"].Should().Be($"{NewDlcsDomain}/auth/clickthrough");
+        dict["auth-logout"].Should().Be($"{NewDlcsDomain}/auth/clickthrough/logout");
+        dict["thumb-service-1"].Should().Be($"{NewDlcsDomain}/thumbs/image1.jp2");
+        dict["thumb-params-1"].Should().Be($"{NewDlcsDomain}/thumbs/image1.jp2/full/max/0/default.jpg");
+        
+        // expected to stay the same:
+        dict["manifest-id"].Should().Be(TestData["manifest-id"]);
+        dict["text-resource"].Should().Be(TestData["text-resource"]);
+        dict["alto-resource"].Should().Be(TestData["alto-resource"]);
+        dict["canvas-id"].Should().Be(TestData["canvas-id"]);
+        dict["other-wc-link"].Should().Be(TestData["other-wc-link"]);
+        dict["other-wc-api-link"].Should().Be(TestData["other-wc-api-link"]);
+        dict["other-external-link"].Should().Be(TestData["other-external-link"]);
+        dict["other-dds"].Should().Be(TestData["other-dds"]);
+    }
 
     [Fact]
     public static void DDS_And_DLCS_Links_Rewritten()

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -3,11 +3,37 @@
     // Which class Library does this class live in?
     public class DdsOptions
     {
-        // TODO - leave this with the name "LinkedDataDomain" for now, for ease of migration,
-        // but later, refactor to "SchemeAndHost"
+        /// <summary>
+        /// The scheme and host that will be emitted when generating IIIF JSON
+        /// E.g., https://iiif.wellcomecollection.org
+        /// TODO - leave this with the name "LinkedDataDomain" for now, for ease of migration,
+        /// but later, refactor to "SchemeAndHost"
+        /// </summary>
         public string? LinkedDataDomain { get; set; }
+        
+        /// <summary>
+        /// Used by Wellcome.Dds.Server or dashboard, just before the point of delivery, to replace
+        /// the LinkedDataDomain value with an alternative - e.g., http://localhost:8084
+        ///
+        /// This allows loading previously created IIIF resources from stage or live buckets rather than
+        /// having to create new IIIF if you need to point links to different locations.
+        ///
+        /// It also allows for A/B testing.
+        /// This will not alter the path part of any URLs.
+        /// </summary>
         public string? RewriteDomainLinksTo { get; set; }
+        
+        /// <summary>
+        /// Similar to RewriteDomainLinksTo but for the DLCS. 
+        /// This will not alter the path part of any URLs.
+        /// </summary>
         public string? RewriteDlcsLinksHostTo { get; set; }
+        
+        /// <summary>
+        /// For the DLCS you might want to point directly at a DLCS instance rather than through
+        /// Cloudfront rewritten URLs. If this value is present (and > 0) the path part of the URL
+        /// will be transformed, inserting the space value provided where necessary.
+        /// </summary>
         public int? RewriteDlcsLinksSpaceTo { get; set; }
         
         public bool AvoidCaching { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -7,6 +7,8 @@
         // but later, refactor to "SchemeAndHost"
         public string? LinkedDataDomain { get; set; }
         public string? RewriteDomainLinksTo { get; set; }
+        public string? RewriteDlcsLinksHostTo { get; set; }
+        public int? RewriteDlcsLinksSpaceTo { get; set; }
         
         public bool AvoidCaching { get; set; }
         public string? EarliestJobDateTime { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/LinkRewriter.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/LinkRewriter.cs
@@ -1,0 +1,114 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Utils;
+
+namespace Wellcome.Dds.Common;
+
+/// <summary>
+/// Transforms any string containing links, to modify DDS and DLCS URLs
+/// This allows for previewing and testing even when loading stored Manifests from S3 that contain "proper" URLs
+///
+/// We want to by default generate our IIIF with the cloudfront paths for both DDS and DLCS.
+/// For DLCS this means without the space parameter in the URL pattern.
+///
+/// For testing we might want to modify the DDS paths to localhost and/or the DLCS paths to a different DLCS.
+/// We need to be able to do these things independently.
+///
+/// This means that appSettings might contain one schema and host for generating iiif.wc.org links, that the
+/// DDS uses for both DDS and DLCS, and then appSettings might also have further settings to modify these links
+/// at the last minute.
+/// </summary>
+public class LinkRewriter
+{
+    private readonly DdsOptions ddsOptions;
+
+    public LinkRewriter(IOptions<DdsOptions> options)
+    {
+        ddsOptions = options.Value;
+        
+        // need to handle -- api.wellcomecollection.org/text
+    }
+
+    public bool RequiresRewriting()
+    {
+        return ddsOptions.RewriteDomainLinksTo.HasText() || ddsOptions.RewriteDlcsLinksHostTo.HasText();
+    }
+
+    public async Task<string> RewriteLinks(StreamReader streamReader)
+    {
+        string raw = await streamReader.ReadToEndAsync();
+        return RewriteLinks(raw);
+    }
+
+    public string RewriteLinks(string raw)
+    {
+        string result = raw;
+
+        // we need to transform the DLCS links and the DDS links separately.
+        // We need to remove the DLCS links from consideration
+        var pattern = GetDlcsLinksRegexPattern(ddsOptions.LinkedDataDomain!);
+        var placeholder = "__DLCS_DOMAIN_PLACEHOLDER__";
+        result = Regex.Replace(raw, pattern, $"\"{placeholder}/$1/$2\"");
+        
+        // we have now separated the DDS and DLCS links so we can do replacements on them independently
+        if (ddsOptions.RewriteDomainLinksTo.HasText())
+        {
+            var newLink = ddsOptions.RewriteDomainLinksTo;
+            result = result.Replace(ddsOptions.LinkedDataDomain!, newLink);
+            result = result.Replace("https://api.wellcomecollection.org/text/", $"{newLink}/text/");
+        }
+
+        if (ddsOptions.RewriteDlcsLinksSpaceTo is > 0)
+        {
+            // modify the space part of the DLCS URLs
+            var space = ddsOptions.RewriteDlcsLinksSpaceTo;
+            
+            // do all of (image|thumbs|pdf|av|auth) use the same pattern? No.
+            var imgPattern = GetDlcsLinksRegexPattern(placeholder, "image");
+            result = Regex.Replace(result, imgPattern, $"\"{placeholder}/iiif-img/2/{space}/$2\"");
+
+            var avPattern = GetDlcsLinksRegexPattern(placeholder, "av");
+            result = Regex.Replace(result, avPattern, $"\"{placeholder}/iiif-av/2/{space}/$2\"");
+            
+            var pdfPattern = GetDlcsLinksRegexPattern(placeholder, "pdf");
+            result = Regex.Replace(result, pdfPattern, $"\"{placeholder}/pdf/2/pdf/{space}/$2\"");
+            
+            var authPattern = GetDlcsLinksRegexPattern(placeholder, "auth");
+            result = Regex.Replace(result, authPattern, $"\"{placeholder}/auth/2/$2\""); // no space
+            
+            // default (ok for thumbs and file)
+            pattern = GetDlcsLinksRegexPattern(placeholder, "thumbs|file");
+            result = Regex.Replace(result, pattern, $"\"{placeholder}/$1/2/{space}/$2\"");
+            
+        }
+        
+        // now either modify the scheme and host part of the DLCS URLs or return it to its original state
+        var dlcsHost = ddsOptions.RewriteDlcsLinksHostTo.HasText()
+            ? ddsOptions.RewriteDlcsLinksHostTo
+            : ddsOptions.LinkedDataDomain;
+
+        result = result.Replace(placeholder, dlcsHost);
+
+        return result;
+    }
+    
+    private string GetDlcsLinksRegexPattern(string domainPart, string? part = null)
+    {
+        var pattern = "\\\"" + domainPart.Replace(".", "\\.");
+        var firstPathElement = part ?? "image|thumbs|pdf|av|auth|file";
+        pattern += "/(" + firstPathElement + ")/([^\"]*)\\\"";
+        return pattern;
+    }
+
+    public string TransformIdentifier(string identifier)
+    {
+        if (ddsOptions.RewriteDomainLinksTo.IsNullOrWhiteSpace())
+        {
+            return identifier;
+        }
+
+        return identifier.Replace(ddsOptions.LinkedDataDomain!, ddsOptions.RewriteDomainLinksTo);
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
@@ -94,6 +94,7 @@ namespace Wellcome.Dds.Dashboard
 
             services.AddSingleton<ISimpleCache, ConcurrentSimpleMemoryCache>();
             services.AddSingleton<UriPatterns>();
+            services.AddSingleton<LinkRewriter>();
 
             // should cover all the resolved type usages...
             services.AddSingleton(typeof(IBinaryObjectCache<>), typeof(BinaryObjectCache<>));

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/Helpers.cs
@@ -1,10 +1,8 @@
 #nullable enable
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Utils.Storage;
@@ -15,14 +13,14 @@ namespace Wellcome.Dds.Server.Controllers
     public class Helpers
     {
         private readonly IStorage storage;
-        private readonly DdsOptions ddsOptions;
+        private readonly LinkRewriter linkRewriter;
 
         public Helpers(
             IStorage storage,
-            IOptions<DdsOptions> options)
+            LinkRewriter linkRewriter)
         {
             this.storage = storage;
-            ddsOptions = options.Value;
+            this.linkRewriter = linkRewriter;
         }
 
         /// <summary>
@@ -49,24 +47,16 @@ namespace Wellcome.Dds.Server.Controllers
             {
                 return controller.NotFound($"No IIIF resource found for {path}");
             }
-            if (string.IsNullOrWhiteSpace(ddsOptions.RewriteDomainLinksTo))
+
+            if (!linkRewriter.RequiresRewriting())
             {
                 // This is the efficient way to return the response
                 return controller.File(stream, contentType);
             }
-
+            
             // This is an inefficient method but allows us to manipulate the response.
             using var reader = new StreamReader(stream, Encoding.UTF8);
-            string raw = await reader.ReadToEndAsync();
-            
-            // This is OK but we want to leave the DLCS links intact!
-            // string rewritten = raw.Replace(ddsOptions.LinkedDataDomain, ddsOptions.RewriteDomainLinksTo);
-            // https://iiif-test\.wellcomecollection\.org/(?<!image|thumbs|pdf|av|auth)/(.*)
-            var pattern = GetRegexPattern(ddsOptions.LinkedDataDomain!);
-            var placeholder = "__PLACEHOLDER__";
-            var pass1 = Regex.Replace(raw, pattern, $"\"{placeholder}/$1/$2\"");
-            var pass2 = pass1.Replace(ddsOptions.LinkedDataDomain!, ddsOptions.RewriteDomainLinksTo);
-            var rewritten = pass2.Replace(placeholder, ddsOptions.LinkedDataDomain);
+            var rewritten = await linkRewriter.RewriteLinks(reader);
             return controller.Content(rewritten, contentType);
         }
 
@@ -76,12 +66,6 @@ namespace Wellcome.Dds.Server.Controllers
             return await file.DoesExist();
         }
 
-        private string GetRegexPattern(string domainPart)
-        {
-            var pattern = "\\\"" + domainPart.Replace(".", "\\.");
-            pattern += "/(image|thumbs|pdf|av|auth)/([^\"]*)\\\"";
-            return pattern;
-        }
 
         public async Task<JObject?> LoadAsJson(string container, string path)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -135,7 +135,8 @@ namespace Wellcome.Dds.Server
 
             services.AddSingleton<ISimpleCache, ConcurrentSimpleMemoryCache>();
             services.AddHttpClient<ICatalogue, WellcomeCollectionCatalogue>();
-            
+
+            services.AddSingleton<LinkRewriter>();
             services.AddSingleton<UriPatterns>();
             services.AddSingleton<Helpers>();
 


### PR DESCRIPTION
Just making this a PR for visibility - it's against the nullable check branch.

You can configure the rewriter for DDS and/or DLCS links. For the latter there are two types of rewrite - whether just to rewrite to an alternative host (but keeping the cloudfront-simplified paths) or whether to rewrite the path part as well, to a DLCS-native format, where it needs to inject the space as well. It handles image, av, file, pdf, thumbs and auth paths, which don't all follow the same rewrite processes to get to the actual DLCS path!

This allows us to serve any existing production manifest, and rewrite any of:

DDS links to iiif-new
DLCS links to iiif-new (cloudfront-fronted)
DLCS links to neworchestrator.dlcs.io


