### PR TITLE
Protagonist delivery channels

### DIFF
--- a/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
@@ -20,5 +20,10 @@
         /// Default timeout (in ms) use for HttpClient.Timeout.
         /// </summary>
         public int DefaultTimeoutMs { get; set; } = 30000;
+
+        /// <summary>
+        /// Whether to call the DLCS using old Deliverator AssetFamily, or protagonist delivery channels
+        /// </summary>
+        public bool SupportsDeliveryChannels { get; set; } = false;
     }
 }

--- a/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
@@ -650,7 +650,8 @@ namespace DlcsWebClient.Dlcs
                     foreach (var image in imageCollection.Members)
                     {
                         image.StorageIdentifier = GetLocalStorageIdentifier(image.Id!);
-                        if (image.Family == 'T')
+                        // same as: if(options.SupportsDeliveryChannels) - we can retire Family later
+                        if (image.MediaType.IsTimeBasedMimeType() || image.Family == 'T')
                         {
                             await LoadMetadata(image);
                         }
@@ -720,6 +721,7 @@ namespace DlcsWebClient.Dlcs
         public string ResourceEntryPoint => options.ResourceEntryPoint!;
         public string InternalResourceEntryPoint => options.InternalResourceEntryPoint!;
 
+        public bool SupportsDeliveryChannels => options.SupportsDeliveryChannels;
     }
 
     class MessageObject : JSONLDBase

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IProcessingBehaviour.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Wellcome.Dds.AssetDomain.DigitalObjects;
+
+public interface IProcessingBehaviour
+{
+    HashSet<string> DeliveryChannels { get; }
+    string? ImageOptimisationPolicy { get; }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/AssetFamily.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/AssetFamily.cs
@@ -25,7 +25,7 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
 
                 return AssetFamily.File;
             }
-            if (mediaType.IsVideoMimeType() || mediaType.IsAudioMimeType())
+            if (mediaType.IsTimeBasedMimeType())
             {
                 return AssetFamily.TimeBased;
             }
@@ -40,6 +40,11 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
         public static bool IsAudioMimeType(this string? mimeType)
         {
             return mimeType != null && mimeType.StartsWith("audio/");
+        }
+
+        public static bool IsTimeBasedMimeType(this string? mimeType)
+        {
+            return mimeType.IsVideoMimeType() || mimeType.IsAudioMimeType();
         }
         
         public static bool IsImageMimeType(this string? mimeType)

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
@@ -115,5 +115,7 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
         
         string ResourceEntryPoint { get; }
         string InternalResourceEntryPoint { get; }
+        
+        bool SupportsDeliveryChannels { get; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
@@ -96,7 +96,7 @@ namespace Wellcome.Dds.AssetDomain.Dlcs.Model
         public string? MediaType { get; set; }
 
         [JsonProperty(Order = 130, PropertyName = "family")]
-        public char Family { get; set; } // i, t, f
+        public char? Family { get; set; } // i, t, f
 
         [JsonProperty(Order = 120, PropertyName = "text")]
         public string? Text { get; set; }
@@ -120,6 +120,8 @@ namespace Wellcome.Dds.AssetDomain.Dlcs.Model
         [JsonProperty(Order = 81, PropertyName = "thumbnailPolicy")]
         public string? ThumbnailPolicy { get; set; }
 
+        [JsonProperty(Order = 82, PropertyName = "deliveryChannel")]
+        public string? DeliveryChannel { get; set; }
     }
 
     public class Thumbnail

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Mets/IPhysicalFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Mets/IPhysicalFile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Dlcs;
 
 namespace Wellcome.Dds.AssetDomain.Mets
@@ -39,6 +40,14 @@ namespace Wellcome.Dds.AssetDomain.Mets
         string? StorageIdentifier { get; set; }
         
         string? MimeType { get; set; }
+        
+        /// <summary>
+        /// Where a METS PhysicalFile has more than one IStoredFile, the AssetMetadata will be that of the IStoredFile
+        /// that's to be synced with the DLCS, the one we are interested in rather than ALTOs etc.
+        ///
+        /// If we decide to sync both MXFs and MP4s within one single PhysicalFile, the convenience of hoisting
+        /// these properties of actual files up to the IPhysicalFile METS abstraction might start getting confusing.
+        /// </summary>
         IAssetMetadata? AssetMetadata { get; set; }
         string? AccessCondition { get; set; }
         
@@ -62,5 +71,7 @@ namespace Wellcome.Dds.AssetDomain.Mets
         string? RelativePosterPath { get; set; }
         string? RelativeTranscriptPath { get; set; }
         string? RelativeMasterPath { get; set; }
+        
+        IProcessingBehaviour ProcessingBehaviour { get; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DashboardRepositoryTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DashboardRepositoryTests.cs
@@ -52,7 +52,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
             var uriPatterns = new UriPatterns(options);
 
             sut = new DigitalObjectRepository(new NullLogger<DigitalObjectRepository>(), uriPatterns, dlcs, metsRepository,
-                ddsInstrumentationContext);
+                ddsInstrumentationContext, options);
         }
 
         [Fact]

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
@@ -120,7 +120,7 @@ public class ProcessingBehaviourTests
     }
     
     [Fact]
-    public void Access_MP4_Has_File_Delivery_Channel()
+    public void Access_MP4_720_Has_File_Delivery_Channel()
     {
         var pf = A.Fake<PhysicalFile>();
         pf.Files = new List<IStoredFile>
@@ -129,14 +129,14 @@ public class ProcessingBehaviourTests
             new StoredFile { MimeType = "application/mxf" }  // the master
         };
         pf.MimeType = "video/mp4";
+        SetHeight(pf, 720);
 
         var processing = pf.ProcessingBehaviour;
 
         processing.DeliveryChannels.Should().OnlyContain(s => s == "file");
-    }    
-        
+    }
     [Fact]
-    public void Access_MP4_Has_None_IOP()
+    public void Access_MP4_1440_Has_iiif_av_and_file_Delivery_Channel()
     {
         var pf = A.Fake<PhysicalFile>();
         pf.Files = new List<IStoredFile>
@@ -145,10 +145,53 @@ public class ProcessingBehaviourTests
             new StoredFile { MimeType = "application/mxf" }  // the master
         };
         pf.MimeType = "video/mp4";
+        SetHeight(pf, 1440);
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av" || s == "file");
+    }
+    
+
+    private static void SetHeight(PhysicalFile pf, int height)
+    {
+        var assetMetadata = A.Fake<IAssetMetadata>();
+        A.CallTo(() => assetMetadata.GetMediaDimensions()).Returns(new MediaDimensions { Height = height });
+        pf.AssetMetadata = assetMetadata;
+    }
+
+    [Fact]
+    public void Access_MP4_720_Has_None_IOP()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.Files = new List<IStoredFile>
+        {
+            new StoredFile { MimeType = "video/mp4" },       // the access copy
+            new StoredFile { MimeType = "application/mxf" }  // the master
+        };
+        pf.MimeType = "video/mp4";
+        SetHeight(pf, 720);
 
         var processing = pf.ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().Be("none");
+    }
+    
+    [Fact]
+    public void Access_MP4_1440_Has_Null_IOP()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.Files = new List<IStoredFile>
+        {
+            new StoredFile { MimeType = "video/mp4" },       // the access copy
+            new StoredFile { MimeType = "application/mxf" }  // the master
+        };
+        pf.MimeType = "video/mp4";
+        SetHeight(pf, 1440);
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.ImageOptimisationPolicy.Should().BeNull();
     }
     
     // Use this to test resolution-specific transcoding - needs the logic in ProcessingBehaviour to change
@@ -162,9 +205,7 @@ public class ProcessingBehaviourTests
             new StoredFile { MimeType = "video/mp4" }
         };
         pf.MimeType = "video/mp4";
-        var assetMetadata = A.Fake<IAssetMetadata>();
-        A.CallTo(() => assetMetadata.GetMediaDimensions()).Returns(new MediaDimensions { Height = 1440 });
-        pf.AssetMetadata = assetMetadata;
+        SetHeight(pf, 1440);
 
         var processing = pf.ProcessingBehaviour;
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using FakeItEasy;
+using FluentAssertions;
+using Wellcome.Dds.AssetDomain.Mets;
+using Wellcome.Dds.AssetDomainRepositories.Mets.Model;
+using Xunit;
+
+namespace Wellcome.Dds.AssetDomainRepositories.Tests.DlcsSynchronisation;
+
+public class ProcessingBehaviourTests
+{
+    [Fact]
+    public void Image_Has_IIIF_and_thumbs_Delivery_Channel()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.MimeType = "image/jpg";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-img" || s == "thumbs");
+    }
+    
+    
+    [Fact]
+    public void MP3_Has_File_Delivery_Channel()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.MimeType = "audio/x-mpeg-3";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.DeliveryChannels.Should().OnlyContain(s => s == "file");
+    }
+    
+    
+    [Fact]
+    public void MP3_Has_None_IOP()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.MimeType = "audio/x-mpeg-3";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.ImageOptimisationPolicy.Should().Be("none");
+    }
+    
+    
+    [Fact]
+    public void Wav_Has_IIIF_AV_Delivery_Channel()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.MimeType = "audio/wav";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av");
+    }    
+    
+    [Fact]
+    public void Wav_Has_Null_IOP()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.MimeType = "audio/wav";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.ImageOptimisationPolicy.Should().BeNull();
+    }
+    
+    [Fact]
+    public void mpeg_Has_IIIF_AV_Delivery_Channel()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.MimeType = "video/mpeg-2";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av");
+    }    
+        
+    [Fact]
+    public void mpeg_Has_Null_IOP()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.MimeType = "video/mpeg-2";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.ImageOptimisationPolicy.Should().BeNull();
+    }
+    
+    [Fact]
+    public void Normal_MP4_Has_IIIF_AV_Delivery_Channel()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.Files = new List<IStoredFile>
+        {
+            new StoredFile { MimeType = "video/mp4" }
+        };
+        pf.MimeType = "video/mp4";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av");
+    }    
+        
+    [Fact]
+    public void Normal_MP4_Has_Null_IOP()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.Files = new List<IStoredFile>
+        {
+            new StoredFile { MimeType = "video/mp4" }  // Mp4 on its own
+        };
+        pf.MimeType = "video/mp4";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.ImageOptimisationPolicy.Should().BeNull();
+    }
+    
+    [Fact]
+    public void Access_MP4_Has_File_Delivery_Channel()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.Files = new List<IStoredFile>
+        {
+            new StoredFile { MimeType = "video/mp4" },       // the access copy
+            new StoredFile { MimeType = "application/mxf" }  // the master
+        };
+        pf.MimeType = "video/mp4";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.DeliveryChannels.Should().OnlyContain(s => s == "file");
+    }    
+        
+    [Fact]
+    public void Access_MP4_Has_None_IOP()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.Files = new List<IStoredFile>
+        {
+            new StoredFile { MimeType = "video/mp4" },       // the access copy
+            new StoredFile { MimeType = "application/mxf" }  // the master
+        };
+        pf.MimeType = "video/mp4";
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.ImageOptimisationPolicy.Should().Be("none");
+    }
+    
+    // Use this to test resolution-specific transcoding - needs the logic in ProcessingBehaviour to change
+    
+    [Fact]
+    public void Resolution_determines_transcode()
+    {
+        var pf = A.Fake<PhysicalFile>();
+        pf.Files = new List<IStoredFile>
+        {
+            new StoredFile { MimeType = "video/mp4" }
+        };
+        pf.MimeType = "video/mp4";
+        var assetMetadata = A.Fake<IAssetMetadata>();
+        A.CallTo(() => assetMetadata.GetMediaDimensions()).Returns(new MediaDimensions { Height = 1440 });
+        pf.AssetMetadata = assetMetadata;
+
+        var processing = pf.ProcessingBehaviour;
+
+        processing.ImageOptimisationPolicy.Should().BeNull();
+        // processing.ImageOptimisationPolicy.Should().Be("QHD");
+        // processing.ImageOptimisationPolicy.Should().Be("HIGHER");
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Ingest/DashboardCloudServicesJobProcessor.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Ingest/DashboardCloudServicesJobProcessor.cs
@@ -300,7 +300,9 @@ namespace Wellcome.Dds.AssetDomainRepositories.Ingest
             var result = new ImageIngestResult();
             if (!syncOperation.HasInvalidAccessCondition)
             {
-                if (usePriorityQueue && syncOperation.DlcsImagesToIngest!.Any(asset => asset.Family != 'I'))
+                // This test used to be  asset.Family != 'I' - is it safe to just use mediaType here? 
+                // do we have any images whose mediaType does not start with image/* ?
+                if (usePriorityQueue && syncOperation.DlcsImagesToIngest!.Any(asset => !asset.MediaType.IsImageMimeType()))
                 {
                     usePriorityQueue = false;
                     logger.LogDebug("SyncOperation contains at least one non-image, so switching to regular queue");

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Xml.Linq;
 using Utils;
 using Wellcome.Dds.AssetDomain;
+using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomain.Mets;
+using Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
 
 namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
 {
@@ -14,6 +16,10 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
         // Only set AssetFamily to Image for born digital mimetypes image/{type} where {type} is one of:
         private static readonly string[] BornDigitalImageTypes = { "jpeg", "tiff" };
 
+        public PhysicalFile()
+        {
+            
+        }
         private PhysicalFile(IWorkStore workStore, string id)
         {
             WorkStore = workStore;
@@ -300,6 +306,9 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                 .ToDictionary(file => (string?) file.Attribute("ID") 
                                       ?? throw new InvalidOperationException("File Element has no ID attribute"));
         }
+
+        private IProcessingBehaviour? processingBehaviour;
+        public IProcessingBehaviour ProcessingBehaviour => processingBehaviour ??= new ProcessingBehaviour(this, false);
     }
     
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
@@ -308,7 +308,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
         }
 
         private IProcessingBehaviour? processingBehaviour;
-        public IProcessingBehaviour ProcessingBehaviour => processingBehaviour ??= new ProcessingBehaviour(this, false);
+        public IProcessingBehaviour ProcessingBehaviour => processingBehaviour ??= new ProcessingBehaviour(
+            this, new ProcessingBehaviourOptions());
     }
     
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
@@ -10,11 +10,11 @@ public class ProcessingBehaviour : IProcessingBehaviour
     public HashSet<string> DeliveryChannels { get; }
     public string? ImageOptimisationPolicy { get; }
 
-    public ProcessingBehaviour(PhysicalFile physicalFile, bool useNamedAVDefaults)
+    public ProcessingBehaviour(PhysicalFile physicalFile, ProcessingBehaviourOptions options)
     {
         DeliveryChannels = new HashSet<string>();
-        string? videoDefault = useNamedAVDefaults ? "video-max" : null;
-        string? audioDefault = useNamedAVDefaults ? "audio-max" : null;
+        string? videoDefault = options.UseNamedAVDefaults ? "video-max" : null;
+        string? audioDefault = options.UseNamedAVDefaults ? "audio-max" : null;
         
         // current DLCS defaults for IOP are simply `video-max` and `audio-max`, which will be chosen by the DLCS
         // if we leave ImageOptimisationPolicy empty.
@@ -24,12 +24,18 @@ public class ProcessingBehaviour : IProcessingBehaviour
         {
             DeliveryChannels.Add("iiif-img");
             DeliveryChannels.Add("thumbs");
-            // deliveryChannels.Add("file"); // if we want to make ALL images available as original
+            if (options.MakeAllSourceImagesAvailable)
+            {
+                DeliveryChannels.Add("file");
+            }
 
             if (physicalFile.MimeType == "image/jp2")
             {
                 ImageOptimisationPolicy = "use-original";
-                // deliveryChannels.Add("file"); // if we want to make the original JP2 available
+                if (options.MakeJP2Available || options.MakeAllSourceImagesAvailable)
+                {   
+                    DeliveryChannels.Add("file");
+                }
             }
         }
 
@@ -51,30 +57,44 @@ public class ProcessingBehaviour : IProcessingBehaviour
         // Video:
         else if (physicalFile.MimeType.IsVideoMimeType())
         {
+            var height = physicalFile.AssetMetadata?.GetMediaDimensions().Height;
+
             if (physicalFile.MimeType == "video/mp4" &&
                 physicalFile.Files!.Exists(f => f.MimeType == "application/mxf"))
             {
                 // At the moment we are saying that if this MP4 accompanies an MXF master,
-                // then it is the access copy and we should just use it as-is.
-                // Later, we may decide that we still want to transcode it into one or more delivery versions.
-                // e.g., if it is a 4K video. So for some mp4s we'd not return "none" here.
-                // We also might decide to send the MXF instead or as well - in which case we need to 
-                // ignore physicalFile.MimeType and look at the actual IStoredFile.
-                ImageOptimisationPolicy = "none";
-                DeliveryChannels.Add("file");
+                // then it is the access copy and we can use it as-is.
+                if (height <= options.MaxUntranscodedAccessMp4 || options.MakeAllAccessMP4sAvailable)
+                {
+                    ImageOptimisationPolicy = "none"; // this IOP is a dummy value, really
+                    DeliveryChannels.Add("file");
+                }
+
+                if (options.MaxUntranscodedAccessMp4 > 0 && height > options.MaxUntranscodedAccessMp4)
+                {
+                    // We still want to transcode it into one or more delivery versions.
+                    // e.g., if it is a 4K video. So for some mp4s we'd not return "none" here.
+                    // We also might decide to send the MXF instead or as well - in which case we need to 
+                    // ignore physicalFile.MimeType and look at the actual IStoredFile.
+                    DeliveryChannels.Add("iiif-av");
+                }
             }
             else
             {
-                // it's not an MXF access MP4, or it's some other non-MP4 video, so we're going to transcode it:
+                // it's not an MXF access MP4, or it's some other non-MP4 video, so we're always going to transcode it:
                 DeliveryChannels.Add("iiif-av");
-                
+            }
+
+            if (DeliveryChannels.Contains("iiif-av"))
+            {
+                // We need to set the ImageOptimsationPolicy
+                // At the moment this always returns videoDefault but the logic is here to do other things.
                 // But what policy are we going to pick? The following allows that to be based on resolution:
-                int? height = physicalFile.AssetMetadata?.GetMediaDimensions().Height;
                 switch (height)
                 {
                     case null or <= 0 or > 5000:
                         // Have a max to catch any weird values.
-                        ImageOptimisationPolicy = videoDefault;  
+                        ImageOptimisationPolicy = videoDefault;
                         break;
                     case <= 720:
                         // dlcs default (probably 720p). 
@@ -88,16 +108,15 @@ public class ProcessingBehaviour : IProcessingBehaviour
                         // QHD (2560 x 1440) or 2K (2048 x 1080)
                         ImageOptimisationPolicy = videoDefault; // "QHD";  
                         break;
-                    
+
                     // and so on, and so on: 4K (3840 x 2160), 8K (7680 x 4320)
-                    
+
                     default:
                         // if here, height is between 1441 and 5000, so maybe use the 1440 setting?
                         // Or send to an HLS setting that will produce a variety of outputs.
                         ImageOptimisationPolicy = videoDefault; // "HIGHER";
                         break;
                 }
-            
             }
         }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using Wellcome.Dds.AssetDomain.DigitalObjects;
+using Wellcome.Dds.AssetDomain.Dlcs;
+using Wellcome.Dds.AssetDomainRepositories.Mets.Model;
+
+namespace Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
+
+public class ProcessingBehaviour : IProcessingBehaviour
+{
+    public HashSet<string> DeliveryChannels { get; }
+    public string? ImageOptimisationPolicy { get; }
+
+    public ProcessingBehaviour(PhysicalFile physicalFile, bool useNamedAVDefaults)
+    {
+        DeliveryChannels = new HashSet<string>();
+        string? videoDefault = useNamedAVDefaults ? "video-max" : null;
+        string? audioDefault = useNamedAVDefaults ? "audio-max" : null;
+        
+        // current DLCS defaults for IOP are simply `video-max` and `audio-max`, which will be chosen by the DLCS
+        // if we leave ImageOptimisationPolicy empty.
+
+        // Images:
+        if (physicalFile.MimeType.IsImageMimeType())
+        {
+            DeliveryChannels.Add("iiif-img");
+            DeliveryChannels.Add("thumbs");
+            // deliveryChannels.Add("file"); // if we want to make ALL images available as original
+
+            if (physicalFile.MimeType == "image/jp2")
+            {
+                ImageOptimisationPolicy = "use-original";
+                // deliveryChannels.Add("file"); // if we want to make the original JP2 available
+            }
+        }
+
+        // Audio:
+        else if (physicalFile.MimeType.IsAudioMimeType())
+        {
+            if (physicalFile.MimeType is "audio/mp3" or "audio/x-mpeg-3")
+            {
+                ImageOptimisationPolicy = "none";
+                DeliveryChannels.Add("file");
+            }
+            else
+            {
+                DeliveryChannels.Add("iiif-av");
+                ImageOptimisationPolicy = audioDefault;
+            }
+        }
+
+        // Video:
+        else if (physicalFile.MimeType.IsVideoMimeType())
+        {
+            if (physicalFile.MimeType == "video/mp4" &&
+                physicalFile.Files!.Exists(f => f.MimeType == "application/mxf"))
+            {
+                // At the moment we are saying that if this MP4 accompanies an MXF master,
+                // then it is the access copy and we should just use it as-is.
+                // Later, we may decide that we still want to transcode it into one or more delivery versions.
+                // e.g., if it is a 4K video. So for some mp4s we'd not return "none" here.
+                // We also might decide to send the MXF instead or as well - in which case we need to 
+                // ignore physicalFile.MimeType and look at the actual IStoredFile.
+                ImageOptimisationPolicy = "none";
+                DeliveryChannels.Add("file");
+            }
+            else
+            {
+                // it's not an MXF access MP4, or it's some other non-MP4 video, so we're going to transcode it:
+                DeliveryChannels.Add("iiif-av");
+                
+                // But what policy are we going to pick? The following allows that to be based on resolution:
+                int? height = physicalFile.AssetMetadata?.GetMediaDimensions().Height;
+                switch (height)
+                {
+                    case null or <= 0 or > 5000:
+                        // Have a max to catch any weird values.
+                        ImageOptimisationPolicy = videoDefault;  
+                        break;
+                    case <= 720:
+                        // dlcs default (probably 720p). 
+                        ImageOptimisationPolicy = videoDefault;
+                        break;
+                    case <= 1080:
+                        // HD (1920 x 1080)
+                        ImageOptimisationPolicy = videoDefault; // "HD";
+                        break;
+                    case <= 1440:
+                        // QHD (2560 x 1440) or 2K (2048 x 1080)
+                        ImageOptimisationPolicy = videoDefault; // "QHD";  
+                        break;
+                    
+                    // and so on, and so on: 4K (3840 x 2160), 8K (7680 x 4320)
+                    
+                    default:
+                        // if here, height is between 1441 and 5000, so maybe use the 1440 setting?
+                        // Or send to an HLS setting that will produce a variety of outputs.
+                        ImageOptimisationPolicy = videoDefault; // "HIGHER";
+                        break;
+                }
+            
+            }
+        }
+
+        // Files:
+        else
+        {
+            ImageOptimisationPolicy = "none";
+            DeliveryChannels.Add("file");
+        }
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviourOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviourOptions.cs
@@ -1,0 +1,10 @@
+namespace Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
+
+public class ProcessingBehaviourOptions
+{
+    public bool UseNamedAVDefaults { get; set; } = false;
+    public bool MakeAllSourceImagesAvailable { get; set; } = false;
+    public bool MakeJP2Available { get; set; } = true;
+    public int MaxUntranscodedAccessMp4 { get; set; } = 720;
+    public bool MakeAllAccessMP4sAvailable { get; set; } = true;
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -75,25 +75,5 @@
         public string? IncludeExtraAccessConditionsInManifest { get; set; }
         
         public int PlaceholderCanvasCacheTimeDays { get; set; }
-
-        /// <summary>
-        /// If an internet type (mediaType, mimeType) is in this list, it will also be made available on the
-        /// file delivery channel. This list is for images, audio and video; Other media types are automatically included.
-        /// This could be a DLCS configuration at some point in the future (providing a default list)
-        /// This list can accept wildcards such as image/*
-        /// </summary>
-        public string[] MediaTypesForFileDelivery { get; set; } = System.Array.Empty<string>();
-        
-        /// <summary>
-        /// This is an additional setting to easily say "all images are on file path EXCEPT the JP2s"
-        /// </summary>
-        public bool ExcludeJP2FromFileDelivery { get; set; } = false;
-        
-        // We might need another exclude list? What's the best way to configure this declaratively?
-        
-        // A media Delivery Options class?
-   
-
-
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.Design.Serialization;
-
-namespace Wellcome.Dds.Common
+﻿namespace Wellcome.Dds.Common
 {
     // Which class Library does this class live in?
     public class DdsOptions

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -75,5 +75,25 @@
         public string? IncludeExtraAccessConditionsInManifest { get; set; }
         
         public int PlaceholderCanvasCacheTimeDays { get; set; }
+
+        /// <summary>
+        /// If an internet type (mediaType, mimeType) is in this list, it will also be made available on the
+        /// file delivery channel. This list is for images, audio and video; Other media types are automatically included.
+        /// This could be a DLCS configuration at some point in the future (providing a default list)
+        /// This list can accept wildcards such as image/*
+        /// </summary>
+        public string[] MediaTypesForFileDelivery { get; set; } = System.Array.Empty<string>();
+        
+        /// <summary>
+        /// This is an additional setting to easily say "all images are on file path EXCEPT the JP2s"
+        /// </summary>
+        public bool ExcludeJP2FromFileDelivery { get; set; } = false;
+        
+        // We might need another exclude list? What's the best way to configure this declaratively?
+        
+        // A media Delivery Options class?
+   
+
+
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Wellcome.Dds.Common
+﻿using System.ComponentModel.Design.Serialization;
+
+namespace Wellcome.Dds.Common
 {
     // Which class Library does this class live in?
     public class DdsOptions

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -562,7 +562,7 @@
                         <th>Order</th>
                         <th>Size</th>
                         <th>Format</th>
-                        <th>Length</th>
+                        <th>Dimensions</th>
                         <th>Access</th>
                         <th>DLCS</th>
                             @*<th>Transcode</th>*@
@@ -601,7 +601,16 @@
                                 <td><small>@pf.AssetMetadata.GetFormatName()</small></td>
                                 if (Model.ManifestationFamily == AssetFamily.TimeBased)
                                 {
-                                    <td>@pf.AssetMetadata.GetDisplayDuration()</td>
+                                    var mediaDims = pf.AssetMetadata.GetMediaDimensions();
+                                    <td>
+                                        @pf.AssetMetadata.GetDisplayDuration()
+                                        @if (mediaDims.Height > 0)
+                                        {
+                                            <br/>@mediaDims.Width
+                                            <text> x </text>
+                                            @mediaDims.Height
+                                        }
+                                    </td>
                                 }
                                 else
                                 {
@@ -675,9 +684,9 @@
                                 <td class="adjunct"><span>&#10551;</span> @adjunct.Use</td>
                                 @if (adjunct.Family == AssetFamily.Image)
                                 {
-                                    <td><small>@adjunct.AssetMetadata?.GetImageWidth() x @adjunct.AssetMetadata?.GetImageHeight()</small></td>
+                                    <td>@StringUtils.FormatFileSize(adjunct.AssetMetadata.GetFileSize())</td>
                                     <td><small>@adjunct.AssetMetadata?.GetFormatName()</small></td>
-                                    <td></td>                                                         
+                                    <td><small>@adjunct.AssetMetadata?.GetImageWidth() x @adjunct.AssetMetadata?.GetImageHeight()</small></td>                                                         
                                 }
                                 else
                                 {

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
@@ -139,9 +139,9 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
         {
             return new AuthProbeService2
             {
-                Id = uriPatterns.DlcsProbeServiceV2(dlcsEntryPoint, assetIdentifier),
-                ErrorHeading = new LanguageMap("en", ClickthroughFailureHeader),
-                ErrorNote = new LanguageMap("en", ClickthroughFailureDescription)
+                Id = uriPatterns.DlcsProbeServiceV2(dlcsEntryPoint, assetIdentifier)
+                // ErrorHeading = new LanguageMap("en", ClickthroughFailureHeader),
+                // ErrorNote = new LanguageMap("en", ClickthroughFailureDescription)
             };
         }
         
@@ -149,9 +149,9 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
         {
             return new AuthProbeService2
             {
-                Id = uriPatterns.DlcsProbeServiceV2(dlcsEntryPoint, assetIdentifier),
-                ErrorHeading = new LanguageMap("en", ClinicalFailureDescription),
-                ErrorNote = new LanguageMap("en", ClinicalFailureDescription),
+                Id = uriPatterns.DlcsProbeServiceV2(dlcsEntryPoint, assetIdentifier)
+                // ErrorHeading = new LanguageMap("en", ClinicalFailureDescription),
+                // ErrorNote = new LanguageMap("en", ClinicalFailureDescription),
             };
         }
         
@@ -159,9 +159,9 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
         {
             return new AuthProbeService2
             {
-                Id = uriPatterns.DlcsProbeServiceV2(dlcsEntryPoint, assetIdentifier),
-                ErrorHeading = new LanguageMap("en", RestrictedHeader),
-                ErrorNote = new LanguageMap("en", RestrictedFailureDescription)
+                Id = uriPatterns.DlcsProbeServiceV2(dlcsEntryPoint, assetIdentifier)
+                // ErrorHeading = new LanguageMap("en", RestrictedHeader),
+                // ErrorNote = new LanguageMap("en", RestrictedFailureDescription)
             };
         }
         

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -75,7 +75,8 @@ namespace Wellcome.Dds.Repositories.Presentation
                 uriPatterns,
                 dlcsOptions.Value.ResourceEntryPoint,
                 ddsOptions.Value.ReferenceV0SearchService,
-                ddsOptions.Value.IncludeExtraAccessConditionsInManifest.SplitByDelimiterIntoArray(','));
+                ddsOptions.Value.IncludeExtraAccessConditionsInManifest.SplitByDelimiterIntoArray(','),
+                dlcsOptions.Value.SupportsDeliveryChannels);
             presentation2Converter = new PresentationConverter(uriPatterns, logger);
         }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -504,6 +504,8 @@ namespace Wellcome.Dds.Repositories.Presentation
                             
                             // Also add the same videos as renderings for download:
                             canvas.Rendering ??= new List<ExternalResource>();
+                            
+                            // Now add auth services, and add them to the rendering
                             foreach (var paintable in avChoice.Items)
                             {
                                 if (paintable is ResourceBase resource)

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -405,12 +405,14 @@ namespace Wellcome.Dds.Repositories.Presentation
 
                         if (useDeliveryChannels && physicalFile.ProcessingBehaviour.DeliveryChannels.Contains("file"))
                         {
+                            var label = physicalFile.MimeType == "image/jp2" ? "JPEG 2000" : physicalFile.MimeType;
                             canvas.Rendering ??= new List<ExternalResource>();
                             canvas.Rendering.Add(
                                 new Image
                                 {
                                     Id = uriPatterns.DlcsFile(dlcsEntryPoint, physicalFile.StorageIdentifier),
-                                    Format = physicalFile.MimeType
+                                    Format = physicalFile.MimeType,
+                                    Label = Lang.Map(label ?? "(unknown format)")
                                 }
                             );
                         }
@@ -499,11 +501,14 @@ namespace Wellcome.Dds.Repositories.Presentation
                                 }
                             };
                             
+                            // Also add the same videos as renderings for download:
+                            canvas.Rendering ??= new List<ExternalResource>();
                             foreach (var paintable in avChoice.Items)
                             {
                                 if (paintable is ResourceBase resource)
                                 {
                                     AddAuthServices(resource, physicalFile, foundAuthServices);
+                                    canvas.Rendering.Add((ExternalResource)resource);
                                 }
                             }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.sln.DotSettings
+++ b/src/Wellcome.Dds/Wellcome.Dds.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JP/@EntryIndexedValue">JP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UV/@EntryIndexedValue">UV</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ADMID/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=altref/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
(see examples below)

This PR is onto #204 

After many failed starts I decided to do it programmatically rather than through config.

I was trying to determine delivery channel and IOP independently, as properties of IPhysicalFile, but they are interrelated and the logic is much simpler if they are determined together.

This PR shows how the IOP and Delivery Channels are determined and then used to synch with the DLCS, and also how they are used when generating the manifest - whether to use a /file/ path to the asset or the AV path.

