### PR TITLE
Sns sqs workflow

### DIFF
--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.json
@@ -60,7 +60,7 @@
     "LinkedDataDomain": "https://iiif.wellcomecollection.org",
     "AvoidCaching": false,
     "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
+    "MinimumJobAgeMinutes": 1,
     "CacheBuster": "TODO - may not need these but if we do it's an object { }",
     "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
     "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",

--- a/src/Wellcome.Dds/Utils.Aws/SQS/QueueMessage.cs
+++ b/src/Wellcome.Dds/Utils.Aws/SQS/QueueMessage.cs
@@ -10,6 +10,14 @@ namespace Utils.Aws.SQS;
 /// </summary>
 public class QueueMessage
 {
+    public QueueMessage(JObject body, Dictionary<string, string> attributes, string messageId, string queueName)
+    {
+        Body = body;
+        Attributes = attributes;
+        MessageId = messageId;
+        QueueName = queueName;
+    }
+
     /// <summary>
     /// The full message body property
     /// </summary>
@@ -55,7 +63,7 @@ public static class QueueMessageX
             try
             {
                 var value = queueMessage.Body[messageKey]!.Value<string>();
-                return JObject.Parse(value);
+                return value.HasText() ? JObject.Parse(value) : null;
             }
             catch (Exception)
             {

--- a/src/Wellcome.Dds/Utils.Aws/SQS/QueueMessage.cs
+++ b/src/Wellcome.Dds/Utils.Aws/SQS/QueueMessage.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Utils.Aws.SQS;
+
+/// <summary>
+/// Generic representation of message pulled from queue.
+/// Adapted from protagonist for NewtonSoft.JSON
+/// </summary>
+public class QueueMessage
+{
+    /// <summary>
+    /// The full message body property
+    /// </summary>
+    public JObject Body { get; set; }
+
+    /// <summary>
+    /// Any attributes associated with message
+    /// </summary>
+    public Dictionary<string, string> Attributes { get; set; }
+        
+    /// <summary>
+    /// Unique identifier for message
+    /// </summary>
+    public string MessageId { get; set; }
+    
+    /// <summary>
+    /// The name of the queue that this message was from
+    /// </summary>
+    public string QueueName { get; set; }
+}
+
+public static class QueueMessageX
+{
+    /// <summary>
+    /// Get a <see cref="JsonObject"/> representing the contents of the message as raised by source system. This helps
+    /// when the message can be from SNS->SQS, SNS->SQS with RawDelivery or SQS directly.
+    /// 
+    /// If originating from SNS and Raw Message Delivery is disabled (default) then the <see cref="QueueMessage"/>
+    /// object will have additional fields about topic etc, and the message will be embedded in a "Message" property.
+    /// e.g. { "Type": "Notification", "MessageId": "1234", "Message": { \"key\": \"value\" } }
+    /// 
+    /// If originating from SQS, or from SNS with Raw Message Delivery enabled, the <see cref="QueueMessage"/> Body
+    /// property will contain the full message only.
+    /// e.g. { "key": "value" }
+    /// </summary>
+    /// <remarks>See https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html </remarks>
+    public static JObject? GetMessageContents(this QueueMessage queueMessage)
+    {
+        const string messageKey = "Message";
+        if (queueMessage.Body.ContainsKey("TopicArn") && queueMessage.Body.ContainsKey(messageKey))
+        {
+            // From SNS without Raw Message Delivery
+            try
+            {
+                var value = queueMessage.Body[messageKey]!.Value<string>();
+                return JObject.Parse(value);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        // From SQS or SNS with Raw Message Delivery
+        return queueMessage.Body;
+    }
+} 

--- a/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
+++ b/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
       <PackageReference Include="AWSSDK.S3" Version="3.7.9.18" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="protobuf-net" Version="3.1.4" />
     </ItemGroup>
 

--- a/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
+++ b/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
@@ -17,4 +17,10 @@
       <PackageReference Include="protobuf-net" Version="3.1.4" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Reference Include="Newtonsoft.Json">
+        <HintPath>..\..\..\..\..\..\.nuget\packages\newtonsoft.json\13.0.1\lib\netstandard2.0\Newtonsoft.Json.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
 </Project>

--- a/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
+++ b/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
@@ -18,10 +18,4 @@
       <PackageReference Include="protobuf-net" Version="3.1.4" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Reference Include="Newtonsoft.Json">
-        <HintPath>..\..\..\..\..\..\.nuget\packages\newtonsoft.json\13.0.1\lib\netstandard2.0\Newtonsoft.Json.dll</HintPath>
-      </Reference>
-    </ItemGroup>
-
 </Project>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/StorageOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/StorageOptions.cs
@@ -12,7 +12,5 @@
         public int MapHttpRuntimeCacheSeconds { get; set; }
         public bool PreferCachedStorageMap { get; set; }
         public int MaxAgeStorageMap { get; set; }
-        
-        public string? WorkflowMessageTopic { get; set; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -65,8 +65,10 @@
         public string? AnnotationContainer { get; set; }
         
         // Workflow
-        public string[]? WorkflowMessageQueues { get; set; }
+        public string[]? WorkflowMessageListenQueues { get; set; }
         public bool WorkflowMessagePoll { get; set; }
+        public string? DashboardPushBornDigitalQueue { get; set; }
+        public string? DashboardPushDigitisedQueue { get; set; }
         
         public bool ReferenceV0SearchService { get; set; }
         public bool UseRequiredStatement { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -65,7 +65,7 @@
         public string? AnnotationContainer { get; set; }
         
         // Workflow
-        public string? WorkflowMessageQueue { get; set; }
+        public string[]? WorkflowMessageQueues { get; set; }
         public bool WorkflowMessagePoll { get; set; }
         
         public bool ReferenceV0SearchService { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using Amazon.SimpleNotificationService;
+using Amazon.SQS;
 using DlcsWebClient.Config;
 using DlcsWebClient.Dlcs;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -73,6 +74,7 @@ namespace Wellcome.Dds.Dashboard
             var storageAwsOptions = Configuration.GetAWSOptions("Storage-AWS");
             services.AddDefaultAWSOptions(ddsAwsOptions);   
             services.AddAWSService<IAmazonSimpleNotificationService>(storageAwsOptions);
+            services.AddAWSService<IAmazonSQS>(ddsAwsOptions);
 
             var dlcsSection = Configuration.GetSection("Dlcs");
             var dlcsOptions = dlcsSection.Get<DlcsOptions>();

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -374,7 +374,7 @@
                 <a href="@Url.Action("Create", "WorkflowCall", new {id = Model.DdsIdentifier.PackageIdentifierPathElementSafe})"><span class="glyphicon glyphicon-bullhorn"></span> Simulate workflow message</a>
             </li>   
             <li class="list-group-item">
-                <a href="@Url.Action("NotifyTopic", "WorkflowCall", new {id = Model.DdsIdentifier.PackageIdentifierPathElementSafe})"><span class="glyphicon glyphicon-bullhorn"></span> Notify workflow topic (SNS)</a>
+                <a href="@Url.Action("PutWorkflowMessageOnQueue", "WorkflowCall", new {id = Model.DdsIdentifier.PackageIdentifierPathElementSafe})"><span class="glyphicon glyphicon-bullhorn"></span> Push to workflow queue (SQS)</a>
             </li>
             @foreach (var job in Model.IngestJobs)
             {

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/WorkflowCall/WorkflowCall.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/WorkflowCall/WorkflowCall.cshtml
@@ -30,7 +30,7 @@
     {
         <div class="alert alert-success alert-dismissible" role="alert">
             <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <strong>Success!</strong> A notification has been sent to the Workflow topic, and the job will be picked up by the workflow processor.
+            <strong>Success!</strong> A message has been sent to the Workflow queue, and the job will be picked up by the workflow processor.
             @if (Model.Created.HasValue)
             {
                 <span>(The workflow call below is the previous call for this item.)</span>
@@ -41,7 +41,7 @@
     {
         <div class="alert alert-danger alert-dismissible" role="alert">
             <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <strong>Failed to notify workflow topic!</strong> @TempData["new-workflow-notification-error"]
+            <strong>Failed to notify workflow queue!</strong> @TempData["new-workflow-notification-error"]
         </div>
     }
     @if (TempData["job-deleted"] != null)

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/WorkflowCall/WorkflowCall.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/WorkflowCall/WorkflowCall.cshtml
@@ -63,7 +63,7 @@ else
 
 <ul class="list-group">
     <li class="list-group-item"><a href="@Url.Action("Create", "WorkflowCall", new {id = ddsId.PathElementSafe})"><span class="glyphicon glyphicon-bullhorn"></span> Simulate Workflow Call</a></li>
-    <li class="list-group-item"><a href="@Url.Action("NotifyTopic", "WorkflowCall", new {id = ddsId.PathElementSafe})"><span class="glyphicon glyphicon-bullhorn"></span> Notify workflow topic (SNS)</a></li>
+    <li class="list-group-item"><a href="@Url.Action("PutWorkflowMessageOnQueue", "WorkflowCall", new {id = ddsId.PathElementSafe})"><span class="glyphicon glyphicon-bullhorn"></span> Push to workflow queue (SQS)</a></li>
     <li class="list-group-item">@Html.ActionLink("DDS View of " + ddsId, "Manifestation", "Dash", new {id = ddsId.PathElementSafe}, new {})</li>
     <li class="list-group-item"><a href="@Url.Action("StorageManifest", "Peek", new {id = ddsId.PathElementSafe})">Storage Manifest</a></li>
     <li class="list-group-item"><a href="@Url.Action("XmlView", "Peek", new {id = ddsId.PathElementSafe, parts = ddsId.PathElementSafe + ".xml"})">METS file</a></li>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.81" />
     <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
@@ -217,4 +217,10 @@
     <Folder Include="Pages" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="AWSSDK.SQS">
+      <HintPath>..\..\..\..\..\..\.nuget\packages\awssdk.sqs\3.7.2.115\lib\netcoreapp3.1\AWSSDK.SQS.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
  </Project>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj
@@ -218,10 +218,4 @@
     <Folder Include="Pages" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="AWSSDK.SQS">
-      <HintPath>..\..\..\..\..\..\.nuget\packages\awssdk.sqs\3.7.2.115\lib\netcoreapp3.1\AWSSDK.SQS.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
  </Project>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Production.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Production.json
@@ -18,7 +18,9 @@
     "TextContainer": "wellcomecollection-iiif-text",
     "AnnotationContainer": "wellcomecollection-iiif-annotations",
     "MinimumJobAgeMinutes": 10,
-    "PlaceholderCanvasCacheTimeDays": 28
+    "PlaceholderCanvasCacheTimeDays": 28,
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-prod",
+    "DashboardPushDigitisedQueue": "digitised-notifications-prod"
   },
   "Dash": {
     "JobProcessorName": "job-processor-prod",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
@@ -25,7 +25,9 @@
     "TextContainer": "wellcomecollection-stage-new-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-new-iiif-annotations",
     "IncludeExtraAccessConditionsInManifest": "Missing,Unknown",
-    "PlaceholderCanvasCacheTimeDays": 0
+    "PlaceholderCanvasCacheTimeDays": 0,
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging-new",
+    "DashboardPushDigitisedQueue": "digitised-notifications-staging-new"
   },
   "Dash": {
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
@@ -22,7 +22,9 @@
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
     "IncludeExtraAccessConditionsInManifest": "Missing,Unknown",
-    "PlaceholderCanvasCacheTimeDays": 0
+    "PlaceholderCanvasCacheTimeDays": 0,
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-test",
+    "DashboardPushDigitisedQueue": "digitised-notifications-test"
   },
   "Dash": {
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
@@ -22,7 +22,9 @@
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
     "IncludeExtraAccessConditionsInManifest": "Missing,Unknown",
-    "PlaceholderCanvasCacheTimeDays": 0
+    "PlaceholderCanvasCacheTimeDays": 0,
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging",
+    "DashboardPushDigitisedQueue": "digitised-notifications-staging"
   },
   "Dash": {
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
@@ -52,7 +52,7 @@
     "LinkedDataDomain": "https://iiif.wellcomecollection.org",
     "AvoidCaching": false,
     "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
+    "MinimumJobAgeMinutes": 10,
     "CacheBuster": "TODO - may not need these but if we do it's an object { }",
     "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
     "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.json
@@ -62,7 +62,7 @@
     "LinkedDataDomain": "https://iiif.wellcomecollection.org",
     "AvoidCaching": false,
     "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
+    "MinimumJobAgeMinutes": 1,
     "CacheBuster": "TODO - may not need these but if we do it's an object { }",
     "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
     "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.14" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.115" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.81" />
     <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.6" />

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
@@ -352,15 +352,36 @@ namespace WorkflowProcessor
             logger.LogInformation($"Job {job.Identifier} created with options {displayString}");
         }
 
+        private async Task<Dictionary<string, string>> GetPollQueues(CancellationToken cancellationToken)
+        {
+            var dict = new Dictionary<string, string>();
+            if (ddsOptions.WorkflowMessagePoll && 
+                ddsOptions.WorkflowMessageQueues != null && 
+                ddsOptions.WorkflowMessageQueues.HasItems())
+            {
+                foreach (var queueName in ddsOptions.WorkflowMessageQueues)
+                {
+                    string queueUrl = null;
+                    try
+                    {
+                        var result = await sqsClient.GetQueueUrlAsync(queueName, cancellationToken);
+                        queueUrl = result.QueueUrl;
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError(e, "Could not resolve queue name {queueName}", queueName);
+                    }
+                    dict.Add(queueName, queueUrl);
+                }
+            }
+
+            return dict;
+        }
+
         private async Task PollForWorkflowJobs(CancellationToken cancellationToken)
         {
             int waitMs = 2;
-            string queueUrl = null;
-            if (ddsOptions.WorkflowMessagePoll && ddsOptions.WorkflowMessageQueue.HasText())
-            {
-                var result = await sqsClient.GetQueueUrlAsync(ddsOptions.WorkflowMessageQueue, cancellationToken);
-                queueUrl = result.QueueUrl;
-            }
+            var queues = await GetPollQueues(cancellationToken);
             while (!cancellationToken.IsCancellationRequested)
             {
                 try
@@ -386,7 +407,7 @@ namespace WorkflowProcessor
                             if (waitMs > 10000)
                             {
                                 // idle more than 30s
-                                await PollQueue(queueUrl, dbContext, cancellationToken);
+                                await PollQueues(queues, dbContext, cancellationToken);
                             }
                             continue;
                         }
@@ -415,45 +436,56 @@ namespace WorkflowProcessor
             logger.LogInformation("Cancellation requested in WorkflowProcessor, shutting down.");
         }
 
-        private async Task PollQueue(string queueUrl, DdsInstrumentationContext dbContext, CancellationToken cancellationToken)
+        private async Task PollQueues(Dictionary<string, string> queues, DdsInstrumentationContext dbContext, CancellationToken cancellationToken)
         {
-            if (queueUrl.IsNullOrWhiteSpace())
+            if (queues.Keys.Count == 0)
             {
+                logger.LogInformation("No queues configured to poll");
                 return;
             }
-            
-            var response = await sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
+
+            foreach (var queue in queues)
             {
-                QueueUrl = queueUrl,
-                WaitTimeSeconds = 5,
-                MaxNumberOfMessages = 10,
-            }, cancellationToken);
-            var messageCount = response.Messages?.Count ?? 0;
-            if (messageCount > 0)
-            {
-                try
+                if (queue.Value.IsNullOrWhiteSpace())
                 {
-                    foreach (var message in response!.Messages!)
-                    {
-                        if (cancellationToken.IsCancellationRequested) return;
-                        var body = JObject.Parse(message.Body)["Message"]!.ToString();
-                        var workflowMessage = JsonConvert.DeserializeObject<WorkflowMessage>(body);
-                        if (workflowMessage != null)
-                        {
-                            await dbContext.PutJob(workflowMessage.Identifier, 
-                                true, false, null, false, false);
-                            await dbContext.SaveChangesAsync(cancellationToken);
-                        }
-                        await sqsClient.DeleteMessageAsync(new DeleteMessageRequest
-                        {
-                            QueueUrl = queueUrl,
-                            ReceiptHandle = message.ReceiptHandle
-                        }, cancellationToken);
-                    }
+                    logger.LogWarning("Queue with name {queueName} has no URL", queue.Key);
+                    continue;
                 }
-                catch (Exception ex)
+                var response = await sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
                 {
-                    logger.LogError(ex, "Error in listen loop for queue {Queue}", queueUrl);
+                    QueueUrl = queue.Value,
+                    WaitTimeSeconds = 5,
+                    MaxNumberOfMessages = 10,
+                }, cancellationToken);
+                var messageCount = response.Messages?.Count ?? 0;
+                if (messageCount > 0)
+                {
+                    logger.LogDebug("Received {messageCount} message(s) from queue {queueName}", messageCount, queue.Key);
+                    try
+                    {
+                        foreach (var message in response!.Messages!)
+                        {
+                            if (cancellationToken.IsCancellationRequested) return;
+                            var body = JObject.Parse(message.Body)["Message"]!.ToString();
+                            var workflowMessage = JsonConvert.DeserializeObject<WorkflowMessage>(body);
+                            if (workflowMessage != null)
+                            {
+                                await dbContext.PutJob(workflowMessage.Identifier, 
+                                    true, false, null, false, false);
+                                await dbContext.SaveChangesAsync(cancellationToken);
+                            }
+                            await sqsClient.DeleteMessageAsync(new DeleteMessageRequest
+                            {
+                                QueueUrl = queue.Value,
+                                ReceiptHandle = message.ReceiptHandle
+                            }, cancellationToken);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Error in listen loop for queue {queueName}, {queueUrl}", 
+                            queue.Key, queue.Value);
+                    }
                 }
             }
         }

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
@@ -480,7 +480,7 @@ namespace WorkflowProcessor
                             if (workflowMessage != null)
                             {
                                 await dbContext.PutJob(workflowMessage.Identifier, 
-                                    true, false, null, false, false);
+                                    true, false, null, false, true);
                                 await dbContext.SaveChangesAsync(cancellationToken);
                             }
                             await sqsClient.DeleteMessageAsync(new DeleteMessageRequest
@@ -506,7 +506,7 @@ namespace WorkflowProcessor
                 using var scope = serviceScopeFactory.CreateScope();
                 var dbContext = scope.ServiceProvider.GetRequiredService<DdsInstrumentationContext>();
                 
-                var workflowJob = await dbContext.PutJob(identifier, true, true, workflowOptions, false, false);
+                var workflowJob = await dbContext.PutJob(identifier, true, true, workflowOptions, false, true);
                 
                 var runner = GetWorkflowRunner(scope);
                 await runner.ProcessJob(workflowJob, stoppingToken);

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Utils;
 using Utils.Aws.SQS;
@@ -357,10 +356,10 @@ namespace WorkflowProcessor
         {
             var dict = new Dictionary<string, string>();
             if (ddsOptions.WorkflowMessagePoll && 
-                ddsOptions.WorkflowMessageQueues != null && 
-                ddsOptions.WorkflowMessageQueues.HasItems())
+                ddsOptions.WorkflowMessageListenQueues != null && 
+                ddsOptions.WorkflowMessageListenQueues.HasItems())
             {
-                foreach (var queueName in ddsOptions.WorkflowMessageQueues)
+                foreach (var queueName in ddsOptions.WorkflowMessageListenQueues)
                 {
                     string queueUrl = null;
                     try

--- a/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
+++ b/src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessorService.cs
@@ -468,12 +468,12 @@ namespace WorkflowProcessor
                             if (cancellationToken.IsCancellationRequested) return;
 
                             var queueMessage = new QueueMessage
-                            {
-                                Attributes = message.Attributes,
-                                Body = JObject.Parse(message.Body),
-                                MessageId = message.MessageId,
-                                QueueName = queue.Key
-                            };
+                            (
+                                JObject.Parse(message.Body),
+                                message.Attributes,
+                                message.MessageId,
+                                queue.Key
+                            );
 
                             var body = queueMessage.GetMessageContents();
                             var workflowMessage = body.ToObject<WorkflowMessage>();

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Production.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Production.json
@@ -26,9 +26,7 @@
       "born-digital-notifications-prod",
       "digitised-notifications-prod"
     ],
-    "WorkflowMessagePoll": false,
-    "DashboardPushBornDigitalQueue": "born-digital-notifications-prod",
-    "DashboardPushDigitisedQueue": "digitised-notifications-prod"
+    "WorkflowMessagePoll": false
   },
   "Storage": {
     "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Production.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Production.json
@@ -22,7 +22,10 @@
     "TextContainer": "wellcomecollection-iiif-text",
     "AnnotationContainer": "wellcomecollection-iiif-annotations",
     "MinimumJobAgeMinutes": 10,
-    "WorkflowMessageQueue": "born-digital-notifications-prod",
+    "WorkflowMessageQueues": [
+      "born-digital-notifications-prod",
+      "digitised-notifications-prod"
+    ],
     "WorkflowMessagePoll": false
   },
   "Storage": {

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Production.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Production.json
@@ -22,11 +22,13 @@
     "TextContainer": "wellcomecollection-iiif-text",
     "AnnotationContainer": "wellcomecollection-iiif-annotations",
     "MinimumJobAgeMinutes": 10,
-    "WorkflowMessageQueues": [
+    "WorkflowMessageListenQueues": [
       "born-digital-notifications-prod",
       "digitised-notifications-prod"
     ],
-    "WorkflowMessagePoll": false
+    "WorkflowMessagePoll": false,
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-prod",
+    "DashboardPushDigitisedQueue": "digitised-notifications-prod"
   },
   "Storage": {
     "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
@@ -24,6 +24,7 @@
     "PresentationContainer": "wellcomecollection-stage-new-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-new-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-new-iiif-annotations",
+    "MinimumJobAgeMinutes": 1,
     "WorkflowMessageListenQueues": [
       "born-digital-notifications-staging-new",
       "digitised-notifications-staging-new"

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
@@ -24,11 +24,13 @@
     "PresentationContainer": "wellcomecollection-stage-new-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-new-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-new-iiif-annotations",
-    "WorkflowMessageQueues": [
+    "WorkflowMessageListenQueues": [
       "born-digital-notifications-staging-new",
       "digitised-notifications-staging-new"
     ],
-    "WorkflowMessagePoll": false
+    "WorkflowMessagePoll": false,
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging-new",
+    "DashboardPushDigitisedQueue": "digitised-notifications-staging-new"
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
@@ -24,7 +24,10 @@
     "PresentationContainer": "wellcomecollection-stage-new-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-new-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-new-iiif-annotations",
-    "WorkflowMessageQueue": "born-digital-notifications-staging",
+    "WorkflowMessageQueues": [
+      "born-digital-notifications-staging-new",
+      "digitised-notifications-staging-new"
+    ],
     "WorkflowMessagePoll": false
   },
   "Storage": {

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
@@ -28,9 +28,7 @@
       "born-digital-notifications-staging-new",
       "digitised-notifications-staging-new"
     ],
-    "WorkflowMessagePoll": false,
-    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging-new",
-    "DashboardPushDigitisedQueue": "digitised-notifications-staging-new"
+    "WorkflowMessagePoll": false
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
@@ -29,7 +29,7 @@
       "born-digital-notifications-staging-new",
       "digitised-notifications-staging-new"
     ],
-    "WorkflowMessagePoll": false
+    "WorkflowMessagePoll": true
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
@@ -21,11 +21,13 @@
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
-    "WorkflowMessageQueues": [
+    "WorkflowMessageListenQueues": [
       "born-digital-notifications-test",
       "digitised-notifications-test"
     ],
-    "WorkflowMessagePoll": false
+    "WorkflowMessagePoll": false,
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-test",
+    "DashboardPushDigitisedQueue": "digitised-notifications-test"
   },
   "Storage": {
     "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
@@ -25,9 +25,7 @@
       "born-digital-notifications-test",
       "digitised-notifications-test"
     ],
-    "WorkflowMessagePoll": false,
-    "DashboardPushBornDigitalQueue": "born-digital-notifications-test",
-    "DashboardPushDigitisedQueue": "digitised-notifications-test"
+    "WorkflowMessagePoll": false
   },
   "Storage": {
     "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
@@ -21,7 +21,10 @@
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
-    "WorkflowMessageQueue": "born-digital-notifications-prod",
+    "WorkflowMessageQueues": [
+      "born-digital-notifications-test",
+      "digitised-notifications-test"
+    ],
     "WorkflowMessagePoll": false
   },
   "Storage": {

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
@@ -21,6 +21,7 @@
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
+    "MinimumJobAgeMinutes": 10,
     "WorkflowMessageListenQueues": [
       "born-digital-notifications-test",
       "digitised-notifications-test"

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
@@ -21,6 +21,7 @@
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
+    "MinimumJobAgeMinutes": 10,
     "WorkflowMessageListenQueues": [
       "born-digital-notifications-staging",
       "digitised-notifications-staging"

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
@@ -21,7 +21,10 @@
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
-    "WorkflowMessageQueue": "born-digital-notifications-staging",
+    "WorkflowMessageQueues": [
+      "born-digital-notifications-staging",
+      "digitised-notifications-staging"
+    ],
     "WorkflowMessagePoll": false
   },
   "Storage": {

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
@@ -21,11 +21,13 @@
     "PresentationContainer": "wellcomecollection-stage-iiif-presentation",
     "TextContainer": "wellcomecollection-stage-iiif-text",
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
-    "WorkflowMessageQueues": [
+    "WorkflowMessageListenQueues": [
       "born-digital-notifications-staging",
       "digitised-notifications-staging"
     ],
-    "WorkflowMessagePoll": false
+    "WorkflowMessagePoll": false,
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging",
+    "DashboardPushDigitisedQueue": "digitised-notifications-staging"
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
@@ -25,9 +25,7 @@
       "born-digital-notifications-staging",
       "digitised-notifications-staging"
     ],
-    "WorkflowMessagePoll": false,
-    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging",
-    "DashboardPushDigitisedQueue": "digitised-notifications-staging"
+    "WorkflowMessagePoll": false
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/{0}/{1}",

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.json
@@ -65,7 +65,7 @@
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
     "AvoidCaching": false,
     "EarliestJobDateTime": "2016-07-07",
-    "MinimumJobAgeMinutes": 0,
+    "MinimumJobAgeMinutes": 10,
     "CacheBuster": "TODO - may not need these but if we do it's an object { }",
     "JobProcessorLog": "<firelens equivalent of> DlcsJobProcessor-ProcessQueue.log",
     "WorkflowProcessorLog": "<firelens equivalent of> WorkflowProcessor.log",


### PR DESCRIPTION
This goes with https://github.com/wellcomecollection/iiif-builder-infrastructure/pull/54, which has only been applied to stage-new.

The dashboard and workflowprocessor now only deal with DDS-infra queues - dash writes, wfp reads.

(adapted from "mini RFC"):

## Workflow queues and topics - questions/decisions

There are two existing SNS topics owned by _*storage*_:

- born-digital-bag-notifications-prod
- born-digital-bag-notifications-staging

We think there will be two new SNS topics for Goobi:

- digitised-bag-notifications-prod
- digitised-bag-notifications-staging

_(or similar names: "born-digital" and "digitised" match the current storage prefixes)_

At the time these first two topics were created, queues were also created, subscribing to these topics:

* arn:aws:sqs:eu-west-1:975596993436:born-digital-notifications-prod (in storage acct)
* arn:aws:sqs:eu-west-1:653428163053:born-digital-notifications-prod (in digirati acct)

There is also an equivalent queue for staging storage. 

## This PR

In this PR, each DDS environment makes use of its own queues, defined for each environment by this Terraform:

https://github.com/wellcomecollection/iiif-builder-infrastructure/pull/54

This references the topics as data, but creates its own queues - at least two for each of our prod, stage, test (aka stage-prod) and also local dev environments. It then subscribes some of these queues to the storage-owned topics. (If the Goobi topic ends up being in a different account we can change, it's commented out for now).

This means the running DDS has no knowledge of the topics, and certainly never publishes to them. For the scenario of a manual initiation of a workflow from the dashboard, the dashboard sends a message on its appropriate, DDS-infra queue.

The WorkflowProcessor listens to a list of queues (so we can add others for testing), and the dashboard is capable of sending messages to one of two specific queues for its environment, one for born digital and one for digitised. In practice, the workflowProcessor in that environment is listening to these same two queues, but it can listen to others.

Example WorkflowProcessor config (a list of queues, doesn't need to know what each is, and could be more than 2):

```
    "WorkflowMessageListenQueues": [
      "born-digital-notifications-staging",
      "digitised-notifications-staging"
    ],
```

WorkflowProcessorService now polls all of the listed queues, rather than the single configured queue.

Example Dashboard config (always 2, explicitly named):

```
    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging",
    "DashboardPushDigitisedQueue": "digitised-notifications-staging"
```


This means that DDS Terraform manages all the notification queues it uses, the only point of contact with storage infra is the queue subscription.

This PR also introduces `QueueMessage`, adapted from Protagonist for NewtonSoft.JSON rather than System.Text.Json, because it might be getting messages from topics, or directly placed by the dashboard, so needs to handle the different wrapping.



