### PR TITLE
Internet archive volume numbering fix

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/LogicalStructDiv.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/LogicalStructDiv.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using Utils;
@@ -108,7 +109,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
             DmdId = (string) div.Attribute("DMDID")!;
             Label = (string) div.Attribute("LABEL")!;
             Type =  (string) div.Attribute("TYPE")!;
-            Order = (int?)   div.Attribute("ORDER");
+            Order = SanitiseOrder(div.Attribute("ORDER"));
 
             Children = div.Elements(XNames.MetsDiv)
                         .Select(md => new LogicalStructDiv(md, containingFileRelativePath, null, workStore) as ILogicalStructDiv)
@@ -135,7 +136,20 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                 }
             }
         }
-        
+
+        private int? SanitiseOrder(XAttribute? attribute)
+        {
+            // Some order labels from Internet Archive workflows look like this: "167402"
+            // Where the first 4 digits are the publication year and the second two are the "real" order.
+            var asString = (string?) attribute;
+            if (asString.HasText() && asString.Length == 6 && asString.All(char.IsDigit))
+            {
+                return Convert.ToInt32(asString[4..]);
+            }
+
+            return (int?) attribute;
+        }
+
         private ModsData? modsData;
         private bool modsLoaded;
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -394,8 +394,8 @@ namespace Wellcome.Dds.Repositories.Presentation
                         {
                             ["en"] = new()
                             {
-                                $"Volume {order}",
-                                work.Title!
+                                work.Title!,
+                                $"Volume {order}"
                             }
                         },
                         Thumbnail = manifestationMetadata.Manifestations.GetThumbnail(metsManifestation.Identifier!)

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/SpecialState/MultiCopyState.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/SpecialState/MultiCopyState.cs
@@ -34,7 +34,7 @@ namespace Wellcome.Dds.Repositories.Presentation.SpecialState
             // Each Manifest will have a copy number.
             // There might be more than one volume per copy, in which case we have
             // a nested collection.
-            if (!(buildResults.First().IIIFResource is Collection bNumberCollection))
+            if (buildResults.First().IIIFResource is not Collection bNumberCollection)
             {
                 throw new IIIFBuildStateException("State is missing the parent collection");
             }


### PR DESCRIPTION
This PR has two fixes for Volume labelling issues.

1 is the 4000+ Internet Archive examples that have values like `ORDER="174504"` where the order value has been created out of the publication year and then the actual order value (4, in this example). 

If the `ORDER` is a 6-digit integer, then parse the last two digits for the real order value.

The other fix is this for https://github.com/wellcomecollection/platform/issues/5623.