### PR TITLE
explicit missing access conditions

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Utils;
 using Wellcome.Dds.AssetDomain.Dlcs.Ingest;
 using Wellcome.Dds.AssetDomain.Dlcs.Model;
+using Wellcome.Dds.AssetDomain.Mets;
 
 namespace Wellcome.Dds.AssetDomain.DigitalObjects
 {
@@ -60,6 +61,11 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
         /// The sync operation has at least one invalid access condition and should not be synced
         /// </summary>
         public bool HasInvalidAccessCondition { get; set; }
+
+        /// <summary>
+        /// Files with no access condition in METS
+        /// </summary>
+        public List<IStoredFile> MissingAccessConditions { get; set; }
 
         public SyncOperation(DlcsCallContext dlcsCallContext)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DashboardRepositoryTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DashboardRepositoryTests.cs
@@ -16,10 +16,12 @@ using Wellcome.Dds.AssetDomain.Dlcs.Model;
 using Wellcome.Dds.AssetDomain.Dlcs.RestOperations;
 using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.AssetDomainRepositories.DigitalObjects;
+using Wellcome.Dds.AssetDomainRepositories.Mets.Model;
 using Wellcome.Dds.Catalogue;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
 using Xunit;
+using AccessCondition = Wellcome.Dds.Common.AccessCondition;
 
 namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
 {
@@ -255,6 +257,25 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
             A.CallTo(() => dlcs.PreventSynchronisation).Returns(true);
             var ctx = new DlcsCallContext("[test]", "[id]");
             var syncOp = new SyncOperation(ctx);
+            Func<Task> action = () => sut.ExecuteDlcsSyncOperation(syncOp, true, ctx);
+            
+            // Assert
+            await action.Should().ThrowAsync<InvalidOperationException>();
+        }
+        
+        
+        [Fact]
+        public async Task ExecuteDlcsSyncOperation_Throws_IfMissingAccessConditions()
+        {
+            // Arrange
+            var pf = new PhysicalFile(A.Fake<IWorkStore>(), "test")
+            {
+                AccessCondition = AccessCondition.Missing
+            };
+            var sf = new StoredFile { PhysicalFile = pf };
+            var ctx = new DlcsCallContext("[test]", "[id]");
+            var syncOp = new SyncOperation(ctx);
+            syncOp.MissingAccessConditions = new List<IStoredFile> { sf };
             Func<Task> action = () => sut.ExecuteDlcsSyncOperation(syncOp, true, ctx);
             
             // Assert

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -120,6 +120,13 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                 throw new InvalidOperationException(syncError);
             }
 
+            if (syncOperation.MissingAccessConditions.HasItems())
+            {
+                throw new InvalidOperationException($"Cannot execute sync operation for {dlcsCallContext.Id} " +
+                                                    $"because it contains {syncOperation.MissingAccessConditions.Count} " +
+                                                    $"file(s) with missing access conditions");
+            }
+            
             var ingestOps = new List<Task>(2);
             logger.LogInformation(
                 "Registering BATCH INGESTS for METS resource (manifestation) with Id {0}, context {callContext}",
@@ -154,17 +161,20 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
             logger.LogDebug("Will construct a SyncOperation for context: {callContext}", dlcsCallContext.Id);
             var metsManifestation = digitisedManifestation.MetsManifestation;
             var imagesAlreadyOnDlcs = digitisedManifestation.DlcsImages!.ToList();
+            var missingAccessConditions = metsManifestation!.SynchronisableFiles
+                .Where(sf => sf.PhysicalFile!.AccessCondition == AccessCondition.Missing).ToList();
             logger.LogDebug(
                 "There are {alreadyCount} images already on the DLCS for {identifier}, callContext: {callContext}",
                 imagesAlreadyOnDlcs.Count, digitisedManifestation.Identifier, dlcsCallContext.Id);
             var syncOperation = new SyncOperation(dlcsCallContext)
             {
-                ManifestationIdentifier = metsManifestation!.Identifier,
+                ManifestationIdentifier = metsManifestation.Identifier,
                 DlcsImagesCurrentlyIngesting = new List<Image>(),
                 StorageIdentifiersToIgnore = metsManifestation.IgnoredStorageIdentifiers,
                 ImagesCurrentlyOnDlcs =
                     await GetImagesExpectedOnDlcs(metsManifestation, imagesAlreadyOnDlcs, dlcsCallContext),
-                ImagesThatShouldBeOnDlcs = new Dictionary<string, Image?>()
+                ImagesThatShouldBeOnDlcs = new Dictionary<string, Image?>(),
+                MissingAccessConditions = missingAccessConditions
             };
 
             /*

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/ModsData.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/ModsData.cs
@@ -73,10 +73,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
             }
             if (!AccessCondition.HasText())
             {
-                AccessCondition = Common.AccessCondition.Open;
+                AccessCondition = Common.AccessCondition.Missing;
             }
-            // TODO: revisit this behaviour for https://github.com/wellcomecollection/platform/issues/5619
-            // e.g., AccessCondition = Common.AccessCondition.Missing;
 
             var dzAccessConditionElements = accessConditions
                 .Where(x => (string?) x.Attribute("type") == "dz").ToList();


### PR DESCRIPTION
This allows the missing condition to be seen in the dashboard, the manifestation page will be made, but we won't be able to generate the Manifest due to existing conditions:

https://github.com/wellcomecollection/iiif-builder/blob/5aabe5c274e849c4abea27b2d456933479fc2bb2/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs#L1044

And we won't be allowed to synchronise because of a new restriction in this PR.