### PR TITLE
Links from dash to portal pages become templates in appSettings

### DIFF
--- a/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
@@ -25,5 +25,8 @@
         /// Whether to call the DLCS using old Deliverator AssetFamily, or protagonist delivery channels
         /// </summary>
         public bool SupportsDeliveryChannels { get; set; } = false;
+        
+        public string PortalPageTemplate { get; set; }
+        public string PortalBatchTemplate { get; set; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
@@ -19,8 +19,6 @@ namespace Wellcome.Dds.Dashboard.Models
 {
     public class ManifestationModel
     {
-        const string PortalPageTemplate = "https://portal.dlcs.io/Image.aspx?space={0}&image={1}";
-        const string PortalBatchTemplate = "https://portal.dlcs.io/Batch.aspx?batch={0}";
         const string GlyphTemplate = "<span class=\"glyphicon glyphicon-{0}\"></span>";
 
         private static readonly char[] SlashSeparator = new[] { '/' };
@@ -176,11 +174,11 @@ namespace Wellcome.Dds.Dashboard.Models
         public string GetPortalPageForImage(Image image)
         {
             int? space = image.Space ?? DefaultSpace;
-            return string.Format(PortalPageTemplate, space, image.StorageIdentifier);
+            return string.Format(DlcsOptions.PortalPageTemplate, space, image.StorageIdentifier);
         }
         public string GetPortalPageForBatch(Batch batch)
         {
-            return string.Format(PortalBatchTemplate, batch.Id.Split(SlashSeparator).Last());
+            return string.Format(DlcsOptions.PortalBatchTemplate, batch.Id.Split(SlashSeparator).Last());
         }
 
         public void MakeManifestationNavData()

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -670,7 +670,7 @@
                             @if (dlcsImage != null)
                             {
                                 <td>
-                                    <a href="@Model.GetPortalPageForImage(dlcsImage)">@pf.StorageIdentifier</a>
+                                    <a href="@Model.GetPortalPageForImage(dlcsImage)" target="_blank">@pf.StorageIdentifier</a>
                                     @if (dlcsImage.Error.HasText())
                                     {
                                         <br/><span class="text-danger small">@dlcsImage.Error</span>
@@ -745,7 +745,7 @@
                                     if (dlcsImage != null)
                                     {
                                         <td>
-                                            <a href="@Model.GetPortalPageForImage(dlcsImage)">@adjunct.StorageIdentifier</a>
+                                            <a href="@Model.GetPortalPageForImage(dlcsImage)" target="_blank">@adjunct.StorageIdentifier</a>
                                         </td>
                                     }
                                     else
@@ -794,7 +794,7 @@
                             @*<td>@orphan.Width x @orphan.Height</td>*@
                             <td>@Model.GetAbridgedRoles(orphan.Roles)</td>
                             <td>@orphan.Error</td>
-                            <td width="30%"><a href="@Model.GetPortalPageForImage(orphan)">@orphan.StorageIdentifier</a></td>
+                            <td width="30%"><a href="@Model.GetPortalPageForImage(orphan)" target="_blank">@orphan.StorageIdentifier</a></td>
                             <td>@orphan.Ingesting</td>
                         </tr>
                     }
@@ -885,7 +885,7 @@
         if (batch.Completed != batch.Count)
         {
             <div class="progress">
-                <a href="@Model.GetPortalPageForBatch(batch)" title="@batch.Submitted">
+                <a href="@Model.GetPortalPageForBatch(batch)" title="@batch.Submitted" target="_blank">
                     <div class="progress-bar progress-bar-success" role="progressbar"
                          aria-valuenow="@batch.Completed" aria-valuemin="0" aria-valuemax="@batch.Count"
                          style="width: @percentComplete">
@@ -946,7 +946,7 @@
                         <br/>
                         @if (dlcsImage != null)
                         {
-                            <a href="@Model.GetPortalPageForImage(dlcsImage)">@file.StorageIdentifier</a>
+                            <a href="@Model.GetPortalPageForImage(dlcsImage)" target="_blank">@file.StorageIdentifier</a>
                             @if (dlcsImage.Error.HasText())
                             {
                                 <br/>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
@@ -17,7 +17,9 @@
     "ApiEntryPoint": "https://newapi.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-stage-new.wellcomecollection.org/",
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
-    "PreventSynchronisation": false
+    "PreventSynchronisation": false,
+    "PortalPageTemplate": "https://portal.dlcs.io/Image.aspx?space={0}&image={1}",
+    "PortalBatchTemplate": "https://portal.dlcs.io/Batch.aspx?batch={0}"
   },
   "Dds": {
     "LinkedDataDomain": "https://iiif-stage-new.wellcomecollection.org",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
@@ -18,8 +18,8 @@
     "ResourceEntryPoint": "https://iiif-stage-new.wellcomecollection.org/",
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
     "PreventSynchronisation": false,
-    "PortalPageTemplate": "https://portal.dlcs.io/Image.aspx?space={0}&image={1}",
-    "PortalBatchTemplate": "https://portal.dlcs.io/Batch.aspx?batch={0}"
+    "PortalPageTemplate": "https://portal.dlcs.digirati.io/images/{0}/{1}",
+    "PortalBatchTemplate": "https://portal.dlcs.digirati.io/batches/{0}"
   },
   "Dds": {
     "LinkedDataDomain": "https://iiif-stage-new.wellcomecollection.org",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
@@ -31,7 +31,9 @@
     "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/",
     "BatchSize": 100,
-    "PreventSynchronisation": false
+    "PreventSynchronisation": false,
+    "PortalPageTemplate": "https://portal.dlcs.io/Image.aspx?space={0}&image={1}",
+    "PortalBatchTemplate": "https://portal.dlcs.io/Batch.aspx?batch={0}"
   },
   "Storage": {
     "StorageApiTemplate": "https://api-stage.wellcomecollection.org/storage/v1/bags/{0}/{1}",


### PR DESCRIPTION
The portal.dlcs.io links were hard-coded, which didn't allow us to deploy for both DLCSes.

Now they are in appSettings. We still don't know what our new dlcs.io portal address will be. Just pointing it at portal.dlcs.digirati.io for now.