### PR TITLE
Stage and prod configs

### DIFF
--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging-Prod.json
@@ -13,7 +13,7 @@
     }
   },
   "Dlcs": {
-    "CustomerDefaultSpace": 6,
+    "CustomerDefaultSpace": 7,
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/"
   },
   "Dds": {

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
@@ -12,7 +12,7 @@
     }
   },
   "Dlcs": {
-    "CustomerDefaultSpace": 6,
+    "CustomerDefaultSpace": 7,
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/",
     "PreventSynchronisation": true
   },

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
@@ -23,8 +23,8 @@
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
     "IncludeExtraAccessConditionsInManifest": "Missing,Unknown",
     "PlaceholderCanvasCacheTimeDays": 0,
-    "DashboardPushBornDigitalQueue": "born-digital-notifications-test",
-    "DashboardPushDigitisedQueue": "digitised-notifications-test"
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging-prod",
+    "DashboardPushDigitisedQueue": "digitised-notifications-staging-prod"
   },
   "Dash": {
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging.json
@@ -23,8 +23,8 @@
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
     "IncludeExtraAccessConditionsInManifest": "Missing,Unknown",
     "PlaceholderCanvasCacheTimeDays": 0,
-    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging",
-    "DashboardPushDigitisedQueue": "digitised-notifications-staging"
+    "DashboardPushBornDigitalQueue": "born-digital-notifications-staging-dds",
+    "DashboardPushDigitisedQueue": "digitised-notifications-staging-dds"
   },
   "Dash": {
     "DashBodyInject": "background-image:url(/dash/img/staging.png); background-repeat;",

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-Prod.json
@@ -12,7 +12,7 @@
     }
   },
   "Dlcs": {
-    "CustomerDefaultSpace": 6,
+    "CustomerDefaultSpace": 7,
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/"
   },
   "Dds": {

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
@@ -23,8 +23,8 @@
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
     "MinimumJobAgeMinutes": 10,
     "WorkflowMessageListenQueues": [
-      "born-digital-notifications-test",
-      "digitised-notifications-test"
+      "born-digital-notifications-staging-prod",
+      "digitised-notifications-staging-prod"
     ],
     "WorkflowMessagePoll": false
   },

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
@@ -13,7 +13,7 @@
     }
   },
   "Dlcs": {
-    "CustomerDefaultSpace": 6,
+    "CustomerDefaultSpace": 7,
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/"
   },
   "Dds": {

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging.json
@@ -23,8 +23,8 @@
     "AnnotationContainer": "wellcomecollection-stage-iiif-annotations",
     "MinimumJobAgeMinutes": 10,
     "WorkflowMessageListenQueues": [
-      "born-digital-notifications-staging",
-      "digitised-notifications-staging"
+      "born-digital-notifications-staging-dds",
+      "digitised-notifications-staging-dds"
     ],
     "WorkflowMessagePoll": false
   },


### PR DESCRIPTION
Use DLCS space 7 for test (staging-prod)
Match queue names to terraform

NB the stage queues for workflow messages have the suffix -dds because there was already a queue called `born-digital-notifications-staging` created by Alex...  