### PR TITLE
Add compose for quick db spinup

### DIFF
--- a/src/compose/db/db.Dockerfile
+++ b/src/compose/db/db.Dockerfile
@@ -1,0 +1,2 @@
+FROM postgres:12.5-alpine
+COPY init.sql /docker-entrypoint-initdb.d/

--- a/src/compose/db/init.sql
+++ b/src/compose/db/init.sql
@@ -1,0 +1,9 @@
+-- Create database for dds
+CREATE database dds;
+CREATE USER dds_user WITH ENCRYPTED PASSWORD 'dds_password';
+GRANT ALL PRIVILEGES ON database dds TO dds_user;
+
+-- Create database for instrumentation
+CREATE database dds_instrumentation;
+CREATE USER dds_instrumentation_user WITH ENCRYPTED PASSWORD 'dds_instrumentation_password';
+GRANT ALL PRIVILEGES ON database dds_instrumentation TO dds_instrumentation_user;

--- a/src/compose/db/readme.md
+++ b/src/compose/db/readme.md
@@ -1,0 +1,10 @@
+# DB
+
+A custom Dockerfile for local development. It is a basic postgreSQL 12.5 instance that will copy and run contents of `init.sql` on startup.
+
+`init.sql` creates 2 databases:
+
+* `dds` with user `dds_user:dds_password`
+* `dds_instrumentation` with user `dds_instrumentation_user:dds_instrumentation_password`
+
+> This is only intended for local development.

--- a/src/compose/docker-compose.local.yml
+++ b/src/compose/docker-compose.local.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+volumes:
+  postgres_data: {}
+
+services:
+  iiif_builder_db:
+    build:
+      context: ./db
+      dockerfile: db.Dockerfile
+    ports:
+      - "5442:5432"
+    volumes:
+       - postgres_data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=master_password

--- a/src/compose/readme.md
+++ b/src/compose/readme.md
@@ -1,0 +1,22 @@
+# Docker Compose
+
+Compose file to ease local development, starts postgres instance with 2 databases for dds + dds_instrumentation on port 5442. 
+
+Running the dashboard project against this will run EF migrations.
+
+Run with:
+
+```bash
+docker compose -f docker-compose.yml up
+```
+
+Use connection strings:
+
+```json
+{
+"ConnectionStrings": {
+    "Dds": "Server=127.0.0.1;Port=5442;Database=dds;User Id=dds_user;Password=dds_password;",
+    "DdsInstrumentation": "Server=127.0.0.1;Port=5442;Database=dds_instrumentation;User Id=dds_instrumentation_user;Password=dds_instrumentation_password;"
+  },
+}
+```


### PR DESCRIPTION
Fairly limited use but can be handy to troubleshoot a single item in dashboard locally. Creates empty postgres instance with 2 db's and 2 users.