### PR TITLE
Dash asset page

### DIFF
--- a/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
@@ -26,7 +26,7 @@
         /// </summary>
         public bool SupportsDeliveryChannels { get; set; } = false;
         
-        public string PortalPageTemplate { get; set; }
-        public string PortalBatchTemplate { get; set; }
+        public string? PortalPageTemplate { get; set; }
+        public string? PortalBatchTemplate { get; set; }
     }
 }

--- a/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
@@ -28,5 +28,6 @@
         
         public string? PortalPageTemplate { get; set; }
         public string? PortalBatchTemplate { get; set; }
+        public string? SingleAssetManifestTemplate { get; set; }
     }
 }

--- a/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Utils;
 using Utils.Logging;
 using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.DigitalObjects;
@@ -79,7 +80,11 @@ namespace DlcsWebClient.Dlcs
                 switch (operation.HttpMethod.Method)
                 {
                     case "POST":
-                        requestMessage.Content = GetJsonContent(operation.RequestJson!);
+                        if (operation.RequestJson.HasText())
+                        {
+                            // a POST to /reingest has no content
+                            requestMessage.Content = GetJsonContent(operation.RequestJson);
+                        }
                         break;
                     case "PATCH":
                         requestMessage.Content = GetJsonContent(operation.RequestJson!);
@@ -213,7 +218,15 @@ namespace DlcsWebClient.Dlcs
 
             return image;
         }
-        
+
+        public async Task<Image?> ReingestImage(int space, string id, DlcsCallContext dlcsCallContext)
+        {
+            var imageReingestUri = $"{options.ApiEntryPoint}customers/{options.CustomerId}/spaces/{space}/images/{id}/reingest";
+            var operation = await DoOperation<string, Image>(HttpMethod.Post, new Uri(imageReingestUri), null, dlcsCallContext);
+            var image = operation.ResponseObject;
+            return image;
+        }
+
         public Task<Operation<ImageQuery, HydraImageCollection>> GetImages(
             ImageQuery query, int defaultSpace, DlcsCallContext dlcsCallContext)
         {

--- a/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
@@ -193,6 +193,27 @@ namespace DlcsWebClient.Dlcs
             return last;
         }
         
+        
+        public async Task<Image?> GetImage(int space, string id, DlcsCallContext dlcsCallContext)
+        {
+            var imageQueryUri = $"{options.ApiEntryPoint}customers/{options.CustomerId}/spaces/{space}/images/{id}";
+            var operation = await DoOperation<string, Image>(HttpMethod.Get, new Uri(imageQueryUri), null, dlcsCallContext);
+            var image = operation.ResponseObject;
+
+            if (image != null)
+            {
+                // check if we need this...
+                image.StorageIdentifier = GetLocalStorageIdentifier(image.Id!);
+                // same as: if(options.SupportsDeliveryChannels) - we can retire Family later
+                if (image.MediaType.IsTimeBasedMimeType() || image.Family == 'T')
+                {
+                    await LoadMetadata(image);
+                }
+            }
+
+            return image;
+        }
+        
         public Task<Operation<ImageQuery, HydraImageCollection>> GetImages(
             ImageQuery query, int defaultSpace, DlcsCallContext dlcsCallContext)
         {
@@ -720,7 +741,6 @@ namespace DlcsWebClient.Dlcs
 
         public string ResourceEntryPoint => options.ResourceEntryPoint!;
         public string InternalResourceEntryPoint => options.InternalResourceEntryPoint!;
-
         public bool SupportsDeliveryChannels => options.SupportsDeliveryChannels;
     }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
@@ -65,7 +65,7 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
         /// <summary>
         /// Files with no access condition in METS
         /// </summary>
-        public List<IStoredFile> MissingAccessConditions { get; set; }
+        public List<IStoredFile>? MissingAccessConditions { get; set; }
 
         public SyncOperation(DlcsCallContext dlcsCallContext)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
@@ -118,5 +118,6 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
         
         bool SupportsDeliveryChannels { get; }
         Task<Image?> GetImage(int space, string id, DlcsCallContext dlcsCallContext);
+        Task<Image?> ReingestImage(int space, string id, DlcsCallContext dlcsCallContext);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
@@ -117,5 +117,6 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
         string InternalResourceEntryPoint { get; }
         
         bool SupportsDeliveryChannels { get; }
+        Task<Image?> GetImage(int space, string id, DlcsCallContext dlcsCallContext);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
@@ -15,7 +15,6 @@ namespace Wellcome.Dds.AssetDomain.Dlcs.Model
         public int? Space { get; set; }
 
         [JsonProperty(Order = 11, PropertyName = "infoJson")]
-        [Obsolete("Use metadata instead; the infoJson is produced from templates at runtime")]
         public string? InfoJson { get; set; }
 
         [JsonProperty(Order = 12, PropertyName = "degradedInfoJson")]

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
@@ -120,7 +120,7 @@ namespace Wellcome.Dds.AssetDomain.Dlcs.Model
         public string? ThumbnailPolicy { get; set; }
 
         [JsonProperty(Order = 82, PropertyName = "deliveryChannel")]
-        public string? DeliveryChannel { get; set; }
+        public string[]? DeliveryChannels { get; set; }
     }
 
     public class Thumbnail

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -778,7 +778,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
             {
                 var processing = asset.PhysicalFile.ProcessingBehaviour;
                 imageRegistration.ImageOptimisationPolicy = processing.ImageOptimisationPolicy;
-                imageRegistration.DeliveryChannel = processing.DeliveryChannels.ToCommaDelimitedList();
+                imageRegistration.DeliveryChannels = processing.DeliveryChannels.ToArray();
                 imageRegistration.Family = null;
             }
             return imageRegistration;

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/AssetController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/AssetController.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DlcsWebClient.Config;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+using Utils;
+using Wellcome.Dds.AssetDomain;
+using Wellcome.Dds.AssetDomain.Dlcs;
+using Wellcome.Dds.AssetDomain.Dlcs.Model;
+using Wellcome.Dds.Dashboard.Models;
+
+namespace Wellcome.Dds.Dashboard.Controllers;
+
+[Route("[controller]")]
+public class AssetController : Controller
+{
+    private readonly ILogger<AssetController> logger;
+    private readonly IDlcs dlcs;
+    private readonly DlcsOptions dlcsOptions;
+    private readonly HttpClient httpClient;
+    
+    public AssetController(
+        ILogger<AssetController> logger,
+        IDlcs dlcs,
+        IOptions<DlcsOptions> options,
+        HttpClient httpClient)
+    {
+        this.logger = logger;
+        this.dlcs = dlcs;
+        dlcsOptions = options.Value;
+        this.httpClient = httpClient;
+    }
+
+    [HttpGet]
+    [Route("{space}/{id}")]
+    public async Task<ActionResult> Index(int space, string id)
+    {
+        var imgCallContext = new DlcsCallContext("AssetController::Index-GetImage", $"{space}/{id}");
+        var image = await dlcs.GetImage(space, id, imgCallContext);
+        // var storageCallContext = new DlcsCallContext("AssetController::Index-GetImageStorage", $"{space}/{id}");
+        // var storage = await dlcs.GetImageStorage(space, id, storageCallContext);
+        var model = new AssetModel
+        {
+            Space = space,
+            ModelId = id,
+            Asset = image,
+            DlcsPortalPage = string.Format(dlcsOptions.PortalPageTemplate!, space, image?.StorageIdentifier),
+            Thumbnails = await GetThumbnails(image?.ThumbnailInfoJson)
+            // Storage = some new storage object from API,
+            // see https://api.dlcs.io/customers/2/spaces/5/images/b31404777_0001.jp2/storage and 
+            // https://api.dlcs.io/customers/2/spaces/5/images/b20018484_0055-0000-7064-0000-0-0000-0000-0.mpg/storage
+            // (latter does not work)
+        };
+        return View(model);
+    }
+
+    private async Task<List<Thumbnail>> GetThumbnails(string thumbnailInfoJsonJson)
+    {
+        if (thumbnailInfoJsonJson.HasText())
+        {
+            var thumbs = new List<Thumbnail>();
+            try
+            {
+                var info = JObject.Parse(await httpClient.GetStringAsync(thumbnailInfoJsonJson));
+                var sizes = info["sizes"];
+                foreach (var size in sizes.Cast<JObject>())
+                {
+                    var thumb = new Thumbnail()
+                    {
+                        Width = size.Value<int>("width"),
+                        Height = size.Value<int>("height"),
+                    };
+                    thumb.Src = $"{thumbnailInfoJsonJson}/full/{thumb.Width},{thumb.Height}/0/default.jpg";
+                    thumbs.Add(thumb);
+                }
+
+                return thumbs;
+            } catch {}
+        }
+
+        return null;
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/AssetModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/AssetModel.cs
@@ -9,5 +9,6 @@ public class AssetModel
     public int Space { get; set; }
     public Image Asset { get; set; }
     public string DlcsPortalPage { get; set; }
+    public string SingleAssetManifest { get; set; }
     public List<Thumbnail> Thumbnails { get; set; }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/AssetModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/AssetModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Wellcome.Dds.AssetDomain.Dlcs.Model;
+
+namespace Wellcome.Dds.Dashboard.Models;
+
+public class AssetModel
+{
+    public string ModelId { get; set; }
+    public int Space { get; set; }
+    public Image Asset { get; set; }
+    public string DlcsPortalPage { get; set; }
+    public List<Thumbnail> Thumbnails { get; set; }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
@@ -4,18 +4,40 @@
 
 <div class="row" style="margin-top: 1em;">
 
+    
+    @if (TempData["reingest-asset"] != null)
+    {
+        <div class="alert alert-success alert-dismissible" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <strong>The DLCS was told to reingest this asset.</strong>
+        </div>
+    }
+    
     <div class="col-md-3">
-        <h3>Jobs</h3>
+        <h3>Preview</h3>
         <ul class="list-group">
             <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Edit</a>
+                <a href="@Model.SingleAssetManifest"><span class="glyphicon glyphicon-file"></span> Single IIIF Manifest</a>
             </li>    
             <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Reingest</a>
+                <a href="https://universalviewer.io/examples/#?manifest=@Model.SingleAssetManifest"><span class="glyphicon glyphicon-eye-open"></span> In UV</a>
             </li>    
             <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Delete</a>
+                <a href="https://tomcrane.github.io/scratch/mirador3/index.html?iiif-content=@Model.SingleAssetManifest"><span class="glyphicon glyphicon-eye-open"></span> In Mirador</a>
             </li>   
+        </ul>
+        
+        <h3>Actions</h3>
+        <ul class="list-group">
+            <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-pencil"></span> Edit (soon)</a>
+            </li>
+            <li class="list-group-item">    
+                <a href="@Url.Action("Reingest", new { space = Model.Space, id=Model.ModelId })"><span class="glyphicon glyphicon-transfer"></span> Reingest</a>
+            </li>
+            <li class="list-group-item">
+                <a href="@Url.Action("Delete", new { space = Model.Space, id=Model.ModelId })"><span class="glyphicon glyphicon-remove"></span> Delete</a>
+            </li>
         </ul>
     </div>
     
@@ -46,6 +68,10 @@
     <tr>
         <td>Family / Media Type</td>
         <td>@Model.Asset.Family / @Model.Asset.MediaType</td>
+    </tr>
+    <tr>
+        <td>Delivery Channels</td>
+        <td>@String.Join(", ", Model.Asset.DeliveryChannels ?? new[]{"(no delivery channels)"})</td>
     </tr>
     <tr>
         <td>Size</td>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
@@ -1,0 +1,171 @@
+@model AssetModel
+
+<h2>Space @Model.Space<text>:</text> @Model.ModelId</h2>
+
+<div class="row" style="margin-top: 1em;">
+
+    <div class="col-md-3">
+        <h3>Jobs</h3>
+        <ul class="list-group">
+            <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Edit</a>
+            </li>    
+            <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Reingest</a>
+            </li>    
+            <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Delete</a>
+            </li>   
+        </ul>
+    </div>
+    
+    <div class="col-md-9">
+        
+<p><a href="@Model.DlcsPortalPage" target="_blank">View in DLCS portal</a></p>
+
+<table class="table">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Value</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>API Endpoint</td>
+        <td><a href="@Model.Asset.Id">@Model.Asset.Id</a></td>
+    </tr>
+    <tr>
+        <td>Image API Endpoint (info.json)</td>
+        <td><a href="@Model.Asset.InfoJson">@Model.Asset.InfoJson</a></td>
+    </tr>
+    <tr>
+        <td>Thumbnail Image API Endpoint (info.json)</td>
+        <td><a href="@Model.Asset.ThumbnailInfoJson">@Model.Asset.ThumbnailInfoJson</a></td>
+    </tr>
+    <tr>
+        <td>Family / Media Type</td>
+        <td>@Model.Asset.Family / @Model.Asset.MediaType</td>
+    </tr>
+    <tr>
+        <td>Size</td>
+        <td>(todo - not on Asset)</td>
+    </tr>
+    <tr>
+        <td>Thumbnail size</td>
+        <td>(todo - not on Asset)</td>
+    </tr>
+    <tr>
+        <td>AV derivatives</td>
+        <td>(todo - not on Asset, will be storage)</td>
+    </tr>
+    <tr>
+        <td>Created</td>
+        <td>@StringUtils.GetFriendlyAge(Model.Asset.Created)</td>
+    </tr>
+    <tr>
+        <td>Ingesting</td>
+        <td>@Model.Asset.Ingesting</td>
+    </tr>
+    <tr>
+        <td>Finished</td>
+        <td>@StringUtils.GetFriendlyAge(Model.Asset.Finished)</td>
+    </tr>
+    <tr>
+        <td>Origin</td>
+        <td><a href="@Model.Asset.Origin">@Model.Asset.Origin</a></td>
+    </tr>
+    <tr>
+        <td>Width x Height</td>
+        <td>@Model.Asset.Width x @Model.Asset.Height</td>
+    </tr>
+    <tr>
+        <td>Duration</td>
+        <td>@Model.Asset.Duration</td>
+    </tr>
+    <tr>
+        <td>String1</td>
+        <td>@Model.Asset.String1</td>
+    </tr>
+    <tr>
+        <td>String2</td>
+        <td>@Model.Asset.String2</td>
+    </tr>
+    <tr>
+        <td>String3</td>
+        <td>@Model.Asset.String3</td>
+    </tr>
+    <tr>
+        <td>Number1</td>
+        <td>@Model.Asset.Number1</td>
+    </tr>
+    <tr>
+        <td>Number2</td>
+        <td>@Model.Asset.Number2</td>
+    </tr>
+    <tr>
+        <td>Number3</td>
+        <td>@Model.Asset.Number3</td>
+    </tr>
+    <tr>
+        <td>Tags</td>
+        <td>@string.Join(',', Model.Asset.Tags ?? Array.Empty<string>())</td>
+    </tr>
+    <tr>
+        <td>Roles</td>
+        <td>@string.Join(',', Model.Asset.Roles ?? Array.Empty<string>())</td>
+    </tr>
+    <tr>
+        <td>Max Unauthorised</td>
+        <td>@Model.Asset.MaxUnauthorised</td>
+    </tr>
+    <tr>
+        <td>Batch</td>
+        <td><a href="@Model.Asset.Batch">@Model.Asset.Batch</a></td>
+    </tr>
+    <tr>
+        <td>Error</td>
+        <td>@Model.Asset.Error</td>
+    </tr>
+    </tbody>
+</table>
+
+@{
+    if (Model.Asset.InfoJson.HasText())
+    {
+        <h2>IIIF Image</h2>
+        <div id="osd" style="width:100%; height: 500px; border: 1px solid gray;"></div>
+    }
+
+
+    if (Model.Asset.ThumbnailInfoJson.HasText())
+    {
+        <h2>Thumbnails</h2>
+        @foreach (var thumb in Model.Thumbnails)
+        {
+            <p>@thumb.Width x @thumb.Height</p>
+            <img src="@thumb.Src" />                    
+        }
+        
+    }
+}
+    </div>
+    
+</div>
+
+
+
+@section scripts
+{
+    @if (Model.Asset.InfoJson.HasText())
+    {
+        <script>
+            const viewer1 = OpenSeadragon({
+                id: "osd",
+                showNavigationControl: false,
+                tileSources: "@Model.Asset.InfoJson"
+            });
+        </script>
+    }
+}
+    

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -670,7 +670,7 @@
                             @if (dlcsImage != null)
                             {
                                 <td>
-                                    <a href="@Model.GetPortalPageForImage(dlcsImage)" target="_blank">@pf.StorageIdentifier</a>
+                                    <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" target="_blank">@pf.StorageIdentifier</a>
                                     @if (dlcsImage.Error.HasText())
                                     {
                                         <br/><span class="text-danger small">@dlcsImage.Error</span>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
@@ -14,6 +14,7 @@
   "Dlcs": {
     "CustomerDefaultSpace": 6,
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
+    "SingleAssetManifestTemplate": "https://neworchestrator.dlcs.io/iiif-manifest/wellcome/{0}/{1}",
     "ApiEntryPoint": "https://newapi.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-stage-new.wellcomecollection.org/",
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
@@ -28,6 +28,7 @@
     "CustomerId": 2,
     "CustomerName": "Wellcome",
     "SkeletonNamedQueryTemplate": "https://dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
+    "SingleAssetManifestTemplate": "https://dlcs.io/iiif-manifest/wellcome/{0}/{1}",
     "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/",
     "BatchSize": 100,

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -73,6 +73,7 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string PersistentCatalogueRecordFormat = "https://search.wellcomelibrary.org/iii/encore/record/C__R{identifier}";
         
         // DLCS Paths
+        // Note that {dlcsEntryPoint} is the public-facing, proxied, Wellcome root, not the raw DLCS orchestrator
         private const string DlcsPdfTemplate          = "{dlcsEntryPoint}pdf/{identifier}";
         private const string DlcsThumbServiceTemplate = "{dlcsEntryPoint}thumbs/{assetIdentifier}";
         private const string DlcsImageServiceTemplate = "{dlcsEntryPoint}image/{assetIdentifier}";


### PR DESCRIPTION
A simple-as-possible page that allows the user to view everything the DLCS knows about an asset. In old DDS there was a link to the asset page in the DLCS Portal. 

We need this page in the DDS because we don't have a replacement portal just yet.

If it's an image, the page shows the thumbnails and an OpenSeadragon instance for testing tile requests.

You can reingest the image (a call to [image-uri]/reingest)

Not implemented yet:

* Delete
* Edit fields