### PR TITLE
Match delivery channel behaviour

### DIFF
--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging-New.json
@@ -17,7 +17,8 @@
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
     "ApiEntryPoint": "https://newapi.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-stage-new.wellcomecollection.org/",
-    "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/"
+    "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
+    "SupportsDeliveryChannels": true
   },
   "Dds": {
     "LinkedDataDomain": "https://iiif-stage-new.wellcomecollection.org"

--- a/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
@@ -26,7 +26,7 @@
         /// </summary>
         public bool SupportsDeliveryChannels { get; set; } = false;
         
-        public string PortalPageTemplate { get; set; }
-        public string PortalBatchTemplate { get; set; }
+        public string? PortalPageTemplate { get; set; }
+        public string? PortalBatchTemplate { get; set; }
     }
 }

--- a/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
@@ -28,5 +28,6 @@
         
         public string? PortalPageTemplate { get; set; }
         public string? PortalBatchTemplate { get; set; }
+        public string? SingleAssetManifestTemplate { get; set; }
     }
 }

--- a/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Utils;
 using Utils.Logging;
 using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.DigitalObjects;
@@ -79,7 +80,11 @@ namespace DlcsWebClient.Dlcs
                 switch (operation.HttpMethod.Method)
                 {
                     case "POST":
-                        requestMessage.Content = GetJsonContent(operation.RequestJson!);
+                        if (operation.RequestJson.HasText())
+                        {
+                            // a POST to /reingest has no content
+                            requestMessage.Content = GetJsonContent(operation.RequestJson);
+                        }
                         break;
                     case "PATCH":
                         requestMessage.Content = GetJsonContent(operation.RequestJson!);
@@ -213,7 +218,15 @@ namespace DlcsWebClient.Dlcs
 
             return image;
         }
-        
+
+        public async Task<Image?> ReingestImage(int space, string id, DlcsCallContext dlcsCallContext)
+        {
+            var imageReingestUri = $"{options.ApiEntryPoint}customers/{options.CustomerId}/spaces/{space}/images/{id}/reingest";
+            var operation = await DoOperation<string, Image>(HttpMethod.Post, new Uri(imageReingestUri), null, dlcsCallContext);
+            var image = operation.ResponseObject;
+            return image;
+        }
+
         public Task<Operation<ImageQuery, HydraImageCollection>> GetImages(
             ImageQuery query, int defaultSpace, DlcsCallContext dlcsCallContext)
         {

--- a/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
@@ -193,6 +193,27 @@ namespace DlcsWebClient.Dlcs
             return last;
         }
         
+        
+        public async Task<Image?> GetImage(int space, string id, DlcsCallContext dlcsCallContext)
+        {
+            var imageQueryUri = $"{options.ApiEntryPoint}customers/{options.CustomerId}/spaces/{space}/images/{id}";
+            var operation = await DoOperation<string, Image>(HttpMethod.Get, new Uri(imageQueryUri), null, dlcsCallContext);
+            var image = operation.ResponseObject;
+
+            if (image != null)
+            {
+                // check if we need this...
+                image.StorageIdentifier = GetLocalStorageIdentifier(image.Id!);
+                // same as: if(options.SupportsDeliveryChannels) - we can retire Family later
+                if (image.MediaType.IsTimeBasedMimeType() || image.Family == 'T')
+                {
+                    await LoadMetadata(image);
+                }
+            }
+
+            return image;
+        }
+        
         public Task<Operation<ImageQuery, HydraImageCollection>> GetImages(
             ImageQuery query, int defaultSpace, DlcsCallContext dlcsCallContext)
         {
@@ -720,7 +741,6 @@ namespace DlcsWebClient.Dlcs
 
         public string ResourceEntryPoint => options.ResourceEntryPoint!;
         public string InternalResourceEntryPoint => options.InternalResourceEntryPoint!;
-
         public bool SupportsDeliveryChannels => options.SupportsDeliveryChannels;
     }
 

--- a/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
@@ -742,7 +742,6 @@ namespace DlcsWebClient.Dlcs
         public async Task<Dictionary<string, long>> GetDlcsQueueLevel()
         {
             var url = $"{options.ApiEntryPoint}queue";
-            // httpClient.Timeout = TimeSpan.FromMilliseconds(4000);
             var response = await httpClient.GetStringAsync(url);
 
             var result = JObject.Parse(response);

--- a/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Dlcs/Dlcs.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Utils;
 using Utils.Logging;
@@ -722,8 +723,9 @@ namespace DlcsWebClient.Dlcs
         {
             try
             {
-                httpClient.Timeout = TimeSpan.FromMilliseconds(2000);
-                image.Metadata = await httpClient.GetStringAsync(image.Metadata);
+                using var cts = new CancellationTokenSource();
+                cts.CancelAfter(TimeSpan.FromSeconds(2));
+                image.Metadata = await httpClient.GetStringAsync(image.Metadata, cts.Token);
             }
             catch (Exception wcEx)
             {

--- a/src/Wellcome.Dds/Utils.Tests/StringUtilsTests.cs
+++ b/src/Wellcome.Dds/Utils.Tests/StringUtilsTests.cs
@@ -144,5 +144,34 @@ namespace Utils.Tests
             // Assert
             actual.Should().Be(expected);
         }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("path", "path")]
+        [InlineData("/path", "path")]
+        [InlineData("https://example.org/some/path", "path")]
+        [InlineData("https://example.org/some/long/path", "https://example.org/some/long/path")]
+        [InlineData("https://example.org/some/xxx/path", "https://example.org/some/long/path")]
+        [InlineData("https://example.org/some/long/path", "https://example.org/some/long/path", 2)]
+        [InlineData("https://example.org/xxx/long/path", "https://example.org/some/long/path", 2)]
+        public void PathElements_Are_Equivalent(string path1, string path2, int walkback = 1)
+        {
+            StringUtils.EndWithSamePathElements(path1, path2, walkback).Should().BeTrue();
+        }
+        
+        [Theory]
+        [InlineData(null, "xxx")]
+        [InlineData("", "xxx")]
+        [InlineData("path", "xxx")]
+        [InlineData("/path", "xxx")]
+        [InlineData("https://example.org/some/path", "xxx")]
+        [InlineData("https://example.org/some/long/path", "https://example.org/some/long/xxx")]
+        [InlineData("https://example.org/some/long/path", "https://example.org/some/xxx/path", 2)]
+        [InlineData("https://example.org/xxx/long/path", "https://example.org/some/long/path", 3)]
+        public void PathElements_Are_Not_Equivalent(string path1, string path2, int walkback = 1)
+        {
+            StringUtils.EndWithSamePathElements(path1, path2, walkback).Should().BeFalse();
+        }
     }
 }

--- a/src/Wellcome.Dds/Utils/StringUtils.cs
+++ b/src/Wellcome.Dds/Utils/StringUtils.cs
@@ -597,5 +597,33 @@ namespace Utils
 
             return String.Join(',', strings);
         }
+        
+        /// <summary>
+        /// To be used carefully when comparing raw strings and RESt resources
+        /// </summary>
+        /// <param name="s1"></param>
+        /// <param name="s2"></param>
+        /// <param name="countBack">How many path elements at the end to consider when matching</param>
+        /// <returns></returns>
+        public static bool EndWithSamePathElements(string? s1, string? s2, int countBack = 1)
+        {
+            if (s1 == s2) return true;
+            if (s1.IsNullOrEmpty() && s2.IsNullOrEmpty()) return true;
+            var parts1 = s1.SplitByDelimiterIntoArray('/');
+            var parts2 = s2.SplitByDelimiterIntoArray('/');
+            if (parts1.Length < countBack || parts2.Length < countBack)
+            {
+                return false;
+            }
+            for (int i = 1; i <= countBack; i++)
+            {
+                if (parts1[^i] != parts2[^i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/AssetExtensions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/AssetExtensions.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using Wellcome.Dds.AssetDomain.DigitalObjects;
+using Wellcome.Dds.AssetDomain.Mets;
+
+namespace Wellcome.Dds.AssetDomain;
+
+public static class AssetExtensions
+{        
+    public static bool IsVideoMimeType(this string? mimeType)
+    {
+        return mimeType != null && mimeType.StartsWith("video/");
+    }
+
+    public static bool IsAudioMimeType(this string? mimeType)
+    {
+        return mimeType != null && mimeType.StartsWith("audio/");
+    }
+
+    public static bool IsTimeBasedMimeType(this string? mimeType)
+    {
+        return mimeType.IsVideoMimeType() || mimeType.IsAudioMimeType();
+    }
+        
+    public static bool IsImageMimeType(this string? mimeType)
+    {
+        return mimeType != null && mimeType.StartsWith("image/");
+    }
+        
+    public static bool IsTextMimeType(this string? mimeType)
+    {
+        return mimeType != null && mimeType.StartsWith("text/");
+    }
+
+    public static IStoredFile? GetDefaultFile(this IPhysicalFile asset)
+    {
+        return asset.Files!.SingleOrDefault(f => f.StorageIdentifier == asset.StorageIdentifier);
+    }
+
+    public static IProcessingBehaviour GetDefaultProcessingBehaviour(this IPhysicalFile asset)
+    {
+        var defaultStoredFile = asset.GetDefaultFile();
+        return defaultStoredFile!.ProcessingBehaviour;
+    }
+    
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/AssetExtensions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/AssetExtensions.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using IIIF;
 using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Mets;
 
@@ -41,5 +42,21 @@ public static class AssetExtensions
         var defaultStoredFile = asset.GetDefaultFile();
         return defaultStoredFile!.ProcessingBehaviour;
     }
+    
+    public static Size? GetWhSize(this IPhysicalFile file)
+    {
+        var dimensions = file.AssetMetadata?.GetMediaDimensions();
+        if (dimensions == null) return null;
+            
+        var w = dimensions.Width.GetValueOrDefault();
+        var h = dimensions.Height.GetValueOrDefault();
+        if (w > 0 && h > 0)
+        {
+            return new Size(w, h);
+        }
+
+        return null;
+    }
+    
     
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DeliveredFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DeliveredFile.cs
@@ -10,7 +10,23 @@ public class DeliveredFile
     public string? DeliveryChannel { get; set; }
     
     public string? MediaType { get; set; }
-    public int Width { get; set; }
-    public int Height { get; set; }
-    public double Duration { get; set; }
+    public int? Width { get; set; }
+    public int? Height { get; set; }
+    public double? Duration { get; set; }
+
+    public string GetSummary()
+    {
+        var s = MediaType;
+        if (Duration.HasValue)
+        {
+            s += $"\nDuration: {Duration}";
+        }
+
+        if (Height.HasValue)
+        {
+            s += $"\nWidth: {Width}, Height: {Height}";
+        }
+
+        return s ?? "(no summary information)";
+    }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DeliveredFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DeliveredFile.cs
@@ -1,0 +1,16 @@
+namespace Wellcome.Dds.AssetDomain;
+
+/// <summary>
+/// Represents files and derivatives of files served by DLCS
+/// </summary>
+public class DeliveredFile
+{
+    public string? PublicUrl { get; set; }
+    public string? DlcsUrl { get; set; }
+    public string? DeliveryChannel { get; set; }
+    
+    public string? MediaType { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public double Duration { get; set; }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IDigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IDigitalObjectRepository.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomain.Dlcs.Ingest;
 using Wellcome.Dds.AssetDomain.Dlcs.Model;
+using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.Common;
 
 namespace Wellcome.Dds.AssetDomain.DigitalObjects
@@ -35,6 +36,13 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
         IngestAction LogAction(string manifestationId, int? jobId, string userName, string action, string? description = null);
         IEnumerable<IngestAction> GetRecentActions(int count, string? user = null);
         Task<Dictionary<string, long>> GetDlcsQueueLevel();
+        
+        
         AVDerivative[] GetAVDerivatives(IDigitalManifestation digitisedManifestation);
+
+
+        DeliveredFile[] GetDeliveredFiles(IPhysicalFile physicalFile);
+        DeliveredFile[] GetDeliveredFiles(IStoredFile? storedFile);
+
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IDigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IDigitalObjectRepository.cs
@@ -38,9 +38,6 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
         Task<Dictionary<string, long>> GetDlcsQueueLevel();
         
         
-        AVDerivative[] GetAVDerivatives(IDigitalManifestation digitisedManifestation);
-
-
         DeliveredFile[] GetDeliveredFiles(IPhysicalFile physicalFile);
         DeliveredFile[] GetDeliveredFiles(IStoredFile? storedFile);
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IProcessingBehaviour.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using IIIF;
 
 namespace Wellcome.Dds.AssetDomain.DigitalObjects;
 
@@ -6,4 +7,5 @@ public interface IProcessingBehaviour
 {
     HashSet<string> DeliveryChannels { get; }
     string? ImageOptimisationPolicy { get; }
+    Size? GetVideoSize(string deliveryChannel);
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
@@ -65,7 +65,7 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
         /// <summary>
         /// Files with no access condition in METS
         /// </summary>
-        public List<IStoredFile> MissingAccessConditions { get; set; }
+        public List<IStoredFile>? MissingAccessConditions { get; set; }
 
         public SyncOperation(DlcsCallContext dlcsCallContext)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
@@ -47,6 +47,7 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
         public Dictionary<string, Image?>? ImagesThatShouldBeOnDlcs { get; set; }
         public List<Image>? DlcsImagesToIngest { get; set; }
         public List<Image>? DlcsImagesToPatch { get; set; }
+        public Dictionary<string, List<string>>? Mismatches { get; set; }
         public List<Image>? DlcsImagesCurrentlyIngesting { get; set; }
         public List<Image>? Orphans { get; set; }
         /// <summary>

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/SyncOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Utils;
 using Wellcome.Dds.AssetDomain.Dlcs.Ingest;
 using Wellcome.Dds.AssetDomain.Dlcs.Model;
@@ -80,6 +81,12 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
 
         public string[] GetSummary()
         {
+            string syncReasons = "(no sync messages)";
+            if (Mismatches != null && Mismatches.Count > 0)
+            {
+                var first = Mismatches.First().Value;
+                syncReasons = string.Join(", ", first);
+            }
             var summary = new List<string>
             {
                 $"SyncOperationIdentifier: {SyncOperationIdentifier}",
@@ -91,7 +98,8 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
                 $"Ignored storage identifiers: {StorageIdentifiersToIgnore!.Count}",
                 $"Orphans: {Orphans!.Count}",
                 $"HasInvalidAccessCondition: {HasInvalidAccessCondition}",
-                $"Message: {Message}"
+                $"Message: {Message}",
+                $"SyncReason: {syncReasons}"
             };
             return summary.ToArray();
         }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/AssetFamily.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/AssetFamily.cs
@@ -31,31 +31,7 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
             }
             return AssetFamily.File;
         }
-        
-        public static bool IsVideoMimeType(this string? mimeType)
-        {
-            return mimeType != null && mimeType.StartsWith("video/");
-        }
 
-        public static bool IsAudioMimeType(this string? mimeType)
-        {
-            return mimeType != null && mimeType.StartsWith("audio/");
-        }
-
-        public static bool IsTimeBasedMimeType(this string? mimeType)
-        {
-            return mimeType.IsVideoMimeType() || mimeType.IsAudioMimeType();
-        }
-        
-        public static bool IsImageMimeType(this string? mimeType)
-        {
-            return mimeType != null && mimeType.StartsWith("image/");
-        }
-        
-        public static bool IsTextMimeType(this string? mimeType)
-        {
-            return mimeType != null && mimeType.StartsWith("text/");
-        }
     }
     
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
@@ -118,5 +118,6 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
         
         bool SupportsDeliveryChannels { get; }
         Task<Image?> GetImage(int space, string id, DlcsCallContext dlcsCallContext);
+        Task<Image?> ReingestImage(int space, string id, DlcsCallContext dlcsCallContext);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/IDlcs.cs
@@ -117,5 +117,6 @@ namespace Wellcome.Dds.AssetDomain.Dlcs
         string InternalResourceEntryPoint { get; }
         
         bool SupportsDeliveryChannels { get; }
+        Task<Image?> GetImage(int space, string id, DlcsCallContext dlcsCallContext);
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
@@ -15,7 +15,6 @@ namespace Wellcome.Dds.AssetDomain.Dlcs.Model
         public int? Space { get; set; }
 
         [JsonProperty(Order = 11, PropertyName = "infoJson")]
-        [Obsolete("Use metadata instead; the infoJson is produced from templates at runtime")]
         public string? InfoJson { get; set; }
 
         [JsonProperty(Order = 12, PropertyName = "degradedInfoJson")]

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
@@ -14,14 +14,11 @@ namespace Wellcome.Dds.AssetDomain.Dlcs.Model
         [JsonProperty(Order = 10, PropertyName = "space")]
         public int? Space { get; set; }
 
-        [JsonProperty(Order = 11, PropertyName = "infoJson")]
-        public string? InfoJson { get; set; }
+        [JsonProperty(Order = 11, PropertyName = "imageService")]
+        public string? ImageService { get; set; }
 
-        [JsonProperty(Order = 12, PropertyName = "degradedInfoJson")]
-        public string? DegradedInfoJson { get; set; }
-
-        [JsonProperty(Order = 13, PropertyName = "thumbnailInfoJson")]
-        public string? ThumbnailInfoJson { get; set; }
+        [JsonProperty(Order = 13, PropertyName = "thumbnailImageService")]
+        public string? ThumbnailImageService { get; set; }
 
         [JsonProperty(Order = 13, PropertyName = "thumbnail400")]
         public string? Thumbnail400 { get; set; }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
@@ -116,7 +116,7 @@ namespace Wellcome.Dds.AssetDomain.Dlcs.Model
         [JsonProperty(Order = 81, PropertyName = "thumbnailPolicy")]
         public string? ThumbnailPolicy { get; set; }
 
-        [JsonProperty(Order = 82, PropertyName = "deliveryChannel")]
+        [JsonProperty(Order = 82, PropertyName = "deliveryChannels")]
         public string[]? DeliveryChannels { get; set; }
     }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/Model/Image.cs
@@ -120,7 +120,7 @@ namespace Wellcome.Dds.AssetDomain.Dlcs.Model
         public string? ThumbnailPolicy { get; set; }
 
         [JsonProperty(Order = 82, PropertyName = "deliveryChannel")]
-        public string? DeliveryChannel { get; set; }
+        public string[]? DeliveryChannels { get; set; }
     }
 
     public class Thumbnail

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Mets/IPhysicalFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Mets/IPhysicalFile.cs
@@ -72,6 +72,5 @@ namespace Wellcome.Dds.AssetDomain.Mets
         string? RelativeTranscriptPath { get; set; }
         string? RelativeMasterPath { get; set; }
         
-        IProcessingBehaviour ProcessingBehaviour { get; }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Mets/IStoredFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Mets/IStoredFile.cs
@@ -1,4 +1,5 @@
 ﻿using Utils.Storage;
+using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Dlcs;
 
 namespace Wellcome.Dds.AssetDomain.Mets
@@ -48,6 +49,9 @@ namespace Wellcome.Dds.AssetDomain.Mets
         /// The METS PhysicalFile this stored file belongs to
         /// </summary>
         IPhysicalFile? PhysicalFile { get; set; }
+        
+        
+        IProcessingBehaviour ProcessingBehaviour { get; }
         
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="iiif-net" Version="0.1.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
@@ -30,7 +30,7 @@ public class ProcessingBehaviourTests
 
         var processing = storedFile.ProcessingBehaviour;
 
-        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-img" || s == "thumbs");
+        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-img");
     }
     
     
@@ -162,7 +162,8 @@ public class ProcessingBehaviourTests
 
         var processing = pf.Files[0].ProcessingBehaviour;
 
-        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av" || s == "file");
+        var expected = new HashSet<string> { "iiif-av", "file" };
+        processing.DeliveryChannels.Should().BeEquivalentTo(expected);
     }
     
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
@@ -10,6 +10,13 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.DlcsSynchronisation;
 
 public class ProcessingBehaviourTests
 {
+    private StoredFile MakeStoredFile()
+    {
+        var pf = MakePhysicalFile();
+        pf.Files = new List<IStoredFile> { new StoredFile{PhysicalFile = pf } };
+        return pf.Files[0] as StoredFile;
+    }
+    
     private PhysicalFile MakePhysicalFile()
     {
         return new PhysicalFile(A.Fake<ArchiveStorageServiceWorkStore>(), "dummy");
@@ -18,10 +25,10 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Image_Has_IIIF_and_thumbs_Delivery_Channel()
     {
-        var pf = MakePhysicalFile();
-        pf.MimeType = "image/jpg";
+        var storedFile = MakeStoredFile();
+        storedFile.MimeType = "image/jpg";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = storedFile.ProcessingBehaviour;
 
         processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-img" || s == "thumbs");
     }
@@ -30,7 +37,7 @@ public class ProcessingBehaviourTests
     [Fact]
     public void MP3_Has_File_Delivery_Channel()
     {
-        var pf = MakePhysicalFile();
+        var pf = MakeStoredFile();
         pf.MimeType = "audio/x-mpeg-3";
 
         var processing = pf.ProcessingBehaviour;
@@ -42,7 +49,7 @@ public class ProcessingBehaviourTests
     [Fact]
     public void MP3_Has_None_IOP()
     {
-        var pf = MakePhysicalFile();
+        var pf = MakeStoredFile();
         pf.MimeType = "audio/x-mpeg-3";
 
         var processing = pf.ProcessingBehaviour;
@@ -54,7 +61,7 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Wav_Has_IIIF_AV_Delivery_Channel()
     {
-        var pf = MakePhysicalFile();
+        var pf = MakeStoredFile();
         pf.MimeType = "audio/wav";
 
         var processing = pf.ProcessingBehaviour;
@@ -65,7 +72,7 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Wav_Has_Null_IOP()
     {
-        var pf = MakePhysicalFile();
+        var pf = MakeStoredFile();
         pf.MimeType = "audio/wav";
 
         var processing = pf.ProcessingBehaviour;
@@ -76,7 +83,7 @@ public class ProcessingBehaviourTests
     [Fact]
     public void mpeg_Has_IIIF_AV_Delivery_Channel()
     {
-        var pf = MakePhysicalFile();
+        var pf = MakeStoredFile();
         pf.MimeType = "video/mpeg-2";
 
         var processing = pf.ProcessingBehaviour;
@@ -87,7 +94,7 @@ public class ProcessingBehaviourTests
     [Fact]
     public void mpeg_Has_Null_IOP()
     {
-        var pf = MakePhysicalFile();
+        var pf = MakeStoredFile();
         pf.MimeType = "video/mpeg-2";
 
         var processing = pf.ProcessingBehaviour;
@@ -101,11 +108,11 @@ public class ProcessingBehaviourTests
         var pf = MakePhysicalFile();
         pf.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4" }
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf }
         };
         pf.MimeType = "video/mp4";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = pf.Files[0].ProcessingBehaviour;
 
         processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av");
     }    
@@ -116,11 +123,11 @@ public class ProcessingBehaviourTests
         var pf = MakePhysicalFile();
         pf.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4" }  // Mp4 on its own
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf }  // Mp4 on its own
         };
         pf.MimeType = "video/mp4";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = pf.Files[0].ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().BeNull();
     }
@@ -131,13 +138,13 @@ public class ProcessingBehaviourTests
         var pf = MakePhysicalFile();
         pf.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4" },       // the access copy
-            new StoredFile { MimeType = "application/mxf" }  // the master
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf },       // the access copy
+            new StoredFile { MimeType = "application/mxf", PhysicalFile = pf }  // the master
         };
         pf.MimeType = "video/mp4";
-        SetHeight(pf, 720);
+        SetHeight(pf.Files[0], 720);
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = pf.Files[0].ProcessingBehaviour;
 
         processing.DeliveryChannels.Should().OnlyContain(s => s == "file");
     }
@@ -147,23 +154,23 @@ public class ProcessingBehaviourTests
         var pf = MakePhysicalFile();
         pf.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4" },       // the access copy
-            new StoredFile { MimeType = "application/mxf" }  // the master
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf},       // the access copy
+            new StoredFile { MimeType = "application/mxf", PhysicalFile = pf }  // the master
         };
         pf.MimeType = "video/mp4";
-        SetHeight(pf, 1440);
+        SetHeight(pf.Files[0], 1440);
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = pf.Files[0].ProcessingBehaviour;
 
         processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av" || s == "file");
     }
     
 
-    private static void SetHeight(PhysicalFile pf, int height)
+    private static void SetHeight(IStoredFile sf, int height)
     {
         var assetMetadata = A.Fake<IAssetMetadata>();
         A.CallTo(() => assetMetadata.GetMediaDimensions()).Returns(new MediaDimensions { Height = height });
-        pf.AssetMetadata = assetMetadata;
+        sf.AssetMetadata = assetMetadata;
     }
 
     [Fact]
@@ -172,13 +179,13 @@ public class ProcessingBehaviourTests
         var pf = MakePhysicalFile();
         pf.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4" },       // the access copy
-            new StoredFile { MimeType = "application/mxf" }  // the master
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf },       // the access copy
+            new StoredFile { MimeType = "application/mxf", PhysicalFile = pf }  // the master
         };
         pf.MimeType = "video/mp4";
-        SetHeight(pf, 720);
+        SetHeight(pf.Files[0], 720);
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = pf.Files[0].ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().Be("none");
     }
@@ -189,13 +196,13 @@ public class ProcessingBehaviourTests
         var pf = MakePhysicalFile();
         pf.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4" },       // the access copy
-            new StoredFile { MimeType = "application/mxf" }  // the master
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf },       // the access copy
+            new StoredFile { MimeType = "application/mxf", PhysicalFile = pf }  // the master
         };
         pf.MimeType = "video/mp4";
-        SetHeight(pf, 1440);
+        SetHeight(pf.Files[0], 1440);
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = pf.Files[0].ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().BeNull();
     }
@@ -208,12 +215,12 @@ public class ProcessingBehaviourTests
         var pf = MakePhysicalFile();
         pf.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4" }
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf }
         };
         pf.MimeType = "video/mp4";
-        SetHeight(pf, 1440);
+        SetHeight(pf.Files[0], 1440);
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = pf.Files[0].ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().BeNull();
         // processing.ImageOptimisationPolicy.Should().Be("QHD");

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -851,7 +851,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
 
             if (dlcs.SupportsDeliveryChannels)
             {
-                var processing = asset.PhysicalFile.ProcessingBehaviour;
+                var processing = asset.ProcessingBehaviour;
                 imageRegistration.ImageOptimisationPolicy = processing.ImageOptimisationPolicy;
                 imageRegistration.DeliveryChannels = processing.DeliveryChannels.ToArray();
                 imageRegistration.Family = null;

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -632,6 +632,9 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                     reingestImage ??= newDlcsImage;
                 }
 
+                // We don't yet support editing the thumbnail policy, but when we do, it will look like this.
+                // For that to work, the expected policy will need to be set in ProcessingBehaviour
+                /*
                 if (!StringUtils.EndWithSamePathElements(existingDlcsImage.ThumbnailPolicy, newDlcsImage.ThumbnailPolicy))
                 {
                     logger.LogDebug(reingestMessageStructuredLoggingFormat, newDlcsImage.StorageIdentifier, 
@@ -640,7 +643,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                         "thumbnailPolicy", newDlcsImage.ThumbnailPolicy, existingDlcsImage.ThumbnailPolicy));
                     reingestImage ??= newDlcsImage;
                 }
-
+                */
+                
                 if (!AreEqual(existingDlcsImage.DeliveryChannels, newDlcsImage.DeliveryChannels))
                 {
                     logger.LogDebug(reingestMessageStructuredLoggingFormat, newDlcsImage.StorageIdentifier,

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -767,6 +767,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                 // remove fields not permitted in patch:
                 patchImage.Origin = null;
                 patchImage.MaxUnauthorised = null;
+                patchImage.ImageOptimisationPolicy = null;
+                patchImage.DeliveryChannels = null;
                 // others?
             }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -14,7 +14,6 @@ using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomain.Dlcs.Ingest;
 using Wellcome.Dds.AssetDomain.Dlcs.Model;
 using Wellcome.Dds.AssetDomain.Mets;
-using Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
 
@@ -591,7 +590,6 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
         /// <param name="existingDlcsImage"></param>
         /// <param name="reasons"></param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
         private Image? GetIngestDiffImage(Image newDlcsImage, Image existingDlcsImage, out List<string> reasons)
         {
             reasons = new List<string>();
@@ -650,6 +648,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                     reingestImage ??= newDlcsImage;
                 }
                 */
+                
+                // See https://github.com/dlcs/protagonist/issues/489 for the above.
                 
                 if (!AreEqual(existingDlcsImage.DeliveryChannels, newDlcsImage.DeliveryChannels))
                 {

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -623,6 +623,10 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
             // We also need to consider what's significant when either new or existing are null
             if (dlcs.SupportsDeliveryChannels)
             {
+                // While we now set IOP to `use-original` for JP2s, we're relying on DLCS defaults for everything else still.
+                // So we can't make this check just yet, because the DDS will assume no policy, which is a mismatch from 
+                // the DLCS' assigned default policy (e.g., `video-max`)
+                /*
                 if (!StringUtils.EndWithSamePathElements(existingDlcsImage.ImageOptimisationPolicy, newDlcsImage.ImageOptimisationPolicy))
                 {
                     logger.LogDebug(reingestMessageStructuredLoggingFormat, newDlcsImage.StorageIdentifier, 
@@ -631,6 +635,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                         "imageOptimisationPolicy", newDlcsImage.ImageOptimisationPolicy, existingDlcsImage.ImageOptimisationPolicy));
                     reingestImage ??= newDlcsImage;
                 }
+                */
 
                 // We don't yet support editing the thumbnail policy, but when we do, it will look like this.
                 // For that to work, the expected policy will need to be set in ProcessingBehaviour

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -778,7 +778,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
             {
                 var processing = asset.PhysicalFile.ProcessingBehaviour;
                 imageRegistration.ImageOptimisationPolicy = processing.ImageOptimisationPolicy;
-                imageRegistration.DeliveryChannel = processing.DeliveryChannels.ToCommaDelimitedList();
+                imageRegistration.DeliveryChannels = processing.DeliveryChannels.ToArray();
                 imageRegistration.Family = null;
             }
             return imageRegistration;

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/IgnoreAssetFilter.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/IgnoreAssetFilter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomain.Mets;
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/BornDigitalManifestation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/BornDigitalManifestation.cs
@@ -43,7 +43,7 @@ public class BornDigitalManifestation : IManifestation
     
     // Going to assume that this isn't relevant any more - or will need a whole new set of operations.
     // This was originally for UV - allow download etc, allow crop,...
-    public string[] PermittedOperations => Array.Empty<string>();
+    public string[] PermittedOperations => new[] { "wholeImageHighResAsJpg" };
 
     // This is not very useful for born digital items, where a sequence can be mixed media
     public string? FirstInternetType => Sequence!.First().MimeType;

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
@@ -303,9 +303,6 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                                       ?? throw new InvalidOperationException("File Element has no ID attribute"));
         }
 
-        private IProcessingBehaviour? processingBehaviour;
-        public IProcessingBehaviour ProcessingBehaviour => processingBehaviour ??= new ProcessingBehaviour(
-            this, new ProcessingBehaviourOptions());
     }
     
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PremisMetadata.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PremisMetadata.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using Utils;
+using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomain.Mets;
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PronomData.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PronomData.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using Utils;
+using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.Dlcs;
 
 namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model;

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/StoredFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/StoredFile.cs
@@ -1,6 +1,8 @@
 ﻿using Wellcome.Dds.AssetDomain;
+using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomain.Mets;
+using Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
 
 namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
 {
@@ -20,5 +22,9 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
         public string? Use { get; set; }
         public AssetFamily Family { get; set; }
         public IPhysicalFile? PhysicalFile { get; set; }
+        
+        private IProcessingBehaviour? processingBehaviour;
+        public IProcessingBehaviour ProcessingBehaviour => processingBehaviour ??= new ProcessingBehaviour(
+            this, new ProcessingBehaviourOptions());
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomainRepositories.Mets.Model;

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using IIIF;
 using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Dlcs;
@@ -10,6 +11,8 @@ public class ProcessingBehaviour : IProcessingBehaviour
 {
     public HashSet<string> DeliveryChannels { get; }
     public string? ImageOptimisationPolicy { get; }
+
+    private Dictionary<string, Size>? videoSizesByChannel;
 
     public ProcessingBehaviour(StoredFile storedFile, ProcessingBehaviourOptions options)
     {
@@ -91,6 +94,14 @@ public class ProcessingBehaviour : IProcessingBehaviour
 
             if (DeliveryChannels.Contains("iiif-av"))
             {
+                // This assumes only one video is produced, but keeps the knowledge that
+                // the default AV IOP creates 720p videos confined to this ProcessingBehaviour implementation.
+                
+                videoSizesByChannel = new Dictionary<string, Size>(1)
+                {
+                    ["iiif-av"] = new Size(1280, 720)
+                };
+
                 // We need to set the ImageOptimsationPolicy
                 // At the moment this always returns videoDefault but the logic is here to do other things.
                 // But what policy are we going to pick? The following allows that to be based on resolution:
@@ -130,5 +141,10 @@ public class ProcessingBehaviour : IProcessingBehaviour
             ImageOptimisationPolicy = "none";
             DeliveryChannels.Add("file");
         }
+    }
+
+    public Size? GetVideoSize(string deliveryChannel)
+    {
+        return videoSizesByChannel?[deliveryChannel];
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
@@ -10,7 +10,7 @@ public class ProcessingBehaviour : IProcessingBehaviour
     public HashSet<string> DeliveryChannels { get; }
     public string? ImageOptimisationPolicy { get; }
 
-    public ProcessingBehaviour(PhysicalFile physicalFile, ProcessingBehaviourOptions options)
+    public ProcessingBehaviour(StoredFile storedFile, ProcessingBehaviourOptions options)
     {
         DeliveryChannels = new HashSet<string>();
         string? videoDefault = options.UseNamedAVDefaults ? "video-max" : null;
@@ -20,7 +20,7 @@ public class ProcessingBehaviour : IProcessingBehaviour
         // if we leave ImageOptimisationPolicy empty.
 
         // Images:
-        if (physicalFile.MimeType.IsImageMimeType())
+        if (storedFile.MimeType.IsImageMimeType())
         {
             DeliveryChannels.Add("iiif-img");
             if (options.AddThumbsAsSeparateChannel)
@@ -32,7 +32,7 @@ public class ProcessingBehaviour : IProcessingBehaviour
                 DeliveryChannels.Add("file");
             }
 
-            if (physicalFile.MimeType == "image/jp2")
+            if (storedFile.MimeType == "image/jp2")
             {
                 ImageOptimisationPolicy = "use-original";
                 if (options.MakeJP2Available || options.MakeAllSourceImagesAvailable)
@@ -43,9 +43,9 @@ public class ProcessingBehaviour : IProcessingBehaviour
         }
 
         // Audio:
-        else if (physicalFile.MimeType.IsAudioMimeType())
+        else if (storedFile.MimeType.IsAudioMimeType())
         {
-            if (physicalFile.MimeType is "audio/mp3" or "audio/x-mpeg-3")
+            if (storedFile.MimeType is "audio/mp3" or "audio/x-mpeg-3")
             {
                 ImageOptimisationPolicy = "none";
                 DeliveryChannels.Add("file");
@@ -58,12 +58,12 @@ public class ProcessingBehaviour : IProcessingBehaviour
         }
 
         // Video:
-        else if (physicalFile.MimeType.IsVideoMimeType())
+        else if (storedFile.MimeType.IsVideoMimeType())
         {
-            var height = physicalFile.AssetMetadata?.GetMediaDimensions().Height;
+            var height = storedFile.AssetMetadata?.GetMediaDimensions().Height;
 
-            if (physicalFile.MimeType == "video/mp4" &&
-                physicalFile.Files!.Exists(f => f.MimeType == "application/mxf"))
+            if (storedFile.MimeType == "video/mp4" &&
+                storedFile.PhysicalFile!.Files!.Exists(f => f.MimeType == "application/mxf"))
             {
                 // At the moment we are saying that if this MP4 accompanies an MXF master,
                 // then it is the access copy and we can use it as-is.

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviour.cs
@@ -23,7 +23,10 @@ public class ProcessingBehaviour : IProcessingBehaviour
         if (physicalFile.MimeType.IsImageMimeType())
         {
             DeliveryChannels.Add("iiif-img");
-            DeliveryChannels.Add("thumbs");
+            if (options.AddThumbsAsSeparateChannel)
+            {
+                DeliveryChannels.Add("thumbs");
+            }
             if (options.MakeAllSourceImagesAvailable)
             {
                 DeliveryChannels.Add("file");

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviourOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviourOptions.cs
@@ -4,7 +4,8 @@ public class ProcessingBehaviourOptions
 {
     public bool UseNamedAVDefaults { get; set; } = false;
     public bool MakeAllSourceImagesAvailable { get; set; } = false;
-    public bool MakeJP2Available { get; set; } = true;
+    public bool MakeJP2Available { get; set; } = false;
+    public bool AddThumbsAsSeparateChannel { get; set; } = false;
     public int MaxUntranscodedAccessMp4 { get; set; } = 720;
     public bool MakeAllAccessMP4sAvailable { get; set; } = true;
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/AssetController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/AssetController.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DlcsWebClient.Config;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+using Utils;
+using Wellcome.Dds.AssetDomain;
+using Wellcome.Dds.AssetDomain.Dlcs;
+using Wellcome.Dds.AssetDomain.Dlcs.Model;
+using Wellcome.Dds.Dashboard.Models;
+
+namespace Wellcome.Dds.Dashboard.Controllers;
+
+[Route("[controller]")]
+public class AssetController : Controller
+{
+    private readonly ILogger<AssetController> logger;
+    private readonly IDlcs dlcs;
+    private readonly DlcsOptions dlcsOptions;
+    private readonly HttpClient httpClient;
+    
+    public AssetController(
+        ILogger<AssetController> logger,
+        IDlcs dlcs,
+        IOptions<DlcsOptions> options,
+        HttpClient httpClient)
+    {
+        this.logger = logger;
+        this.dlcs = dlcs;
+        dlcsOptions = options.Value;
+        this.httpClient = httpClient;
+    }
+
+    [HttpGet]
+    [Route("{space}/{id}")]
+    public async Task<ActionResult> Index(int space, string id)
+    {
+        var imgCallContext = new DlcsCallContext("AssetController::Index-GetImage", $"{space}/{id}");
+        var image = await dlcs.GetImage(space, id, imgCallContext);
+        // var storageCallContext = new DlcsCallContext("AssetController::Index-GetImageStorage", $"{space}/{id}");
+        // var storage = await dlcs.GetImageStorage(space, id, storageCallContext);
+        var model = new AssetModel
+        {
+            Space = space,
+            ModelId = id,
+            Asset = image,
+            DlcsPortalPage = string.Format(dlcsOptions.PortalPageTemplate!, space, image?.StorageIdentifier),
+            Thumbnails = await GetThumbnails(image?.ThumbnailInfoJson)
+            // Storage = some new storage object from API,
+            // see https://api.dlcs.io/customers/2/spaces/5/images/b31404777_0001.jp2/storage and 
+            // https://api.dlcs.io/customers/2/spaces/5/images/b20018484_0055-0000-7064-0000-0-0000-0000-0.mpg/storage
+            // (latter does not work)
+        };
+        return View(model);
+    }
+
+    private async Task<List<Thumbnail>> GetThumbnails(string thumbnailInfoJsonJson)
+    {
+        if (thumbnailInfoJsonJson.HasText())
+        {
+            var thumbs = new List<Thumbnail>();
+            try
+            {
+                var info = JObject.Parse(await httpClient.GetStringAsync(thumbnailInfoJsonJson));
+                var sizes = info["sizes"];
+                foreach (var size in sizes.Cast<JObject>())
+                {
+                    var thumb = new Thumbnail()
+                    {
+                        Width = size.Value<int>("width"),
+                        Height = size.Value<int>("height"),
+                    };
+                    thumb.Src = $"{thumbnailInfoJsonJson}/full/{thumb.Width},{thumb.Height}/0/default.jpg";
+                    thumbs.Add(thumb);
+                }
+
+                return thumbs;
+            } catch {}
+        }
+
+        return null;
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/AssetController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/AssetController.cs
@@ -51,7 +51,7 @@ public class AssetController : Controller
             Asset = image,
             DlcsPortalPage = string.Format(dlcsOptions.PortalPageTemplate!, space, image?.StorageIdentifier),
             SingleAssetManifest = string.Format(dlcsOptions.SingleAssetManifestTemplate!, space, image?.StorageIdentifier),
-            Thumbnails = await GetThumbnails(image?.ThumbnailInfoJson)
+            Thumbnails = await GetThumbnails(image?.ThumbnailImageService)
             // Storage = some new storage object from API,
             // see https://api.dlcs.io/customers/2/spaces/5/images/b31404777_0001.jp2/storage and 
             // https://api.dlcs.io/customers/2/spaces/5/images/b20018484_0055-0000-7064-0000-0-0000-0000-0.mpg/storage

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/AssetModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/AssetModel.cs
@@ -9,5 +9,6 @@ public class AssetModel
     public int Space { get; set; }
     public Image Asset { get; set; }
     public string DlcsPortalPage { get; set; }
+    public string SingleAssetManifest { get; set; }
     public List<Thumbnail> Thumbnails { get; set; }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/AssetModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/AssetModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Wellcome.Dds.AssetDomain.Dlcs.Model;
+
+namespace Wellcome.Dds.Dashboard.Models;
+
+public class AssetModel
+{
+    public string ModelId { get; set; }
+    public int Space { get; set; }
+    public Image Asset { get; set; }
+    public string DlcsPortalPage { get; set; }
+    public List<Thumbnail> Thumbnails { get; set; }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
@@ -288,14 +288,14 @@ namespace Wellcome.Dds.Dashboard.Models
             return null;
         }
 
-        public List<string> GetProblems(string storageIdentifier)
+        public string GetProblemMessage(string storageIdentifier)
         {
             if (SyncOperation.Mismatches.ContainsKey(storageIdentifier))
             {
-                return SyncOperation.Mismatches[storageIdentifier];
+                return string.Join("\r\n", SyncOperation.Mismatches[storageIdentifier]);
             }
 
-            return new List<string>(0);
+            return null;
         }
 
         public bool IsIgnored(string storageIdentifier)

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
@@ -288,6 +288,16 @@ namespace Wellcome.Dds.Dashboard.Models
             return null;
         }
 
+        public List<string> GetProblems(string storageIdentifier)
+        {
+            if (SyncOperation.Mismatches.ContainsKey(storageIdentifier))
+            {
+                return SyncOperation.Mismatches[storageIdentifier];
+            }
+
+            return new List<string>(0);
+        }
+
         public bool IsIgnored(string storageIdentifier)
         {
             return SyncOperation.StorageIdentifiersToIgnore.Contains(storageIdentifier);

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,6 +15,7 @@ using Wellcome.Dds.AssetDomain.Dlcs.Model;
 using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.Catalogue;
 using Wellcome.Dds.Common;
+using ICollection = Wellcome.Dds.AssetDomain.Mets.ICollection;
 
 namespace Wellcome.Dds.Dashboard.Models
 {
@@ -453,12 +455,13 @@ namespace Wellcome.Dds.Dashboard.Models
         }
 
 
-        public AVDerivative[] AVDerivatives { get; set; }
+        public Dictionary<string, DeliveredFile[]> DeliveredFilesMap { get; set; }
         public Work Work { get; set; }
         public string WorkPage { get; set; }
         public string CatalogueApi { get; set; }
         public string CatalogueApiFull { get; set; }
         public string ManifestUrl { get; set; }
+        public object GetDeliveredFiles { get; set; }
 
         /// <summary>
         /// return the additional (adjunct) files that need to be displayed in the dashboard
@@ -482,6 +485,7 @@ namespace Wellcome.Dds.Dashboard.Models
             }    
             return String.Empty;
         }
+
     }
 
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModelBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModelBuilder.cs
@@ -131,7 +131,7 @@ namespace Wellcome.Dds.Dashboard.Models
                         DlcsOptions = dlcsOptions,
                         DlcsSkeletonManifest = skeletonPreview,
                         Work = work,
-                        ManifestUrl = uriPatterns.Manifest(identifier),
+                        ManifestUrl = uriPatterns.Manifest(identifier)
                     };
                     if (work != null)
                     {

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModelBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModelBuilder.cs
@@ -131,7 +131,7 @@ namespace Wellcome.Dds.Dashboard.Models
                         DlcsOptions = dlcsOptions,
                         DlcsSkeletonManifest = skeletonPreview,
                         Work = work,
-                        ManifestUrl = uriPatterns.Manifest(identifier)
+                        ManifestUrl = uriPatterns.Manifest(identifier),
                     };
                     if (work != null)
                     {
@@ -142,7 +142,13 @@ namespace Wellcome.Dds.Dashboard.Models
                         model.WorkPage = uriPatterns.PersistentPlayerUri(work.Id);
                     }
 
-                    model.AVDerivatives = digitalObjectRepository.GetAVDerivatives(dgManifestation);
+                    model.DeliveredFilesMap = new Dictionary<string, DeliveredFile[]>();
+                    foreach (var file in dgManifestation.MetsManifestation!.SynchronisableFiles!)
+                    {
+                        model.DeliveredFilesMap[file.StorageIdentifier!] =
+                            digitalObjectRepository.GetDeliveredFiles(file);
+                    }
+                    
                     model.MakeManifestationNavData();
                     jobLogger.Log("Start dashboardRepository.GetRationalisedJobActivity(syncOperation)");
                     var jobActivity = await digitalObjectRepository.GetRationalisedJobActivity(syncOperation, dlcsCallContext);

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
@@ -4,18 +4,40 @@
 
 <div class="row" style="margin-top: 1em;">
 
+    
+    @if (TempData["reingest-asset"] != null)
+    {
+        <div class="alert alert-success alert-dismissible" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <strong>The DLCS was told to reingest this asset.</strong>
+        </div>
+    }
+    
     <div class="col-md-3">
-        <h3>Jobs</h3>
+        <h3>Preview</h3>
         <ul class="list-group">
             <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Edit</a>
+                <a href="@Model.SingleAssetManifest"><span class="glyphicon glyphicon-file"></span> Single IIIF Manifest</a>
             </li>    
             <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Reingest</a>
+                <a href="https://universalviewer.io/examples/#?manifest=@Model.SingleAssetManifest"><span class="glyphicon glyphicon-eye-open"></span> In UV</a>
             </li>    
             <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Delete</a>
+                <a href="https://tomcrane.github.io/scratch/mirador3/index.html?iiif-content=@Model.SingleAssetManifest"><span class="glyphicon glyphicon-eye-open"></span> In Mirador</a>
             </li>   
+        </ul>
+        
+        <h3>Actions</h3>
+        <ul class="list-group">
+            <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-pencil"></span> Edit (soon)</a>
+            </li>
+            <li class="list-group-item">    
+                <a href="@Url.Action("Reingest", new { space = Model.Space, id=Model.ModelId })"><span class="glyphicon glyphicon-transfer"></span> Reingest</a>
+            </li>
+            <li class="list-group-item">
+                <a href="@Url.Action("Delete", new { space = Model.Space, id=Model.ModelId })"><span class="glyphicon glyphicon-remove"></span> Delete</a>
+            </li>
         </ul>
     </div>
     
@@ -46,6 +68,10 @@
     <tr>
         <td>Family / Media Type</td>
         <td>@Model.Asset.Family / @Model.Asset.MediaType</td>
+    </tr>
+    <tr>
+        <td>Delivery Channels</td>
+        <td>@String.Join(", ", Model.Asset.DeliveryChannels ?? new[]{"(no delivery channels)"})</td>
     </tr>
     <tr>
         <td>Size</td>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
@@ -165,14 +165,14 @@
 </table>
 
 @{
-    if (Model.Asset.ImageService.HasText())
+    if (Model.Asset.MediaType.IsImageMimeType())
     {
         <h2>IIIF Image</h2>
         <div id="osd" style="width:100%; height: 500px; border: 1px solid gray;"></div>
     }
 
 
-    if (Model.Asset.ThumbnailImageService.HasText())
+    if (Model.Thumbnails.HasItems())
     {
         <h2>Thumbnails</h2>
         @foreach (var thumb in Model.Thumbnails)
@@ -191,7 +191,7 @@
 
 @section scripts
 {
-    @if (Model.Asset.ImageService.HasText())
+    @if (Model.Asset.MediaType.IsImageMimeType())
     {
         <script>
             const viewer1 = OpenSeadragon({

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
@@ -1,0 +1,171 @@
+@model AssetModel
+
+<h2>Space @Model.Space<text>:</text> @Model.ModelId</h2>
+
+<div class="row" style="margin-top: 1em;">
+
+    <div class="col-md-3">
+        <h3>Jobs</h3>
+        <ul class="list-group">
+            <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Edit</a>
+            </li>    
+            <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Reingest</a>
+            </li>    
+            <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-info-sign"></span> Delete</a>
+            </li>   
+        </ul>
+    </div>
+    
+    <div class="col-md-9">
+        
+<p><a href="@Model.DlcsPortalPage" target="_blank">View in DLCS portal</a></p>
+
+<table class="table">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Value</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>API Endpoint</td>
+        <td><a href="@Model.Asset.Id">@Model.Asset.Id</a></td>
+    </tr>
+    <tr>
+        <td>Image API Endpoint (info.json)</td>
+        <td><a href="@Model.Asset.InfoJson">@Model.Asset.InfoJson</a></td>
+    </tr>
+    <tr>
+        <td>Thumbnail Image API Endpoint (info.json)</td>
+        <td><a href="@Model.Asset.ThumbnailInfoJson">@Model.Asset.ThumbnailInfoJson</a></td>
+    </tr>
+    <tr>
+        <td>Family / Media Type</td>
+        <td>@Model.Asset.Family / @Model.Asset.MediaType</td>
+    </tr>
+    <tr>
+        <td>Size</td>
+        <td>(todo - not on Asset)</td>
+    </tr>
+    <tr>
+        <td>Thumbnail size</td>
+        <td>(todo - not on Asset)</td>
+    </tr>
+    <tr>
+        <td>AV derivatives</td>
+        <td>(todo - not on Asset, will be storage)</td>
+    </tr>
+    <tr>
+        <td>Created</td>
+        <td>@StringUtils.GetFriendlyAge(Model.Asset.Created)</td>
+    </tr>
+    <tr>
+        <td>Ingesting</td>
+        <td>@Model.Asset.Ingesting</td>
+    </tr>
+    <tr>
+        <td>Finished</td>
+        <td>@StringUtils.GetFriendlyAge(Model.Asset.Finished)</td>
+    </tr>
+    <tr>
+        <td>Origin</td>
+        <td><a href="@Model.Asset.Origin">@Model.Asset.Origin</a></td>
+    </tr>
+    <tr>
+        <td>Width x Height</td>
+        <td>@Model.Asset.Width x @Model.Asset.Height</td>
+    </tr>
+    <tr>
+        <td>Duration</td>
+        <td>@Model.Asset.Duration</td>
+    </tr>
+    <tr>
+        <td>String1</td>
+        <td>@Model.Asset.String1</td>
+    </tr>
+    <tr>
+        <td>String2</td>
+        <td>@Model.Asset.String2</td>
+    </tr>
+    <tr>
+        <td>String3</td>
+        <td>@Model.Asset.String3</td>
+    </tr>
+    <tr>
+        <td>Number1</td>
+        <td>@Model.Asset.Number1</td>
+    </tr>
+    <tr>
+        <td>Number2</td>
+        <td>@Model.Asset.Number2</td>
+    </tr>
+    <tr>
+        <td>Number3</td>
+        <td>@Model.Asset.Number3</td>
+    </tr>
+    <tr>
+        <td>Tags</td>
+        <td>@string.Join(',', Model.Asset.Tags ?? Array.Empty<string>())</td>
+    </tr>
+    <tr>
+        <td>Roles</td>
+        <td>@string.Join(',', Model.Asset.Roles ?? Array.Empty<string>())</td>
+    </tr>
+    <tr>
+        <td>Max Unauthorised</td>
+        <td>@Model.Asset.MaxUnauthorised</td>
+    </tr>
+    <tr>
+        <td>Batch</td>
+        <td><a href="@Model.Asset.Batch">@Model.Asset.Batch</a></td>
+    </tr>
+    <tr>
+        <td>Error</td>
+        <td>@Model.Asset.Error</td>
+    </tr>
+    </tbody>
+</table>
+
+@{
+    if (Model.Asset.InfoJson.HasText())
+    {
+        <h2>IIIF Image</h2>
+        <div id="osd" style="width:100%; height: 500px; border: 1px solid gray;"></div>
+    }
+
+
+    if (Model.Asset.ThumbnailInfoJson.HasText())
+    {
+        <h2>Thumbnails</h2>
+        @foreach (var thumb in Model.Thumbnails)
+        {
+            <p>@thumb.Width x @thumb.Height</p>
+            <img src="@thumb.Src" />                    
+        }
+        
+    }
+}
+    </div>
+    
+</div>
+
+
+
+@section scripts
+{
+    @if (Model.Asset.InfoJson.HasText())
+    {
+        <script>
+            const viewer1 = OpenSeadragon({
+                id: "osd",
+                showNavigationControl: false,
+                tileSources: "@Model.Asset.InfoJson"
+            });
+        </script>
+    }
+}
+    

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
@@ -58,12 +58,12 @@
         <td><a href="@Model.Asset.Id">@Model.Asset.Id</a></td>
     </tr>
     <tr>
-        <td>Image API Endpoint (info.json)</td>
-        <td><a href="@Model.Asset.InfoJson">@Model.Asset.InfoJson</a></td>
+        <td>Image API Endpoint (image service)</td>
+        <td><a href="@Model.Asset.ImageService">@Model.Asset.ImageService</a></td>
     </tr>
     <tr>
-        <td>Thumbnail Image API Endpoint (info.json)</td>
-        <td><a href="@Model.Asset.ThumbnailInfoJson">@Model.Asset.ThumbnailInfoJson</a></td>
+        <td>Thumbnail Image API Endpoint</td>
+        <td><a href="@Model.Asset.ThumbnailImageService">@Model.Asset.ThumbnailImageService</a></td>
     </tr>
     <tr>
         <td>Family / Media Type</td>
@@ -100,6 +100,14 @@
     <tr>
         <td>Origin</td>
         <td><a href="@Model.Asset.Origin">@Model.Asset.Origin</a></td>
+    </tr>
+    <tr>
+        <td>Image Optimisation Policy</td>
+        <td>@Model.Asset.ImageOptimisationPolicy</td>
+    </tr>
+    <tr>
+        <td>Thumbnail Policy</td>
+        <td>@Model.Asset.ThumbnailPolicy</td>
     </tr>
     <tr>
         <td>Width x Height</td>
@@ -157,14 +165,14 @@
 </table>
 
 @{
-    if (Model.Asset.InfoJson.HasText())
+    if (Model.Asset.ImageService.HasText())
     {
         <h2>IIIF Image</h2>
         <div id="osd" style="width:100%; height: 500px; border: 1px solid gray;"></div>
     }
 
 
-    if (Model.Asset.ThumbnailInfoJson.HasText())
+    if (Model.Asset.ThumbnailImageService.HasText())
     {
         <h2>Thumbnails</h2>
         @foreach (var thumb in Model.Thumbnails)
@@ -183,13 +191,13 @@
 
 @section scripts
 {
-    @if (Model.Asset.InfoJson.HasText())
+    @if (Model.Asset.ImageService.HasText())
     {
         <script>
             const viewer1 = OpenSeadragon({
                 id: "osd",
                 showNavigationControl: false,
-                tileSources: "@Model.Asset.InfoJson"
+                tileSources: "@Model.Asset.ImageService"
             });
         </script>
     }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Asset/Index.cshtml
@@ -170,6 +170,8 @@
         <h2>IIIF Image</h2>
         <div id="osd" style="width:100%; height: 500px; border: 1px solid gray;"></div>
     }
+    
+    <!-- TODO - but needs https://github.com/dlcs/protagonist/issues/488 - show audio, video tags etc -->
 
 
     if (Model.Thumbnails.HasItems())

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -950,28 +950,29 @@
                         </a>
                     }
                     
-                    
-                    
-                    
-                                    @if (dlcsImage != null)
-                                            {
-                                                <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" 
-                                                   target="_blank"  
-                                                   title="@file.OriginalName"><strong>
-                                                    @Html.Raw(Model.GetAssetGlyph(file.Family, file.MimeType))
-                                                    @file.OriginalName.GetFileName()
-                                                </strong></a>
-                                                                                                                         
-                                            }
-                                            else
-                                            {
-                                                <strong>
-                                                    @Html.Raw(Model.GetAssetGlyph(file.Family, file.MimeType))
-                                                    @file.OriginalName.GetFileName()
-                                                </strong>
-                                            }
-                    
-                    
+                    @if (dlcsImage != null)
+                    {
+                        <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" 
+                           target="_blank"  
+                           title="@file.OriginalName"><strong>
+                            @Html.Raw(Model.GetAssetGlyph(file.Family, file.MimeType))
+                            @file.OriginalName.GetFileName()
+                        </strong></a>
+                                   
+                        @if (dlcsImage.Error.HasText())
+                        {
+                            <br/>
+                            <span class="text-danger">@dlcsImage.Error</span>
+                        }
+                    }
+                    else
+                    {
+                        <strong>
+                            @Html.Raw(Model.GetAssetGlyph(file.Family, file.MimeType))
+                            @file.OriginalName.GetFileName()
+                        </strong>
+                        <span class="text-muted small"> - NOT ON DLCS</span>
+                    }
                     
                     <br/>
                     <div class="small" style="margin-left: 18px;">
@@ -991,23 +992,9 @@
                         |
                         @file.AssetMetadata.GetMediaDimensions().ToString()
                         <br/>
-                        @if (dlcsImage != null)
-                        {
-                            <a href="@Model.GetAwsConsoleUri(file.GetStoredFileInfo().Uri)" target="_blank">
-                                <strong>S3:</strong> @file.StorageIdentifier
-                            </a>
-                            @if (dlcsImage.Error.HasText())
-                            {
-                                <br/>
-                                <span class="text-danger">@dlcsImage.Error</span>
-                            }
-                                                                                                     
-                        }
-                        else
-                        {
-                            <span class="text-danger">@file.StorageIdentifier</span>
-                             <span class="text-muted small"> - NOT ON DLCS</span>
-                        }
+                        <a href="@Model.GetAwsConsoleUri(file.GetStoredFileInfo().Uri)" target="_blank">
+                            <strong>S3:</strong> @file.StorageIdentifier
+                        </a>  
                         <br/>
                         @foreach (var deliveredFile in Model.DeliveredFilesMap[file.StorageIdentifier])
                         {
@@ -1029,7 +1016,5 @@
                 }
             }
         </ul>
-        
     }
-
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -670,7 +670,7 @@
                             @if (dlcsImage != null)
                             {
                                 <td>
-                                    <a href="@Model.GetPortalPageForImage(dlcsImage)" target="_blank">@pf.StorageIdentifier</a>
+                                    <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" target="_blank">@pf.StorageIdentifier</a>
                                     @if (dlcsImage.Error.HasText())
                                     {
                                         <br/><span class="text-danger small">@dlcsImage.Error</span>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -618,21 +618,16 @@
                     @foreach (IPhysicalFile pf in metsManifestation.Sequence)
                     {
                         var dlcsImage = Model.GetDlcsImage(pf.StorageIdentifier);
-                        var problems = Model.GetProblems(pf.StorageIdentifier);
+                        var problems = Model.GetProblemMessage(pf.StorageIdentifier);
                         bool ignored = false; // The physical file itself is never ignored.
                         <tr class="@Model.GetCssClassForImageRow(dlcsImage, ignored)" id="@Model.GetTableId(pf.StorageIdentifier)">
                             <td>
                                 <small>@pf.Order</small>
-                                @if (problems.HasItems())
+                                @if (problems.HasText())
                                 {
-                                    <a class="sync-problem" href="#" data-placement="auto" title="
-@foreach (var problem in problems)
-{
-@problem
-<text>  
-</text>    
-}    
-"><span class="glyphicon glyphicon-exclamation-sign"></span> </a>
+                                    <a class="sync-problem" href="#" data-placement="auto" title="@problems">
+                                        <span class="glyphicon glyphicon-exclamation-sign"></span>
+                                    </a>
                                 }
                             </td>
 
@@ -726,23 +721,15 @@
                         {
                             dlcsImage = Model.GetDlcsImage(adjunct.StorageIdentifier);
                             ignored = Model.IsIgnored(adjunct.StorageIdentifier);
-                            problems = Model.GetProblems(adjunct.StorageIdentifier);
+                            problems = Model.GetProblemMessage(adjunct.StorageIdentifier);
                             <tr class="@Model.GetCssClassForImageRow(dlcsImage, ignored)" id="@Model.GetTableId(adjunct.StorageIdentifier)">
                                 <td class="adjunct"><span>&#10551;</span>
-                                    
-                                    
-@if (problems.HasItems())
-{
-    <a class="sync-problem" href="#" data-placement="auto" title="
-@foreach (var problem in problems)
-{
-@problem
-<text>
-</text>      
-}    
-"><span class="glyphicon glyphicon-exclamation-sign"></span> </a>
-                                                                    }
-                                    
+                                    @if (problems.HasText())
+                                    {
+                                        <a class="sync-problem" href="#" data-placement="auto" title="@problems">
+                                            <span class="glyphicon glyphicon-exclamation-sign"></span>
+                                        </a>
+                                    }
                                     
                                     @adjunct.Use</td>
                                 @if (adjunct.Family == AssetFamily.Image)

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -950,12 +950,29 @@
                         </a>
                     }
                     
-                    <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" 
-                       target="_blank"  
-                       title="@file.OriginalName"><strong>
-                        @Html.Raw(Model.GetAssetGlyph(file.Family, file.MimeType))
-                        @file.OriginalName.GetFileName()
-                    </strong></a>
+                    
+                    
+                    
+                                    @if (dlcsImage != null)
+                                            {
+                                                <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" 
+                                                   target="_blank"  
+                                                   title="@file.OriginalName"><strong>
+                                                    @Html.Raw(Model.GetAssetGlyph(file.Family, file.MimeType))
+                                                    @file.OriginalName.GetFileName()
+                                                </strong></a>
+                                                                                                                         
+                                            }
+                                            else
+                                            {
+                                                <strong>
+                                                    @Html.Raw(Model.GetAssetGlyph(file.Family, file.MimeType))
+                                                    @file.OriginalName.GetFileName()
+                                                </strong>
+                                            }
+                    
+                    
+                    
                     <br/>
                     <div class="small" style="margin-left: 18px;">
                         @file.MimeType 

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -271,19 +271,6 @@
                         <li class="needsOrigin">@Html.ActionLink("DDS Preview IIIF 2/3 in Mirador", "MiradorPreview", "Dash", new {id = Model.DdsIdentifier.PathElementSafe}, new {target="_blank"})</li>
                     </ul>
                 </li>
-                @if (metsManifestation.Type == "Video" || metsManifestation.Type == "Audio")
-                {
-                    <li class="list-group-item">
-                        Derivatives:
-                        <ul class="list-unstyled">
-                            @foreach (var derivative in Model.AVDerivatives)
-                            {
-                                <li>- <a target="_blank" href="@derivative.PublicUrl">@derivative.Label</a> | 
-                                    <a target="_blank" href="@derivative.DlcsUrl">(dlcs)</a></li>
-                            }
-                        </ul>
-                    </li>
-                }
                 <li class="list-group-item">
                     Permitted operations:
                     <ul class="list-unstyled">
@@ -639,7 +626,12 @@
                             else
                             {
                                 <td>@StringUtils.FormatFileSize(pf.AssetMetadata.GetFileSize())</td>
-                                <td><small>@pf.AssetMetadata.GetFormatName()</small></td>
+                                <td><small>@pf.AssetMetadata.GetFormatName()</small><br/>
+                                @foreach (var deliveredFile in Model.DeliveredFilesMap[pf.StorageIdentifier])
+                                {
+                                    <a href="@deliveredFile.PublicUrl" title="@deliveredFile.GetSummary()"><span class="label label-primary">@deliveredFile.DeliveryChannel</span></a>
+                                }
+                                    </td>
                                 if (Model.ManifestationFamily == AssetFamily.TimeBased)
                                 {
                                     var mediaDims = pf.AssetMetadata.GetMediaDimensions();
@@ -741,7 +733,15 @@
                                 else
                                 {
                                     <td>@StringUtils.FormatFileSize(adjunct.AssetMetadata.GetFileSize())</td>
-                                    <td><small>@adjunct.AssetMetadata.GetFormatName()</small></td>
+                                    <td><small>@adjunct.AssetMetadata.GetFormatName()</small>
+                                        @if (!ignored)
+                                        {
+                                            <br/>
+                                            @foreach (var deliveredFile in Model.DeliveredFilesMap[adjunct.StorageIdentifier])
+                                            {
+                                                <a href="@deliveredFile.PublicUrl" title="@deliveredFile.GetSummary()"><span class="label label-primary">@deliveredFile.DeliveryChannel</span></a>
+                                            }
+                                        }</td>
                                     if (adjunct.Family == AssetFamily.TimeBased)
                                     {
                                         <td>@adjunct.AssetMetadata.GetDisplayDuration()</td>
@@ -936,10 +936,22 @@
             {
                 var file = fileMap[fileId];
                 var dlcsImage = Model.GetDlcsImage(file.StorageIdentifier);
-                <li class="list-group-item" id="@Model.GetTableId(file.StorageIdentifier)">
+                <li class="list-group-item list-group-item-@Model.GetCssClassForImageRow(dlcsImage, false)" id="@Model.GetTableId(file.StorageIdentifier)">
                     <span class="badge">@StringUtils.FormatFileSize(file.AssetMetadata.GetFileSize(), true)</span>
                     <span class="badge" style="@Model.GetAccessConditionStyle(file.AccessCondition)">@file.AccessCondition</span>
-                    <a href="@Model.GetAwsConsoleUri(file.GetStoredFileInfo().Uri)" 
+                    
+                    @{
+                        var problems = Model.GetProblemMessage(file.StorageIdentifier);
+                    }
+                    @if (problems.HasText())
+                    {
+                        <a class="sync-problem" href="#" data-placement="auto" title="@problems">
+                            <span class="glyphicon glyphicon-exclamation-sign"></span>
+                        </a>
+                    }
+                    
+                    <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" 
+                       target="_blank"  
                        title="@file.OriginalName"><strong>
                         @Html.Raw(Model.GetAssetGlyph(file.Family, file.MimeType))
                         @file.OriginalName.GetFileName()
@@ -964,7 +976,9 @@
                         <br/>
                         @if (dlcsImage != null)
                         {
-                            <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" target="_blank">@file.StorageIdentifier</a>
+                            <a href="@Model.GetAwsConsoleUri(file.GetStoredFileInfo().Uri)" target="_blank">
+                                <strong>S3:</strong> @file.StorageIdentifier
+                            </a>
                             @if (dlcsImage.Error.HasText())
                             {
                                 <br/>
@@ -976,6 +990,11 @@
                         {
                             <span class="text-danger">@file.StorageIdentifier</span>
                              <span class="text-muted small"> - NOT ON DLCS</span>
+                        }
+                        <br/>
+                        @foreach (var deliveredFile in Model.DeliveredFilesMap[file.StorageIdentifier])
+                        {
+                            <a href="@deliveredFile.PublicUrl" title="@deliveredFile.GetSummary()"><span class="label label-primary">@deliveredFile.DeliveryChannel</span></a>
                         }
                     </div>
                 </li>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -629,8 +629,8 @@
 @foreach (var problem in problems)
 {
 @problem
-<text>
-</text>      
+<text>  
+</text>    
 }    
 "><span class="glyphicon glyphicon-exclamation-sign"></span> </a>
                                 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -726,8 +726,25 @@
                         {
                             dlcsImage = Model.GetDlcsImage(adjunct.StorageIdentifier);
                             ignored = Model.IsIgnored(adjunct.StorageIdentifier);
+                            problems = Model.GetProblems(adjunct.StorageIdentifier);
                             <tr class="@Model.GetCssClassForImageRow(dlcsImage, ignored)" id="@Model.GetTableId(adjunct.StorageIdentifier)">
-                                <td class="adjunct"><span>&#10551;</span> @adjunct.Use</td>
+                                <td class="adjunct"><span>&#10551;</span>
+                                    
+                                    
+@if (problems.HasItems())
+{
+    <a class="sync-problem" href="#" data-placement="auto" title="
+@foreach (var problem in problems)
+{
+@problem
+<text>
+</text>      
+}    
+"><span class="glyphicon glyphicon-exclamation-sign"></span> </a>
+                                                                    }
+                                    
+                                    
+                                    @adjunct.Use</td>
                                 @if (adjunct.Family == AssetFamily.Image)
                                 {
                                     <td>@StringUtils.FormatFileSize(adjunct.AssetMetadata.GetFileSize())</td>
@@ -759,7 +776,7 @@
                                     if (dlcsImage != null)
                                     {
                                         <td>
-                                            <a href="@Model.GetPortalPageForImage(dlcsImage)" target="_blank">@adjunct.StorageIdentifier</a>
+                                            <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" target="_blank">@adjunct.StorageIdentifier</a>
                                         </td>
                                     }
                                     else
@@ -808,7 +825,7 @@
                             @*<td>@orphan.Width x @orphan.Height</td>*@
                             <td>@Model.GetAbridgedRoles(orphan.Roles)</td>
                             <td>@orphan.Error</td>
-                            <td width="30%"><a href="@Model.GetPortalPageForImage(orphan)" target="_blank">@orphan.StorageIdentifier</a></td>
+                            <td width="30%"><a href="@Url.Action("Index", "Asset", new { space = orphan.Space, id = orphan.ModelId })" target="_blank">@orphan.StorageIdentifier</a></td>
                             <td>@orphan.Ingesting</td>
                         </tr>
                     }
@@ -960,7 +977,7 @@
                         <br/>
                         @if (dlcsImage != null)
                         {
-                            <a href="@Model.GetPortalPageForImage(dlcsImage)" target="_blank">@file.StorageIdentifier</a>
+                            <a href="@Url.Action("Index", "Asset", new { space = dlcsImage.Space, id = dlcsImage.ModelId })" target="_blank">@file.StorageIdentifier</a>
                             @if (dlcsImage.Error.HasText())
                             {
                                 <br/>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -618,9 +618,23 @@
                     @foreach (IPhysicalFile pf in metsManifestation.Sequence)
                     {
                         var dlcsImage = Model.GetDlcsImage(pf.StorageIdentifier);
+                        var problems = Model.GetProblems(pf.StorageIdentifier);
                         bool ignored = false; // The physical file itself is never ignored.
                         <tr class="@Model.GetCssClassForImageRow(dlcsImage, ignored)" id="@Model.GetTableId(pf.StorageIdentifier)">
-                            <td><small>@pf.Order</small></td>
+                            <td>
+                                <small>@pf.Order</small>
+                                @if (problems.HasItems())
+                                {
+                                    <a class="sync-problem" href="#" data-placement="auto" title="
+@foreach (var problem in problems)
+{
+@problem
+<text>
+</text>      
+}    
+"><span class="glyphicon glyphicon-exclamation-sign"></span> </a>
+                                }
+                            </td>
 
                             @if (Model.ManifestationFamily == AssetFamily.Image)
                             {

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Fixtures/SheetFixtures.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Fixtures/SheetFixtures.cshtml
@@ -33,7 +33,8 @@
         }
         else if(dict["Level"] == "Item")
         {
-            var identifier = new DdsIdentifier(dict["PublicRef"]);
+            var altForm = dict["PublicRef"].ReplaceFirst("/", "");
+            var identifier = new DdsIdentifier(altForm);
             <tr>
                 <td>@Html.ActionLink(identifier.PackageIdentifier, "Manifestation", "Dash", new { id = identifier.PackageIdentifierPathElementSafe }, new { })</td>
                 <td>@dict["Extent"]</td>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
@@ -20,7 +20,8 @@
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
     "PreventSynchronisation": false,
     "PortalPageTemplate": "https://portal.dlcs.digirati.io/images/{0}/{1}",
-    "PortalBatchTemplate": "https://portal.dlcs.digirati.io/batches/{0}"
+    "PortalBatchTemplate": "https://portal.dlcs.digirati.io/batches/{0}",
+    "SupportsDeliveryChannels": true
   },
   "Dds": {
     "LinkedDataDomain": "https://iiif-stage-new.wellcomecollection.org",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-New.json
@@ -14,6 +14,7 @@
   "Dlcs": {
     "CustomerDefaultSpace": 6,
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
+    "SingleAssetManifestTemplate": "https://neworchestrator.dlcs.io/iiif-manifest/wellcome/{0}/{1}",
     "ApiEntryPoint": "https://newapi.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-stage-new.wellcomecollection.org/",
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.json
@@ -28,6 +28,7 @@
     "CustomerId": 2,
     "CustomerName": "Wellcome",
     "SkeletonNamedQueryTemplate": "https://dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
+    "SingleAssetManifestTemplate": "https://dlcs.io/iiif-manifest/wellcome/{0}/{1}",
     "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/",
     "BatchSize": 100,

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/wwwroot/js/dash.js
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/wwwroot/js/dash.js
@@ -44,6 +44,7 @@ $(document).ready(function () {
     authDo = $('#authDo');
     authDo.bind('click', doClickthroughViaWindow);
     bindPreview();
+    //bindProblems();
     
     $("img.iiifpreview").unveil(300);
     
@@ -148,6 +149,12 @@ function bindPreview() {
     $('.iiifpreview').click(function () {
         selectForModal($(this));
         $('#imgModal').modal();
+    });
+}
+
+function bindProblems() {
+    $('.sync-problem').tooltip({
+        html: true
     });
 }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/wwwroot/js/dash.js
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/wwwroot/js/dash.js
@@ -44,7 +44,6 @@ $(document).ready(function () {
     authDo = $('#authDo');
     authDo.bind('click', doClickthroughViaWindow);
     bindPreview();
-    //bindProblems();
     
     $("img.iiifpreview").unveil(300);
     
@@ -149,12 +148,6 @@ function bindPreview() {
     $('.iiifpreview').click(function () {
         selectForModal($(this));
         $('#imgModal').modal();
-    });
-}
-
-function bindProblems() {
-    $('.sync-problem').tooltip({
-        html: true
     });
 }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/BuildExtensions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/BuildExtensions.cs
@@ -7,7 +7,9 @@ using IIIF.Presentation.V3.Constants;
 using IIIF.Presentation.V3.Content;
 using Newtonsoft.Json;
 using Utils;
+using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Mets;
+using Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
 using Wellcome.Dds.Common;
 using Image = IIIF.Presentation.V3.Content.Image;
 using Size = IIIF.Size;
@@ -50,6 +52,12 @@ namespace Wellcome.Dds.Repositories.Presentation
         {
             var sizes = asset.GetAvailableSizes();
             return JsonConvert.SerializeObject(sizes.Select(s => new []{s.Width,s.Height}.ToList()));
+        }
+
+        public static IProcessingBehaviour GetDefaultProcessingBehaviour(this IPhysicalFile asset)
+        {
+            var defaultStoredFile = asset.Files!.SingleOrDefault(f => f.StorageIdentifier == asset.StorageIdentifier);
+            return defaultStoredFile!.ProcessingBehaviour;
         }
 
         public static List<Size> GetAvailableSizes(this IPhysicalFile asset)

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/BuildExtensions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/BuildExtensions.cs
@@ -221,21 +221,5 @@ namespace Wellcome.Dds.Repositories.Presentation
                     return false;
             }
         }
-
-
-        public static Size? GetWhSize(this IPhysicalFile file)
-        {
-            var dimensions = file.AssetMetadata?.GetMediaDimensions();
-            if (dimensions == null) return null;
-            
-            var w = dimensions.Width.GetValueOrDefault();
-            var h = dimensions.Height.GetValueOrDefault();
-            if (w > 0 && h > 0)
-            {
-                return new Size(w, h);
-            }
-
-            return null;
-        }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/BuildExtensions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/BuildExtensions.cs
@@ -54,12 +54,6 @@ namespace Wellcome.Dds.Repositories.Presentation
             return JsonConvert.SerializeObject(sizes.Select(s => new []{s.Width,s.Height}.ToList()));
         }
 
-        public static IProcessingBehaviour GetDefaultProcessingBehaviour(this IPhysicalFile asset)
-        {
-            var defaultStoredFile = asset.Files!.SingleOrDefault(f => f.StorageIdentifier == asset.StorageIdentifier);
-            return defaultStoredFile!.ProcessingBehaviour;
-        }
-
         public static List<Size> GetAvailableSizes(this IPhysicalFile asset)
         {
             var sizes = new List<Size>();

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -72,11 +72,12 @@ namespace Wellcome.Dds.Repositories.Presentation
                 throw new InvalidOperationException("Resource Entry Point not specified in DDS Options");
             }
             build = new IIIFBuilderParts(
+                digitalObjectRepository,
                 uriPatterns,
                 dlcsOptions.Value.ResourceEntryPoint,
                 ddsOptions.Value.ReferenceV0SearchService,
-                ddsOptions.Value.IncludeExtraAccessConditionsInManifest.SplitByDelimiterIntoArray(','),
-                dlcsOptions.Value.SupportsDeliveryChannels);
+                ddsOptions.Value.IncludeExtraAccessConditionsInManifest.SplitByDelimiterIntoArray(',')
+                );
             presentation2Converter = new PresentationConverter(uriPatterns, logger);
         }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -405,7 +405,7 @@ namespace Wellcome.Dds.Repositories.Presentation
 
                         AddAuthServices(mainImage, physicalFile, foundAuthServices);
                         
-                        if (useDeliveryChannels && physicalFile.ProcessingBehaviour.DeliveryChannels.Contains("file"))
+                        if (useDeliveryChannels && physicalFile.GetDefaultProcessingBehaviour().DeliveryChannels.Contains("file"))
                         {
                             var label = physicalFile.MimeType == "image/jp2" ? "JPEG 2000" : physicalFile.MimeType;
                             var rendering = new Image
@@ -897,7 +897,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             // most times we get here. You'd have to come back and run the workflow again to pick it up.
             var choice = new PaintingChoice { Items = new List<IPaintable>() };
             var deliveryChannels = useDeliveryChannels ? 
-                physicalFile.ProcessingBehaviour.DeliveryChannels : new HashSet<string> { "iiif-av" };
+                physicalFile.GetDefaultProcessingBehaviour().DeliveryChannels : new HashSet<string> { "iiif-av" };
             if (IsVideoFile(metsManifestation, physicalFile) && videoSize != null)
             {
                 // First do the <= 720p video which is going to     

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-New.json
@@ -16,7 +16,8 @@
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
     "ApiEntryPoint": "https://newapi.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-stage-new.wellcomecollection.org/",
-    "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/"
+    "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
+    "SupportsDeliveryChannels": true
   },
   "Dds": {
     "LinkedDataDomain": "https://iiif-stage-new.wellcomecollection.org",

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -73,6 +73,7 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string PersistentCatalogueRecordFormat = "https://search.wellcomelibrary.org/iii/encore/record/C__R{identifier}";
         
         // DLCS Paths
+        // Note that {dlcsEntryPoint} is the public-facing, proxied, Wellcome root, not the raw DLCS orchestrator
         private const string DlcsPdfTemplate          = "{dlcsEntryPoint}pdf/{identifier}";
         private const string DlcsThumbServiceTemplate = "{dlcsEntryPoint}thumbs/{assetIdentifier}";
         private const string DlcsImageServiceTemplate = "{dlcsEntryPoint}image/{assetIdentifier}";

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-New.json
@@ -17,7 +17,8 @@
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
     "ApiEntryPoint": "https://newapi.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-stage-new.wellcomecollection.org/",
-    "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/"
+    "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
+    "SupportsDeliveryChannels": true
   },
   "Dds": {
     "LinkedDataDomain": "https://iiif-stage-new.wellcomecollection.org",


### PR DESCRIPTION
Flesh out the delivery channel behaviour and reflect this in the dashboard.

 - Add an Asset Page - https://iiif-stage-new.wellcomecollection.org/dash/Asset/6/b2178081x_0002_0001.jp2
(see https://github.com/wellcomecollection/iiif-builder/pull/220 which is included in this one)
`AssetController` and associated view show this in the dashboard.

 - Add operations to IDlcs to support Asset page (`GetImage`, `ReingestImage`)

Request AV metadata with a different httpClient timeout

Refactor Extension methods into a new `AssetExtensions` class (they were spread out)

Add rich instrumentation to the dashboard for _why_ an asset needs synchronising (previously only visible in logs).
This is the `Mismatches` map on `SyncOperation`.
`DigitalobjectRepository` now records mismatched Asset props here.
This comes out in the View (Manifestation.cshtml) as `var problems = Model.GetProblemMessage(pf.StorageIdentifier);`

Move the `ProcessingBehaviour` property from IPhysicalFile to IStoredFile. This is because one PhysicalFile might have a video and a transcript (two IStoredFiles) that need different delivery channels. Add an extension method for PhysicalFile to select the default processing behaviour for when you have an IPhysicalFile reference.
Re-write tests for ProcessingBehaviour as a result.

Give born digital images a default permitted operation of `wholeImageHighResAsJpg` (see https://digirati.slack.com/archives/CBT40CMKQ/p1681911541546979)

## Delivery Channels

Add `DeliveredFile` class to model a derivative supplied by the DLCS

Add two new methods to IDigitalObjectRepository, that replace `GetAVDerivatives`. These should return a list of the derivatives we think the DLCS should be producing:

```
DeliveredFile[] GetDeliveredFiles(IPhysicalFile physicalFile);
DeliveredFile[] GetDeliveredFiles(IStoredFile? storedFile);
```

(This has a bug explained in https://github.com/wellcomecollection/platform/issues/5679)

`ProcessingBehaviour` knows the _general_ rules about what delivery channels and IOP to give to an asset, and `DigitalObjectRepository::GetDeliveredFiles(IStoredFile? storedFile)` produces a data object holding the effects of that ProcessingBehaviour for a particular IStoredFile - the URLs of the transcoded AV, the duration, height and width etc.

Some of that logic used to be in `IIIFBuilderParts` (assigning sizes, etc) but now it's concentrated here. Most opf the changes are in the method `private PaintingChoice GetAVChoice(..)` - although this still _temporarily_ supports deliverator too. 

There's still some work to do on where information lives, and this won't handle a future IOP for a video that produces multiple size outputs. 
It also meant adding this to IProcessingBehaviour:

```
Size? GetVideoSize(string deliveryChannel)
```

e.g., given "iiif-av", what size video will that produce? 
This needs revisiting, and could be obtained from the DLCS more formally.

Eventually the DLCS should provide this DeliveredFile information - as per https://github.com/dlcs/protagonist/issues/488. But even then, the DDS should produce this summary and compare it to what that manifest says.

Remove AVDerivative info from dashboard left hand side, and add DeliveredFile info into the individual table rows (or `li` elements for Born Digital trees).