### PR TITLE
ProcessingBehaviour sets AssetFamily

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IDigitalManifestation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IDigitalManifestation.cs
@@ -7,7 +7,7 @@ namespace Wellcome.Dds.AssetDomain.DigitalObjects
 {
     public interface IDigitalManifestation : IDigitalObject
     {
-        IManifestation? MetsManifestation { get; set; }
+        IManifestation MetsManifestation { get; }
 
         /// <summary>
         /// The images held by the DLCS that match the metadata for this manifestation

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IProcessingBehaviour.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/DigitalObjects/IProcessingBehaviour.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using IIIF;
+using Wellcome.Dds.AssetDomain.Dlcs;
 
 namespace Wellcome.Dds.AssetDomain.DigitalObjects;
 
@@ -8,4 +9,5 @@ public interface IProcessingBehaviour
     HashSet<string> DeliveryChannels { get; }
     string? ImageOptimisationPolicy { get; }
     Size? GetVideoSize(string deliveryChannel);
+    AssetFamily AssetFamily { get; }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/AssetFamily.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Dlcs/AssetFamily.cs
@@ -1,37 +1,8 @@
-﻿using System.Linq;
-using Utils;
+﻿namespace Wellcome.Dds.AssetDomain.Dlcs;
 
-namespace Wellcome.Dds.AssetDomain.Dlcs
+public enum AssetFamily
 {
-    public enum AssetFamily
-    {
-        Image = 'I',
-        TimeBased = 'T',
-        File = 'F'
-    }
-
-    public static class AssetFamilyUtils
-    {
-        public static AssetFamily GetAssetFamily(this string? mediaType, string[]? permittedImages = null)
-        {
-            if (mediaType.IsImageMimeType())
-            {
-                if (!permittedImages.HasItems()) return AssetFamily.Image;
-                var part2 = mediaType.RemoveStart("image/");
-                if (permittedImages.Contains(part2))
-                {
-                    return AssetFamily.Image;
-                }
-
-                return AssetFamily.File;
-            }
-            if (mediaType.IsTimeBasedMimeType())
-            {
-                return AssetFamily.TimeBased;
-            }
-            return AssetFamily.File;
-        }
-
-    }
-    
+    Image = 'I',
+    TimeBased = 'T',
+    File = 'F'
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Mets/IStoredFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Mets/IStoredFile.cs
@@ -43,7 +43,6 @@ namespace Wellcome.Dds.AssetDomain.Mets
         /// This will only be declared in
         /// </summary>
         string? Use { get; set; }
-        AssetFamily Family { get; set; }
         
         /// <summary>
         /// The METS PhysicalFile this stored file belongs to

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/DlcsSynchronisation/ProcessingBehaviourTests.cs
@@ -3,6 +3,7 @@ using FakeItEasy;
 using FluentAssertions;
 using Wellcome.Dds.AssetDomain.Mets;
 using Wellcome.Dds.AssetDomainRepositories.Mets.Model;
+using Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
 using Wellcome.Dds.AssetDomainRepositories.Storage.WellcomeStorageService;
 using Xunit;
 
@@ -23,36 +24,37 @@ public class ProcessingBehaviourTests
     }
     
     [Fact]
-    public void Image_Has_IIIF_and_thumbs_Delivery_Channel()
+    public void JPEG_Image_Has_IIIF_and_File_Delivery_Channel()
     {
         var storedFile = MakeStoredFile();
         storedFile.MimeType = "image/jpg";
 
         var processing = storedFile.ProcessingBehaviour;
 
-        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-img");
+        processing.DeliveryChannels.Should().HaveCount(2);
+        processing.DeliveryChannels.Should().OnlyContain(s => s == Channels.IIIFImage || s == Channels.File);
     }
     
     
     [Fact]
     public void MP3_Has_File_Delivery_Channel()
     {
-        var pf = MakeStoredFile();
-        pf.MimeType = "audio/x-mpeg-3";
+        var storedFile = MakeStoredFile();
+        storedFile.MimeType = "audio/x-mpeg-3";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = storedFile.ProcessingBehaviour;
 
-        processing.DeliveryChannels.Should().OnlyContain(s => s == "file");
+        processing.DeliveryChannels.Should().OnlyContain(s => s == Channels.File);
     }
     
     
     [Fact]
     public void MP3_Has_None_IOP()
     {
-        var pf = MakeStoredFile();
-        pf.MimeType = "audio/x-mpeg-3";
+        var storedFile = MakeStoredFile();
+        storedFile.MimeType = "audio/x-mpeg-3";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = storedFile.ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().Be("none");
     }
@@ -61,21 +63,21 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Wav_Has_IIIF_AV_Delivery_Channel()
     {
-        var pf = MakeStoredFile();
-        pf.MimeType = "audio/wav";
+        var storedFile = MakeStoredFile();
+        storedFile.MimeType = "audio/wav";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = storedFile.ProcessingBehaviour;
 
-        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av");
+        processing.DeliveryChannels.Should().OnlyContain(s => s == Channels.IIIFAv);
     }    
     
     [Fact]
     public void Wav_Has_Null_IOP()
     {
-        var pf = MakeStoredFile();
-        pf.MimeType = "audio/wav";
+        var storedFile = MakeStoredFile();
+        storedFile.MimeType = "audio/wav";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = storedFile.ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().BeNull();
     }
@@ -83,21 +85,21 @@ public class ProcessingBehaviourTests
     [Fact]
     public void mpeg_Has_IIIF_AV_Delivery_Channel()
     {
-        var pf = MakeStoredFile();
-        pf.MimeType = "video/mpeg-2";
+        var storedFile = MakeStoredFile();
+        storedFile.MimeType = "video/mpeg-2";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = storedFile.ProcessingBehaviour;
 
-        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av");
+        processing.DeliveryChannels.Should().OnlyContain(s => s == Channels.IIIFAv);
     }    
         
     [Fact]
     public void mpeg_Has_Null_IOP()
     {
-        var pf = MakeStoredFile();
-        pf.MimeType = "video/mpeg-2";
+        var storedFile = MakeStoredFile();
+        storedFile.MimeType = "video/mpeg-2";
 
-        var processing = pf.ProcessingBehaviour;
+        var processing = storedFile.ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().BeNull();
     }
@@ -105,29 +107,29 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Normal_MP4_Has_IIIF_AV_Delivery_Channel()
     {
-        var pf = MakePhysicalFile();
-        pf.Files = new List<IStoredFile>
+        var physicalFile = MakePhysicalFile();
+        physicalFile.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf }
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = physicalFile }
         };
-        pf.MimeType = "video/mp4";
+        physicalFile.MimeType = "video/mp4";
 
-        var processing = pf.Files[0].ProcessingBehaviour;
+        var processing = physicalFile.Files[0].ProcessingBehaviour;
 
-        processing.DeliveryChannels.Should().OnlyContain(s => s == "iiif-av");
+        processing.DeliveryChannels.Should().OnlyContain(s => s == Channels.IIIFAv);
     }    
         
     [Fact]
     public void Normal_MP4_Has_Null_IOP()
     {
-        var pf = MakePhysicalFile();
-        pf.Files = new List<IStoredFile>
+        var physicalFile = MakePhysicalFile();
+        physicalFile.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf }  // Mp4 on its own
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = physicalFile }  // Mp4 on its own
         };
-        pf.MimeType = "video/mp4";
+        physicalFile.MimeType = "video/mp4";
 
-        var processing = pf.Files[0].ProcessingBehaviour;
+        var processing = physicalFile.Files[0].ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().BeNull();
     }
@@ -135,34 +137,34 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Access_MP4_720_Has_File_Delivery_Channel()
     {
-        var pf = MakePhysicalFile();
-        pf.Files = new List<IStoredFile>
+        var physicalFile = MakePhysicalFile();
+        physicalFile.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf },       // the access copy
-            new StoredFile { MimeType = "application/mxf", PhysicalFile = pf }  // the master
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = physicalFile },       // the access copy
+            new StoredFile { MimeType = "application/mxf", PhysicalFile = physicalFile }  // the master
         };
-        pf.MimeType = "video/mp4";
-        SetHeight(pf.Files[0], 720);
+        physicalFile.MimeType = "video/mp4";
+        SetHeight(physicalFile.Files[0], 720);
 
-        var processing = pf.Files[0].ProcessingBehaviour;
+        var processing = physicalFile.Files[0].ProcessingBehaviour;
 
-        processing.DeliveryChannels.Should().OnlyContain(s => s == "file");
+        processing.DeliveryChannels.Should().OnlyContain(s => s == Channels.File);
     }
     [Fact]
     public void Access_MP4_1440_Has_iiif_av_and_file_Delivery_Channel()
     {
-        var pf = MakePhysicalFile();
-        pf.Files = new List<IStoredFile>
+        var physicalFile = MakePhysicalFile();
+        physicalFile.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf},       // the access copy
-            new StoredFile { MimeType = "application/mxf", PhysicalFile = pf }  // the master
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = physicalFile},       // the access copy
+            new StoredFile { MimeType = "application/mxf", PhysicalFile = physicalFile }  // the master
         };
-        pf.MimeType = "video/mp4";
-        SetHeight(pf.Files[0], 1440);
+        physicalFile.MimeType = "video/mp4";
+        SetHeight(physicalFile.Files[0], 1440);
 
-        var processing = pf.Files[0].ProcessingBehaviour;
+        var processing = physicalFile.Files[0].ProcessingBehaviour;
 
-        var expected = new HashSet<string> { "iiif-av", "file" };
+        var expected = new HashSet<string> { Channels.IIIFAv, Channels.File };
         processing.DeliveryChannels.Should().BeEquivalentTo(expected);
     }
     
@@ -177,16 +179,16 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Access_MP4_720_Has_None_IOP()
     {
-        var pf = MakePhysicalFile();
-        pf.Files = new List<IStoredFile>
+        var physicalFile = MakePhysicalFile();
+        physicalFile.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf },       // the access copy
-            new StoredFile { MimeType = "application/mxf", PhysicalFile = pf }  // the master
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = physicalFile },       // the access copy
+            new StoredFile { MimeType = "application/mxf", PhysicalFile = physicalFile }  // the master
         };
-        pf.MimeType = "video/mp4";
-        SetHeight(pf.Files[0], 720);
+        physicalFile.MimeType = "video/mp4";
+        SetHeight(physicalFile.Files[0], 720);
 
-        var processing = pf.Files[0].ProcessingBehaviour;
+        var processing = physicalFile.Files[0].ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().Be("none");
     }
@@ -194,16 +196,16 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Access_MP4_1440_Has_Null_IOP()
     {
-        var pf = MakePhysicalFile();
-        pf.Files = new List<IStoredFile>
+        var physicalFile = MakePhysicalFile();
+        physicalFile.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf },       // the access copy
-            new StoredFile { MimeType = "application/mxf", PhysicalFile = pf }  // the master
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = physicalFile },       // the access copy
+            new StoredFile { MimeType = "application/mxf", PhysicalFile = physicalFile }  // the master
         };
-        pf.MimeType = "video/mp4";
-        SetHeight(pf.Files[0], 1440);
+        physicalFile.MimeType = "video/mp4";
+        SetHeight(physicalFile.Files[0], 1440);
 
-        var processing = pf.Files[0].ProcessingBehaviour;
+        var processing = physicalFile.Files[0].ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().BeNull();
     }
@@ -213,15 +215,15 @@ public class ProcessingBehaviourTests
     [Fact]
     public void Resolution_determines_transcode()
     {
-        var pf = MakePhysicalFile();
-        pf.Files = new List<IStoredFile>
+        var physicalFile = MakePhysicalFile();
+        physicalFile.Files = new List<IStoredFile>
         {
-            new StoredFile { MimeType = "video/mp4", PhysicalFile = pf }
+            new StoredFile { MimeType = "video/mp4", PhysicalFile = physicalFile }
         };
-        pf.MimeType = "video/mp4";
-        SetHeight(pf.Files[0], 1440);
+        physicalFile.MimeType = "video/mp4";
+        SetHeight(physicalFile.Files[0], 1440);
 
-        var processing = pf.Files[0].ProcessingBehaviour;
+        var processing = physicalFile.Files[0].ProcessingBehaviour;
 
         processing.ImageOptimisationPolicy.Should().BeNull();
         // processing.ImageOptimisationPolicy.Should().Be("QHD");

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsRepositoryTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsRepositoryTests.cs
@@ -93,8 +93,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Mets
             // Transcript with metadata
             physFile.Files.Should().Contain(f => f.Use == "TRANSCRIPT");
             var transcript = physFile.Files.Single(f => f.Use == "TRANSCRIPT");
-            transcript.ProcessingBehaviour.Should().NotBeNull();
-            transcript.Family.Should().Be(AssetFamily.File);
+            transcript.ProcessingBehaviour.AssetFamily.Should().Be(AssetFamily.File);
             transcript.RelativePath.Should().Be(physFile.RelativeTranscriptPath);
             transcript.AssetMetadata.GetNumberOfPages().Should().Be(86);
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsRepositoryTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsRepositoryTests.cs
@@ -93,6 +93,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Mets
             // Transcript with metadata
             physFile.Files.Should().Contain(f => f.Use == "TRANSCRIPT");
             var transcript = physFile.Files.Single(f => f.Use == "TRANSCRIPT");
+            transcript.ProcessingBehaviour.Should().NotBeNull();
             transcript.Family.Should().Be(AssetFamily.File);
             transcript.RelativePath.Should().Be(physFile.RelativeTranscriptPath);
             transcript.AssetMetadata.GetNumberOfPages().Should().Be(86);

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalManifestation.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalManifestation.cs
@@ -9,7 +9,12 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
 {
     public class DigitalManifestation : BaseDigitalObject, IDigitalManifestation
     {
-        public IManifestation? MetsManifestation { get; set; }
+        public DigitalManifestation(IManifestation metsManifestation)
+        {
+            MetsManifestation = metsManifestation;
+        }
+        
+        public IManifestation MetsManifestation { get; }
         
         /// <summary>
         /// The images already on the DLCS for this manifestation

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -14,6 +14,7 @@ using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomain.Dlcs.Ingest;
 using Wellcome.Dds.AssetDomain.Dlcs.Model;
 using Wellcome.Dds.AssetDomain.Mets;
+using Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
 
@@ -808,7 +809,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                 Number1 = sequenceIndex,
                 Number2 = asset.PhysicalFile!.Index,
                 MediaType = asset.MimeType,
-                Family = (char)asset.Family
+                Family = (char)asset.ProcessingBehaviour.AssetFamily
             };
             if (asset.PhysicalFile.RelativeAltoPath.HasText())
             {
@@ -840,7 +841,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
 
             var roles = GetRoles(asset.PhysicalFile);
             imageRegistration.Roles = roles;
-            if (asset.Family == AssetFamily.Image)
+            if (asset.ProcessingBehaviour.AssetFamily == AssetFamily.Image)
             {
                 imageRegistration.MaxUnauthorised = GetMaxUnauthorised(maxUnauthorised, roles);
             }
@@ -1139,10 +1140,10 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                     deliveredFiles.Add(file);
                 }
 
-                switch (storedFile.Family)
+                switch (storedFile.ProcessingBehaviour.AssetFamily)
                 {
                     case AssetFamily.Image:
-                        if (behaviour.DeliveryChannels.Contains("iiif-img"))
+                        if (behaviour.DeliveryChannels.Contains(Channels.IIIFImage))
                         {
                             var imgService = new DeliveredFile
                             {
@@ -1175,11 +1176,11 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                             {
                                 file.Duration = metadata?.GetDuration();
                             }
-                            if (behaviour.DeliveryChannels.Contains("iiif-av"))
+                            if (behaviour.DeliveryChannels.Contains(Channels.IIIFAv))
                             {
                                 var mp3 = new DeliveredFile
                                 {
-                                    DeliveryChannel = "iiif-av",
+                                    DeliveryChannel = Channels.IIIFAv,
                                     PublicUrl = uriPatterns.DlcsAudio(dlcs.ResourceEntryPoint,
                                         storedFile.StorageIdentifier, "mp3"),
                                     MediaType = "audio/mp3",
@@ -1199,11 +1200,11 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                                 file.Width = metadata?.GetImageWidth();
                                 file.Height = metadata?.GetImageHeight();
                             }
-                            if (behaviour.DeliveryChannels.Contains("iiif-av"))
+                            if (behaviour.DeliveryChannels.Contains(Channels.IIIFAv))
                             {
                                 // our iiif-av channel mp4 will always be confined to a box.
                                 // Only the ProcessingBehaviour should know how big that box is (it's the transcode policy).
-                                var confineToBox = storedFile.ProcessingBehaviour.GetVideoSize("iiif-av");
+                                var confineToBox = storedFile.ProcessingBehaviour.GetVideoSize(Channels.IIIFAv);
 
                                 // we still need to accomodate this hangover from early Goobi flows with no dimensions
                                 var videoSize = storedFile.PhysicalFile!.GetWhSize() ?? new Size(999, 999);
@@ -1211,7 +1212,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
                                 
                                 var mp4 = new DeliveredFile
                                 {
-                                    DeliveryChannel = "iiif-av",
+                                    DeliveryChannel = Channels.IIIFAv,
                                     PublicUrl = uriPatterns.DlcsVideo(dlcs.ResourceEntryPoint,
                                         storedFile.StorageIdentifier, "mp4"),
                                     MediaType = "video/mp4",

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs
@@ -347,9 +347,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.DigitalObjects
 
             await Task.WhenAll(getDlcsImages, getPdf);
 
-            return new DigitalManifestation
+            return new DigitalManifestation(metsManifestation)
             {
-                MetsManifestation = metsManifestation,
                 Identifier = metsManifestation.Identifier,
                 DlcsImages = getDlcsImages.Result,
                 PdfControlFile = getPdf.Result

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
@@ -66,8 +66,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                 Use = fileElement.Parent?.Attribute("USE")?.Value
             };
 
-            file.Family = file.ProcessingBehaviour.AssetFamily;
-            physicalFile.Family = file.Family;
+            physicalFile.Family = file.ProcessingBehaviour.AssetFamily;
             physicalFile.Files.Add(file);
             
             return physicalFile;
@@ -172,8 +171,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                         // TODO: MimeType determination, revisit.
                         physicalFile.MimeType = file.MimeType;
                         physicalFile.RelativePath = file.RelativePath;
-                        file.Family = file.ProcessingBehaviour.AssetFamily;
-                        physicalFile.Family = file.Family;
+                        physicalFile.Family = file.ProcessingBehaviour.AssetFamily;
                         break;
                 }
             }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
@@ -13,9 +13,6 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
 {
     public class PhysicalFile : IPhysicalFile
     {
-        // Only set AssetFamily to Image for born digital mimetypes image/{type} where {type} is one of:
-        //private static readonly string[] BornDigitalImageTypes = { "jpeg", "tiff" };
-
         public PhysicalFile(IWorkStore workStore, string id)
         {
             WorkStore = workStore;

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/PhysicalFile.cs
@@ -14,7 +14,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
     public class PhysicalFile : IPhysicalFile
     {
         // Only set AssetFamily to Image for born digital mimetypes image/{type} where {type} is one of:
-        private static readonly string[] BornDigitalImageTypes = { "jpeg", "tiff" };
+        //private static readonly string[] BornDigitalImageTypes = { "jpeg", "tiff" };
 
         public PhysicalFile(IWorkStore workStore, string id)
         {
@@ -52,7 +52,6 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
             physicalFile.StorageIdentifier = GetSafeStorageIdentifierForBornDigital(workStore.Identifier, physicalFile.RelativePath);
             physicalFile.MimeType = physicalFile.AssetMetadata.GetMimeType(); 
             physicalFile.CreatedDate = physicalFile.AssetMetadata.GetCreatedDate();
-            physicalFile.Family = physicalFile.MimeType.GetAssetFamily(BornDigitalImageTypes);
                 
             // for BD there is only one StoredFile per PhysicalFile
             var file = new StoredFile
@@ -64,9 +63,11 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                 RelativePath = physicalFile.RelativePath,
                 StorageIdentifier = physicalFile.StorageIdentifier,
                 MimeType = physicalFile.MimeType,
-                Family = physicalFile.Family,
                 Use = fileElement.Parent?.Attribute("USE")?.Value
             };
+
+            file.Family = file.ProcessingBehaviour.AssetFamily;
+            physicalFile.Family = file.Family;
             physicalFile.Files.Add(file);
             
             return physicalFile;
@@ -138,7 +139,6 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                 }
                 file.StorageIdentifier = GetSafeStorageIdentifierForDigitised(file.RelativePath, workStore);
                 file.MimeType = (string?) fileElement.Attribute("MIMETYPE");
-                file.Family = file.MimeType.GetAssetFamily();
 
                 switch (file.Use)
                 {
@@ -147,6 +147,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                         break;
                     
                     case "POSTER":
+                        // atm this is not going to the DLCS. But in future it could, in which case we'd need
+                        // to assign it some AssetMetadata here.
                         physicalFile.RelativePosterPath = file.RelativePath;
                         break;
                     
@@ -170,6 +172,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
                         // TODO: MimeType determination, revisit.
                         physicalFile.MimeType = file.MimeType;
                         physicalFile.RelativePath = file.RelativePath;
+                        file.Family = file.ProcessingBehaviour.AssetFamily;
                         physicalFile.Family = file.Family;
                         break;
                 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/StoredFile.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/Model/StoredFile.cs
@@ -20,7 +20,6 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets.Model
         public string? StorageIdentifier { get; set; }
         public string? MimeType { get; set; }
         public string? Use { get; set; }
-        public AssetFamily Family { get; set; }
         public IPhysicalFile? PhysicalFile { get; set; }
         
         private IProcessingBehaviour? processingBehaviour;

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/Channels.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/Channels.cs
@@ -1,0 +1,9 @@
+namespace Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
+
+public static class Channels
+{
+    public const string IIIFImage = "iiif-img";
+    public const string IIIFAv = "iiif-av";
+    public const string Thumbs = "thumbs";
+    public const string File = "file";
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviourOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviourOptions.cs
@@ -8,4 +8,11 @@ public class ProcessingBehaviourOptions
     public bool AddThumbsAsSeparateChannel { get; set; } = false;
     public int MaxUntranscodedAccessMp4 { get; set; } = 720;
     public bool MakeAllAccessMP4sAvailable { get; set; } = true;
+
+    /// <summary>
+    /// Even if an asset has a content type of image/xxx, it will be treated as a file
+    /// unless xxx is in this list
+    /// </summary>
+    public string[] ImageServiceFormats { get; set; } = 
+        { "jp2", "j2k", "jpg", "jpeg", "tif", "tiff", "png", "gif", "bmp" };
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviourOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/ProcessingDecisions/ProcessingBehaviourOptions.cs
@@ -1,18 +1,30 @@
+using System.Collections.Generic;
+
 namespace Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
 
 public class ProcessingBehaviourOptions
 {
     public bool UseNamedAVDefaults { get; set; } = false;
-    public bool MakeAllSourceImagesAvailable { get; set; } = false;
-    public bool MakeJP2Available { get; set; } = false;
     public bool AddThumbsAsSeparateChannel { get; set; } = false;
     public int MaxUntranscodedAccessMp4 { get; set; } = 720;
     public bool MakeAllAccessMP4sAvailable { get; set; } = true;
 
+
     /// <summary>
-    /// Even if an asset has a content type of image/xxx, it will be treated as a file
-    /// unless xxx is in this list
+    /// Image formats (contentType: image/*) that ARE NOT in this list will be `file` only
     /// </summary>
-    public string[] ImageServiceFormats { get; set; } = 
-        { "jp2", "j2k", "jpg", "jpeg", "tif", "tiff", "png", "gif", "bmp" };
+    public Dictionary<string, string[]> ImageDeliveryChannels { get; set; } = new()
+    {
+        ["jp2"]  = new[] { Channels.IIIFImage },  // do not serve JP2s on the file channel, yet
+        ["jpg"]  = new[] { Channels.IIIFImage, Channels.File },
+        ["jpeg"] = new[] { Channels.IIIFImage, Channels.File },
+        ["tif"]  = new[] { Channels.IIIFImage, Channels.File },
+        ["tiff"] = new[] { Channels.IIIFImage, Channels.File },
+        ["png"]  = new[] { Channels.IIIFImage, Channels.File },
+        ["gif"]  = new[] { Channels.IIIFImage, Channels.File },
+        ["bmp"]  = new[] { Channels.IIIFImage, Channels.File }
+    };
+
+    public string[] DefaultImageDeliveryChannels { get; set; } = { Channels.File };
+
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModel.cs
@@ -128,7 +128,8 @@ namespace Wellcome.Dds.Dashboard.Models
             }
         }
 
-        public AssetFamily ManifestationFamily => DigitisedManifestation.MetsManifestation.FirstInternetType.GetAssetFamily();
+        public AssetFamily ManifestationFamily => DigitisedManifestation.MetsManifestation.Sequence!
+            .First().GetDefaultProcessingBehaviour().AssetFamily;
 
         private string typeSummary;
         public string GetTypeSummary()

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -724,7 +724,7 @@
                                     }
                                     
                                     @adjunct.Use</td>
-                                @if (adjunct.Family == AssetFamily.Image)
+                                @if (adjunct.ProcessingBehaviour.AssetFamily == AssetFamily.Image)
                                 {
                                     <td>@StringUtils.FormatFileSize(adjunct.AssetMetadata.GetFileSize())</td>
                                     <td><small>@adjunct.AssetMetadata?.GetFormatName()</small></td>
@@ -742,7 +742,7 @@
                                                 <a href="@deliveredFile.PublicUrl" title="@deliveredFile.GetSummary()"><span class="label label-primary">@deliveredFile.DeliveryChannel</span></a>
                                             }
                                         }</td>
-                                    if (adjunct.Family == AssetFamily.TimeBased)
+                                    if (adjunct.ProcessingBehaviour.AssetFamily == AssetFamily.TimeBased)
                                     {
                                         <td>@adjunct.AssetMetadata.GetDisplayDuration()</td>
                                     }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Job/Index.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Job/Index.cshtml
@@ -13,7 +13,7 @@
     <div class="alert alert-success" role="alert">
         <span class="glyphicon glyphicon-ok"></span>
         Regardless of the state of this particular job,
-        Manifestation @Html.ActionLink(manifestation, "Manifestation", "Dash", new {id = manifestation}, new {}) was updated as "success" by this or a subsequent job.
+        Manifestation @Html.ActionLink(manifestation, "Manifestation", "Dash", new {id = ((DdsIdentifier)manifestation).PathElementSafe}, new {}) was updated as "success" by this or a subsequent job.
         That doesn't mean that that the manifestation is <em>still</em> a success.
     </div>
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Shared/_JobList.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Shared/_JobList.cshtml
@@ -31,7 +31,7 @@
                     <td><a class="row-toggle" href="#"><span class="glyphicon glyphicon-chevron-down"></span> </a></td>
                     <td>@Html.ActionLink(job.Id.ToString(), "Index", "Job", new { id = job.Id }, new { })</td>
                 }
-                <td>@Html.ActionLink(manifestation, "Manifestation", "Dash", new { id = manifestation }, new { })</td>
+                <td>@Html.ActionLink(manifestation, "Manifestation", "Dash", new { id = ((DdsIdentifier)manifestation).PathElementSafe }, new { })</td>
                 <td>@job.Created</td>
                 <td>@job.StartProcessed</td>
                 <td>@job.EndProcessed</td>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -17,6 +17,7 @@ using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.DigitalObjects;
 using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomain.Mets;
+using Wellcome.Dds.AssetDomainRepositories.Mets.ProcessingDecisions;
 using Wellcome.Dds.Catalogue;
 using Wellcome.Dds.IIIFBuilding;
 using Wellcome.Dds.Repositories.Presentation.AuthServices;
@@ -407,7 +408,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                         AddAuthServices(mainImage, physicalFile, foundAuthServices);
 
                         var deliveredFiles = digitalObjectRepository.GetDeliveredFiles(physicalFile);
-                        var asFile = deliveredFiles.SingleOrDefault(df => df.DeliveryChannel == "file");
+                        var asFile = deliveredFiles.SingleOrDefault(df => df.DeliveryChannel == Channels.File);
                         if (asFile != null)
                         {
                             var label = physicalFile.MimeType == "image/jp2" ? "JPEG 2000" : physicalFile.MimeType;

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Synchroniser.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Synchroniser.cs
@@ -211,7 +211,7 @@ namespace Wellcome.Dds.Repositories
                         ddsManifestation.FirstFileExtension =
                             asset.AssetMetadata!.GetFileName()!.GetFileExtension().ToLowerInvariant();
                         ddsManifestation.DipStatus = null;
-                        switch (ddsManifestation.AssetType.GetAssetFamily())
+                        switch (metsManifestation.Sequence.First().GetDefaultProcessingBehaviour().AssetFamily)
                         {
                             case AssetFamily.Image:
                                 ddsManifestation.FirstFileThumbnailDimensions = asset.GetAvailableSizeAsString();


### PR DESCRIPTION
Instead of using `myFile.Family` we now have `myFile.ProcessingBehaviour.Family`

There's also a nicer config format for what image files are turned into IIIF Image API.