### PR TITLE
Fix text cache config inheriting base appSetting

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModelBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Models/ManifestationModelBuilder.cs
@@ -265,15 +265,15 @@ namespace Wellcome.Dds.Dashboard.Models
             // TODO - these paths should not be repeated here
             var identifier = model.DdsIdentifier;
             var textFileInfo = new S3StoredFileInfo(ddsOptions.TextContainer, $"raw/{identifier}", amazonS3);
-            var annosFileInfo = new S3StoredFileInfo(ddsOptions.AnnotationContainer,
-                $"v3/{identifier}/all/line", amazonS3);
+            var imagesFileInfo = new S3StoredFileInfo(ddsOptions.AnnotationContainer,
+                $"v3/{identifier}/images", amazonS3);
             var manifestFileInfo = new S3StoredFileInfo(ddsOptions.PresentationContainer, $"v3/{identifier}", amazonS3);
 
-            await Task.WhenAll(textFileInfo.EnsureObjectMetadata(), annosFileInfo.EnsureObjectMetadata(),
+            await Task.WhenAll(textFileInfo.EnsureObjectMetadata(), imagesFileInfo.EnsureObjectMetadata(),
                 manifestFileInfo.EnsureObjectMetadata());
 
             model.TextWriteTime = textFileInfo.GetLastWriteTime().Result;
-            model.AnnotationWriteTime = annosFileInfo.GetLastWriteTime().Result;
+            model.AnnotationWriteTime = imagesFileInfo.GetLastWriteTime().Result;
             model.ManifestWriteTime = manifestFileInfo.GetLastWriteTime().Result;
         }
     }

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-New.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-New.json
@@ -34,6 +34,14 @@
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
       "Container": "wellcomecollection-stage-new-iiif-storagemaps",
       "Prefix": "stgmap-"
+    },
+    "Wellcome.Dds.WordsAndPictures.Text": {
+      "Container": "wellcomecollection-stage-new-iiif-text",
+      "Prefix": "stgtext-"
+    },
+    "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
+      "Container": "wellcomecollection-stage-new-iiif-annotations",
+      "Prefix": "stgannos-"
     }
   },
   "S3CacheOptions": {

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-Prod.json
@@ -34,6 +34,14 @@
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
       "Container": "wellcomecollection-test-iiif-storagemaps",
       "Prefix": "stgmap-"
+    },
+    "Wellcome.Dds.WordsAndPictures.Text": {
+      "Container": "wellcomecollection-test-iiif-text",
+      "Prefix": "stgtext-"
+    },
+    "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
+      "Container": "wellcomecollection-test-iiif-annotations",
+      "Prefix": "stgannos-"
     }
   },
   "S3CacheOptions": {

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging.json
@@ -30,6 +30,14 @@
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {
       "Container": "wellcomecollection-stage-iiif-storagemaps",
       "Prefix": "stgmap-"
+    },
+    "Wellcome.Dds.WordsAndPictures.Text": {
+      "Container": "wellcomecollection-stage-iiif-text",
+      "Prefix": "stgtext-"
+    },
+    "Wellcome.Dds.WordsAndPictures.SimpleAltoServices.AnnotationPageList": {
+      "Container": "wellcomecollection-stage-iiif-annotations",
+      "Prefix": "stgannos-"
     }
   }
 }


### PR DESCRIPTION
[ManifestationModelBuilder.cs](https://github.com/wellcomecollection/iiif-builder/pull/225/files#diff-8e79f8dff4a2eaf910a2061f7ed4988cfe2040a5ee99c323c3b0cac26ccc1004) change is because we are not currently producing the all annotations file (way too big) but the dashboard was checking its presence.