### PR TITLE
Set Timezone + language to uk for dashboard

### DIFF
--- a/Dockerfile-dashboard
+++ b/Dockerfile-dashboard
@@ -32,6 +32,9 @@ RUN dotnet publish "Wellcome.Dds.Dashboard.csproj" -c Release -o /app/publish
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 
+ENV TZ Europe/London
+ENV LANG en_GB.UTF8
+
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/wellcomecollection/iiif-builder
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashGlobalsActionFilter.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashGlobalsActionFilter.cs
@@ -26,7 +26,7 @@ namespace Wellcome.Dds.Dashboard.Controllers
             viewBag.StopClass = runProcesses ? "" : "btn-danger";
             var heartbeat = await statusProvider.GetHeartbeat();
             viewBag.Heartbeat = heartbeat;
-            var warningState = heartbeat == null || heartbeat.Value.AddMinutes(3) < DateTime.Now;
+            var warningState = heartbeat == null || heartbeat.Value.AddMinutes(3) < DateTime.UtcNow;
             viewBag.HeartbeatWarning = warningState;
             viewBag.HeartbeatClass = warningState ? "btn-danger" : "";
             var getQueueLevel = digitalObjectRepository.GetDlcsQueueLevel();


### PR DESCRIPTION
Verified this behaviour by setting `TZ` and `LANG` envvars on ECS service in test environment, adding to Dockerfile makes it easier to roll out.

Change in heartbeat calculation to use `UtcNow` is because the value would have been written in Utc timezone.

> I have some concerns that this fix might introduce other "out by 1 hour" bugs as `DateTime.Now` is used a lot, rather than `DateTime.UtcNow`. This _may_ be resolved by using `LANG` only so that the correct format is used although the times will still be 1 hour out. It might be safer to fix this alongside https://github.com/wellcomecollection/platform/issues/5564 as the clearest fix is to use Utc everywhere