### PR TITLE
Smoke test app

### DIFF
--- a/src/Wellcome.Dds/IIIFServerSmokeTest/Fixtures.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/Fixtures.cs
@@ -14,13 +14,161 @@ public class Fixtures
                 ManifestCount = 2,
                 HasAlto = true
             },
+            new("b22454408", "Short text")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = true
+            },
+            new("b2043067x", "2 images no text")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false
+            },
+            new("b24923333", "2 x 550 page MM")
+            {
+                IdentifierIsCollection = true,
+                ManifestCount = 2,
+                HasAlto = true
+            },
             new("b30136155", "short MOH report")
             {
                 IdentifierIsCollection = false,
                 HasAlto = true
+            },
+            new("b16641097", "Video, no transcript")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false
+            },
+            new("b16759230", "Video, expressed as multiple manifestation, but only one manifestation present")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false
+            },
+            new("b16675630", "Video, with transcript (2-part multiple manifestation)")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false,
+                HasTranscriptAsDocument = true
+            },
+            new("b28462270", "PDF only")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false
+            },
+            new("b17307922", "Audio, MP3")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false
+            },
+            new("b29524404", "Audio Multiple Manifestation (interview with PDF transcript)")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false,
+                HasTranscriptAsDocument = true
+            },
+            new("b20641151", "A very large archive (5661 images) without access control")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false
+            },
+            new("b24963215", "A very large archive (6320 images) with access control")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false
+            },
+            new("b24990796", "A work with a very large number of volumes (66 manifestations, 10,136 images)")
+            {
+                IdentifierIsCollection = true,
+                ManifestCount = 67,
+                HasAlto = true
+            },
+            new("b29236927", "A 6 'volume' audio multiple manifestation")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = false
+            },
+            new("b20298341", "Arabic manuscript, mixed languages")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b19291449", "Manuscript with structure (TOC)")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b19192162", "Clickthrough")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b19974760", "Chemist and Druggist! ??")
+            {
+                Skip = true, // obvs
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b16673104", "A day at Gebel Moya: ingested mpg, no ingested derivative, TRANSCODE")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b32718184", "(Malaria): use ingested mp4 derivative 720p as FILE - serve as-is")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b3223756x", "Duplicity of vision: 2k mp4 ingested, TRANSCODE (later multiple transcodes, 2k, 720?)")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b1665836x", "Anthelmintics: as above but content-advisory and with PDF")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b30655729", "(cat), ingested wav, TRANSCODE (single transcode, lo-res)")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b16677298", "Clinical access condition image (warning, explicit)")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b11607798",
+                    "Clinical image: Hawley Harvey Crippen and Ethel Le Neve. Photograph by Arthur Barrett, 1910 (non-explicit)")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b16754967", "Clinical video: The chemotherapy of experimental amoebiasis")
+            {
+                Skip = true, // not currently served
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b1825908x", "Restricted Images: \"Schizophrenia Trust\": minutes, correspondence")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b18530692", "Restricted Images: 'Lacaille, AD'")
+            {
+                IdentifierIsCollection = false, 
+                HasAlto = false
+            },
+            new("b29214531", "Restricted Video: Haemorrhage.")
+            {
+                Skip = true, // Restricted, not served currently
+                IdentifierIsCollection = false, 
+                HasAlto = false
             }
         };
-        
+
         foreach (var fixture in List)
         {
             fixture.ManifestShouldBeAfter = minimumDateTime;

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/Fixtures.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/Fixtures.cs
@@ -1,0 +1,29 @@
+namespace IIIFServerSmokeTest;
+
+public class Fixtures
+{
+    public List<WorkFixture> List { get; }
+
+    public Fixtures(DateTime minimumDateTime)
+    {
+        List = new List<WorkFixture>()
+        {
+            new("b2178081x", "2 smallish volumes")
+            {
+                IdentifierIsCollection = true,
+                ManifestCount = 2,
+                HasAlto = true
+            },
+            new("b30136155", "short MOH report")
+            {
+                IdentifierIsCollection = false,
+                HasAlto = true
+            }
+        };
+        
+        foreach (var fixture in List)
+        {
+            fixture.ManifestShouldBeAfter = minimumDateTime;
+        }
+    }
+}

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/IIIFServerSmokeTest.csproj
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/IIIFServerSmokeTest.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Wellcome.Dds.Common\Wellcome.Dds.Common.csproj" />
+      <ProjectReference Include="..\Wellcome.Dds\Wellcome.Dds.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="iiif-net" Version="0.1.11" />
+    </ItemGroup>
+
+</Project>

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/Program.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/Program.cs
@@ -1,0 +1,64 @@
+﻿
+// Usage:
+
+// Run the default list of fixtures:
+// IIIFServerSmokeTest.exe 
+
+// Run the default list of fixtures, expecting them to be more recent than 2023-05-01:
+// IIIFServerSmokeTest.exe 2023-05-01
+
+// Run a particular identifier using only the information from the initial Manifest load:
+// IIIFServerSmokeTest.exe b12121212
+
+// Run a particular identifier using only the information from the initial Manifest load, expecting Manifest to be later than 2023-05-01
+// IIIFServerSmokeTest.exe 2023-05-01 b12121212
+
+// Run multiple identifiers, just following links from first load
+// IIIFServerSmokeTest.exe b12121212 b23232323 b34343434
+// IIIFServerSmokeTest.exe 2023-05-01 b12121212 b23232323 b34343434
+
+
+
+using IIIFServerSmokeTest;
+
+DateTime minDateTime = DateTime.MinValue;
+List<WorkFixture> fixtures;
+
+if (args.Length == 0)
+{
+    fixtures = new Fixtures(minDateTime).List;
+}
+else
+{
+    int argIndex = 0;
+    if (DateTime.TryParse(args[0], out minDateTime))
+    {
+        argIndex = 1;
+    }
+
+    if (args.Length > argIndex + 1)
+    {
+        fixtures = new List<WorkFixture>();
+        for (int i = argIndex; i < args.Length; i++)
+        {
+            fixtures.Add(new WorkFixture(args[i], args[i]));
+        }
+    }
+    else
+    {
+        fixtures = new Fixtures(minDateTime).List;
+    }
+}
+
+var smokeTester = new SmokeTester(
+    "https://iiif.wellcomecollection.org",
+    "https://api.wellcomecollection.org",
+    "https://api.wellcomecollection.org/catalogue/v2/works");
+
+foreach (var fixture in fixtures)
+{
+    var result = await smokeTester.Test(fixture);
+    var outcome = result.Success ? "success" : "FAILURE";
+    Console.WriteLine($"========== {outcome}");
+    Console.WriteLine();
+}

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/Program.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/Program.cs
@@ -51,9 +51,15 @@ else
 }
 
 var smokeTester = new SmokeTester(
-    "https://iiif.wellcomecollection.org",
+    "https://iiif.wellcomecollection.org", // This needs to be a command line arg
     "https://api.wellcomecollection.org",
     "https://api.wellcomecollection.org/catalogue/v2/works");
+
+int fixtureCount = 0;
+int failureCount = 0;
+
+// helps with adding new ones;
+fixtures.Reverse();
 
 foreach (var fixture in fixtures)
 {
@@ -61,4 +67,14 @@ foreach (var fixture in fixtures)
     var outcome = result.Success ? "success" : "FAILURE";
     Console.WriteLine($"========== {outcome}");
     Console.WriteLine();
+    fixtureCount++;
+    if (!result.Success)
+    {
+        failureCount++;
+    }
 }
+
+Console.WriteLine();
+Console.WriteLine($"{failureCount} failure(s) from {fixtureCount} fixtures.");
+Console.WriteLine();
+

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/Result.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/Result.cs
@@ -18,7 +18,7 @@ public class Result
     {
         Success = false;
         messages.Add(message);
-        Console.BackgroundColor = ConsoleColor.Red;
+        Console.ForegroundColor = ConsoleColor.Red;
         Console.WriteLine(message);
         Console.ResetColor();
     }

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/Result.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/Result.cs
@@ -1,0 +1,25 @@
+namespace IIIFServerSmokeTest;
+
+public class Result
+{
+    private List<string> messages = new List<string>();
+
+    public bool Success { get; private set; } = true;
+    
+    public string[] Messages => messages.ToArray();
+
+    public void Add(string message)
+    {
+        messages.Add(message);
+        Console.WriteLine(message);
+    }
+
+    public void AddFailure(string message)
+    {
+        Success = false;
+        messages.Add(message);
+        Console.BackgroundColor = ConsoleColor.Red;
+        Console.WriteLine(message);
+        Console.ResetColor();
+    }
+}

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/SmokeTester.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/SmokeTester.cs
@@ -1,7 +1,6 @@
 using IIIF.Presentation.V3;
 using IIIF.Serialisation;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Wellcome.Dds.Common;
 using Wellcome.Dds.IIIFBuilding;
@@ -30,87 +29,83 @@ public class SmokeTester
         var client = new HttpClient();
         var initialIIIF = uriPatterns.Manifest(fixture.Identifier);
         var jsonString = await client.GetStringAsync(initialIIIF);
-        JObject? iiifObject = null;
         try
         {
-            iiifObject = JObject.Parse(jsonString);
-            if (iiifObject.ContainsKey("type"))
+            var iiifObject = JObject.Parse(jsonString);
+            var type = iiifObject["type"]!.Value<string>();
+            if (fixture.IdentifierIsCollection.HasValue)
             {
-                var type = iiifObject["type"].Value<string>();
-                if (fixture.IdentifierIsCollection.HasValue)
+                if (fixture.IdentifierIsCollection.Value && type == "Collection")
                 {
-                    if (fixture.IdentifierIsCollection.Value && type == "Collection")
+                    result.Add($"Parsed an expected Collection from {initialIIIF}");
+                } 
+                else if(!fixture.IdentifierIsCollection.Value && type == "Manifest")
+                {
+                    result.Add($"Parsed an expected Manifest from {initialIIIF}");
+                }
+                else
+                {
+                    result.AddFailure($"Unexpected type {type} from {initialIIIF}");
+                }
+            }
+            else
+            {
+                if (type is "Collection" or "Manifest")
+                {
+                    result.Add($"Determined {initialIIIF} is a {type}");
+                }
+                else
+                {
+                    result.AddFailure($"Unexpected type {type} from {initialIIIF}");
+                }
+            }
+
+            if (type == "Collection")
+            {
+                IList<JToken> manifests = iiifObject["items"]!.Children().ToList();
+                if (fixture.ManifestCount.HasValue)
+                {
+                    if (manifests.Count == fixture.ManifestCount.Value)
                     {
-                        result.Add($"Parsed an expected Collection from {initialIIIF}");
-                    } 
-                    else if(!fixture.IdentifierIsCollection.Value && type == "Manifest")
-                    {
-                        result.Add($"Parsed an expected Manifest from {initialIIIF}");
+                        result.Add($"Collection has the expected {fixture.ManifestCount.Value} items.");
                     }
                     else
                     {
-                        result.AddFailure($"Unexpected type {type} from {initialIIIF}");
+                        result.AddFailure($"Collection DOES NOT have the expected {fixture.ManifestCount.Value} items.");
                     }
                 }
                 else
                 {
-                    if (type is "Collection" or "Manifest")
-                    {
-                        result.Add($"Determined {initialIIIF} is a {type}");
-                    }
-                    else
-                    {
-                        result.AddFailure($"Unexpected type {type} from {initialIIIF}");
-                    }
+                    result.Add($"Collection observed to have {manifests.Count} items.");
                 }
+                foreach (var manifest in manifests)
+                {
+                    var manifestUrl = manifest["id"]!.Value<string>();
+                    JObject? manifestObject = null;
+                    try
+                    {
+                        var manifestJson = await client.GetStringAsync(manifestUrl);
+                        manifestObject = JObject.Parse(manifestJson);
+                    }
+                    catch(Exception mex)
+                    {
+                        result.AddFailure("Unable to load and parse " + manifestUrl);
+                        result.AddFailure(mex.Message);
+                    }
 
-                if (type == "Collection")
-                {
-                    IList<JToken> manifests = iiifObject["items"].Children().ToList();
-                    if (fixture.ManifestCount.HasValue)
+                    if (manifestObject != null)
                     {
-                        if (manifests.Count == fixture.ManifestCount.Value)
-                        {
-                            result.Add($"Collection has the expected {fixture.ManifestCount.Value} items.");
-                        }
-                        else
-                        {
-                            result.AddFailure($"Collection DOES NOT have the expected {fixture.ManifestCount.Value} items.");
-                        }
-                    }
-                    else
-                    {
-                        result.Add($"Collection observed to have {manifests.Count} items.");
-                    }
-                    foreach (var manifest in manifests)
-                    {
-                        var manifestUrl = manifest["id"].Value<string>();
-                        JObject? manifestObject = null;
-                        try
-                        {
-                            var manifestJson = await client.GetStringAsync(manifestUrl);
-                            manifestObject = JObject.Parse(manifestJson);
-                        }
-                        catch(Exception mex)
-                        {
-                            result.AddFailure("Unable to load and parse " + manifestUrl);
-                            result.AddFailure(mex.Message);
-                        }
-
-                        if (manifestObject != null)
-                        {
-                            TestManifest(fixture, manifestObject, result);
-                        }
+                        await TestManifest(client, fixture, manifestObject, result);
                     }
                 }
-                else if (type == "Manifest")
-                {
-                    TestManifest(fixture, iiifObject, result);
-                }
-                else
-                {
-                    result.AddFailure($"Unknown type: {type}");
-                }
+            }
+            else if (type == "Manifest")
+            {
+                await TestManifest(client, fixture, iiifObject, result);
+            }
+            else
+            {
+                result.AddFailure($"Unknown type: {type}");
             }
         }
         catch (Exception ex)
@@ -122,9 +117,120 @@ public class SmokeTester
         return result;
     }
 
-    private void TestManifest(WorkFixture fixture, JObject manifest, Result result)
+    private async Task TestManifest(HttpClient client, WorkFixture fixture, JObject manifest, Result result)
     {
-        result.Add("Testing manifest");
+        var manifestId = manifest["id"]!.Value<string>();
+        result.Add($"Testing manifest {manifestId}");
+        
+        IList<JToken> services = manifest["services"]!.Children().ToList();
+        CheckTimestamp(fixture, result, services);
+
+        IList<JToken> service = manifest["service"]!.Children().ToList();
+        await TestSearchService(client, fixture, result, service);
+        
+        // we don't want to test ALL the canvases. If there are more than three, test the first, middle and last canvases.
+        IList<JToken> canvases = manifest["items"]!.Children().ToList();
+        TestCanvas(canvases[0], client, fixture, result);
+        switch (canvases.Count)
+        {
+            case 1:
+                break; // already done
+            case 2:
+                TestCanvas(canvases[1], client, fixture, result);
+                break;
+            case 3:
+                TestCanvas(canvases[1], client, fixture, result);
+                TestCanvas(canvases[2], client, fixture, result);
+                break;
+            default:
+                TestCanvas(canvases[canvases.Count / 2], client, fixture, result);
+                TestCanvas(canvases[^1], client, fixture, result);
+                break;
+        }
+    }
+
+    private void TestCanvas(JToken canvas, HttpClient client, WorkFixture fixture, Result result)
+    {
+        var canvasId = canvas["id"]!.Value<string>();
+        result.Add($"Testing canvas {canvasId}");
+    }
+
+    private static async Task TestSearchService(HttpClient client, WorkFixture fixture, Result result, IList<JToken> service)
+    {
+        var searchService = service.SingleOrDefault(s => s["@type"]!.Value<string>() == "SearchService1");
+        if (fixture.HasAlto.HasValue)
+        {
+            if (fixture.HasAlto.Value && searchService != null)
+            {
+                result.Add($"Expected Search Service found");
+            }
+            else if (fixture.HasAlto.Value && searchService == null)
+            {
+                result.AddFailure("Did not find expected search service");
+            }
+            else if (!fixture.HasAlto.Value && searchService == null)
+            {
+                result.Add($"Not expected to have Search Service and none found");
+            }
+            else if (!fixture.HasAlto.Value && searchService != null)
+            {
+                result.AddFailure("Did not expect a search service but found one");
+            }
+        }
+
+        if (searchService != null)
+        {
+            try
+            {
+                // we'll test it anyway regardless of whether it was expected
+                var searchServiceQuery = searchService["@id"]!.Value<string>() + "?q=xyz";
+                var searchResponse = await client.GetStringAsync(searchServiceQuery);
+                var searchResponseObj = JObject.Parse(searchResponse);
+                if (searchResponseObj.ContainsKey("hits"))
+                {
+                    // it's OK (and likely) for hits to be empty
+                    result.Add($"Search service returned result with hits property (from {searchServiceQuery})");
+                }
+                else
+                {
+                    result.AddFailure($"No hits property on search response to {searchServiceQuery}");
+                }
+
+                // Now for autocomplete - always the immediate child service
+                var autocompleteQuery = searchService["service"]!["@id"]!.Value<string>() + "?q=xyz";
+                var autocompleteResponse = await client.GetStringAsync(autocompleteQuery);
+                var autocompleteResponseObj = JObject.Parse(autocompleteResponse);
+                if (autocompleteResponseObj.ContainsKey("terms"))
+                {
+                    // it's OK (and likely) for terms to be empty
+                    result.Add($"Autocomplete service returned result with terms property (from {autocompleteQuery})");
+                }
+                else
+                {
+                    result.AddFailure($"No terms property on Autocomplete response to {autocompleteQuery}");
+                }
+            }
+            catch (Exception ex)
+            {
+                result.AddFailure($"Unable to use search service: " + ex.Message);
+            }
+        }
+    }
+
+    private static void CheckTimestamp(WorkFixture fixture, Result result, IList<JToken> services)
+    {
+        const string timestampProfile = "https://github.com/wellcomecollection/iiif-builder/build-timestamp";
+        var timestampService = services.Single(s => s["profile"]!.Value<string>() == timestampProfile);
+        var timestamp = timestampService["label"]!["none"]![0]!.Value<string>();
+        var timestampDt = DateTime.Parse(timestamp);
+        if (timestampDt > fixture.ManifestShouldBeAfter)
+        {
+            result.Add("Manifest generated after cutoff: " + timestamp);
+        }
+        else
+        {
+            result.AddFailure("Manifest is OLDER than cutoff: " + timestamp);
+        }
     }
 
 
@@ -160,7 +266,7 @@ public class SmokeTester
             {
                 // we'll need to work out what it is
                 var jo = JObject.Parse(jsonString);
-                var jType = jo["type"].Value<string>();
+                var jType = jo["type"]!.Value<string>();
                 if (jType == "Collection")
                 {
                     collection = jsonString.FromJson<Collection>();

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/SmokeTester.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/SmokeTester.cs
@@ -1,0 +1,204 @@
+using IIIF.Presentation.V3;
+using IIIF.Serialisation;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Wellcome.Dds.Common;
+using Wellcome.Dds.IIIFBuilding;
+
+namespace IIIFServerSmokeTest;
+
+public class SmokeTester
+{
+    private UriPatterns uriPatterns;
+
+    public SmokeTester(string publicIIIFRoot, string wellcomeCollectionApi, string apiWorkTemplate)
+    {
+        var options = Options.Create(new DdsOptions
+        {
+            LinkedDataDomain = publicIIIFRoot,
+            WellcomeCollectionApi = wellcomeCollectionApi,
+            ApiWorkTemplate = apiWorkTemplate
+        });
+        uriPatterns = new UriPatterns(options);
+    }
+
+    public async Task<Result> Test(WorkFixture fixture)
+    {
+        var result = new Result();
+        result.Add($"Testing fixture {fixture.Identifier}: {fixture.Label}");
+        var client = new HttpClient();
+        var initialIIIF = uriPatterns.Manifest(fixture.Identifier);
+        var jsonString = await client.GetStringAsync(initialIIIF);
+        JObject? iiifObject = null;
+        try
+        {
+            iiifObject = JObject.Parse(jsonString);
+            if (iiifObject.ContainsKey("type"))
+            {
+                var type = iiifObject["type"].Value<string>();
+                if (fixture.IdentifierIsCollection.HasValue)
+                {
+                    if (fixture.IdentifierIsCollection.Value && type == "Collection")
+                    {
+                        result.Add($"Parsed an expected Collection from {initialIIIF}");
+                    } 
+                    else if(!fixture.IdentifierIsCollection.Value && type == "Manifest")
+                    {
+                        result.Add($"Parsed an expected Manifest from {initialIIIF}");
+                    }
+                    else
+                    {
+                        result.AddFailure($"Unexpected type {type} from {initialIIIF}");
+                    }
+                }
+                else
+                {
+                    if (type is "Collection" or "Manifest")
+                    {
+                        result.Add($"Determined {initialIIIF} is a {type}");
+                    }
+                    else
+                    {
+                        result.AddFailure($"Unexpected type {type} from {initialIIIF}");
+                    }
+                }
+
+                if (type == "Collection")
+                {
+                    IList<JToken> manifests = iiifObject["items"].Children().ToList();
+                    if (fixture.ManifestCount.HasValue)
+                    {
+                        if (manifests.Count == fixture.ManifestCount.Value)
+                        {
+                            result.Add($"Collection has the expected {fixture.ManifestCount.Value} items.");
+                        }
+                        else
+                        {
+                            result.AddFailure($"Collection DOES NOT have the expected {fixture.ManifestCount.Value} items.");
+                        }
+                    }
+                    else
+                    {
+                        result.Add($"Collection observed to have {manifests.Count} items.");
+                    }
+                    foreach (var manifest in manifests)
+                    {
+                        var manifestUrl = manifest["id"].Value<string>();
+                        JObject? manifestObject = null;
+                        try
+                        {
+                            var manifestJson = await client.GetStringAsync(manifestUrl);
+                            manifestObject = JObject.Parse(manifestJson);
+                        }
+                        catch(Exception mex)
+                        {
+                            result.AddFailure("Unable to load and parse " + manifestUrl);
+                            result.AddFailure(mex.Message);
+                        }
+
+                        if (manifestObject != null)
+                        {
+                            TestManifest(fixture, manifestObject, result);
+                        }
+                    }
+                }
+                else if (type == "Manifest")
+                {
+                    TestManifest(fixture, iiifObject, result);
+                }
+                else
+                {
+                    result.AddFailure($"Unknown type: {type}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            result.AddFailure("Unable to load and parse " + initialIIIF);
+            result.AddFailure(ex.Message);
+        }
+
+        return result;
+    }
+
+    private void TestManifest(WorkFixture fixture, JObject manifest, Result result)
+    {
+        result.Add("Testing manifest");
+    }
+
+
+    /// <summary>
+    /// This isn't working yet
+    /// </summary>
+    /// <param name="fixture"></param>
+    /// <returns></returns>
+    public async Task<string[]> TestWithIIIFNet(WorkFixture fixture)
+    {
+        var messages = new List<string>();
+        var client = new HttpClient();
+        var initialIIIF = uriPatterns.Manifest(fixture.Identifier);
+        var jsonString = await client.GetStringAsync(initialIIIF);
+        Manifest? manifest = null;
+        Collection? collection = null;
+        try
+        {
+
+            if (fixture.IdentifierIsCollection.HasValue)
+            {
+                // explicitly stated to be a collection or manifest
+                if (fixture.IdentifierIsCollection.Value)
+                {
+                    collection = jsonString.FromJson<Collection>();
+                }
+                else
+                {
+                    manifest = jsonString.FromJson<Manifest>();
+                }
+            }
+            else
+            {
+                // we'll need to work out what it is
+                var jo = JObject.Parse(jsonString);
+                var jType = jo["type"].Value<string>();
+                if (jType == "Collection")
+                {
+                    collection = jsonString.FromJson<Collection>();
+                }
+                else if (jType == "Manifest")
+                {
+                    manifest = jsonString.FromJson<Manifest>();
+                }
+                else
+                {
+                    messages.Add("Unknown type: " + jType);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            messages.Add("Unable to load and parse " + initialIIIF);
+            messages.Add(ex.Message);
+            return messages.ToArray();
+        }
+
+        if (collection == null && manifest == null)
+        {
+            messages.Add("Unable to load and parse " + initialIIIF);
+            return messages.ToArray();
+        }
+
+        if (collection != null)
+        {
+            Console.WriteLine("Loaded Collection from " + initialIIIF);
+        } 
+
+
+        if (manifest != null)
+        {
+            Console.WriteLine("Loaded Manifest from " + initialIIIF);
+        } 
+        
+        return messages.ToArray();
+    }
+}

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/WorkFixture.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/WorkFixture.cs
@@ -1,0 +1,28 @@
+using Wellcome.Dds.Common;
+
+namespace IIIFServerSmokeTest;
+
+public class WorkFixture
+{
+    public WorkFixture(string identifier, string label)
+    {
+        Identifier = new DdsIdentifier(identifier);
+        Label = label;
+    }
+    
+    public DdsIdentifier Identifier { get; }
+    
+    public string Label { get; }
+    
+    public DateTime? ManifestShouldBeAfter { get; set; }
+
+    public bool? IdentifierIsCollection { get; set; }
+    
+    // Only for collections
+    public int? ManifestCount { get; set; } = 0;
+    
+    public bool? HasAlto { get; set; }
+    
+    
+    
+}

--- a/src/Wellcome.Dds/IIIFServerSmokeTest/WorkFixture.cs
+++ b/src/Wellcome.Dds/IIIFServerSmokeTest/WorkFixture.cs
@@ -23,6 +23,9 @@ public class WorkFixture
     
     public bool? HasAlto { get; set; }
     
-    
-    
+    public bool? HasTranscriptAsDocument { get; set; }
+
+    public bool Skip { get; set; } = false;
+
+
 }

--- a/src/Wellcome.Dds/OAuth2/OAuth2.csproj
+++ b/src/Wellcome.Dds/OAuth2/OAuth2.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
+++ b/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
@@ -14,7 +14,7 @@
       <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
       <PackageReference Include="AWSSDK.S3" Version="3.7.9.18" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
       <PackageReference Include="protobuf-net" Version="3.1.4" />
     </ItemGroup>
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="iiif-net" Version="0.1.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="DeepCopy" Version="1.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
-    <PackageReference Include="iiif-net" Version="0.1.8" />
+    <PackageReference Include="iiif-net" Version="0.1.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="iiif-net" Version="0.1.8" />
+        <PackageReference Include="iiif-net" Version="0.1.11" />
         <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.1.8" />
+      <PackageReference Include="iiif-net" Version="0.1.11" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
       <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="3.1.2" />
       <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />

--- a/src/Wellcome.Dds/Wellcome.Dds.sln
+++ b/src/Wellcome.Dds/Wellcome.Dds.sln
@@ -67,6 +67,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdfThumbGenerator", "PdfThu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wellcome.Dds.Tests", "Wellcome.Dds.Tests\Wellcome.Dds.Tests.csproj", "{7E074FC1-89FF-461B-B32C-B04982B6E61F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IIIFServerSmokeTest", "IIIFServerSmokeTest\IIIFServerSmokeTest.csproj", "{362F3989-9E33-4E1D-A83F-DCED7C8ED5B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -193,6 +195,10 @@ Global
 		{7E074FC1-89FF-461B-B32C-B04982B6E61F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E074FC1-89FF-461B-B32C-B04982B6E61F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E074FC1-89FF-461B-B32C-B04982B6E61F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{362F3989-9E33-4E1D-A83F-DCED7C8ED5B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{362F3989-9E33-4E1D-A83F-DCED7C8ED5B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{362F3989-9E33-4E1D-A83F-DCED7C8ED5B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{362F3989-9E33-4E1D-A83F-DCED7C8ED5B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -212,6 +218,7 @@ Global
 		{2A32208E-4DC8-49D9-A592-C5A6AA7692E0} = {0591D781-5C15-454F-9243-FE6536EDFEC1}
 		{B17BDC9A-A75B-484C-9821-503A9C24E01D} = {5D9253C3-38DA-4125-9676-12E43AEBDD1D}
 		{7E074FC1-89FF-461B-B32C-B04982B6E61F} = {0591D781-5C15-454F-9243-FE6536EDFEC1}
+		{362F3989-9E33-4E1D-A83F-DCED7C8ED5B4} = {5D9253C3-38DA-4125-9676-12E43AEBDD1D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2745EEFB-05EA-40E0-BECC-7F24548F7DE7}

--- a/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="3.1.4" />
-    <PackageReference Include="iiif-net" Version="0.1.8" />
+    <PackageReference Include="iiif-net" Version="0.1.11" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is still a WIP, but it can be run anywhere as a console app.

It loads IIIF resources, validates they are manifests or collections.
Each [WorkFixture](https://github.com/wellcomecollection/iiif-builder/pull/228/files#diff-53c9ecdf8aa78024517aa56b894d55b1678a8ef5286cf2624fcadbe2b672a10f) has nullable props so that you can prepare some fixtures "explicitly" - I _expect_ this to have ALTO - in which case the absence of text features will be an error.

To allow for batch running, it can work without explicit expected values - in which case it will process what it finds. The things it finds should still work (e.g., search and autocomplete) but it won't know whether the Manifest should have had them.

It checks all text based resources, including PDF transcripts of AV.

It samples 3 canvases per manifest rather than all of them - from the beginning, middle and end.

Still to do:

 - Look for and validate auth services
 - use uriPatterns to validate the resource IDs within a Manifest
 - check image services
 - check thumbnails
 - check AV
 - check born digital resources

I should break up the SmokeTester class into individual tests.
