### PR TITLE
Format dates for local time when not using GetFriendlyAge

### DIFF
--- a/src/Wellcome.Dds/Utils/StringUtils.cs
+++ b/src/Wellcome.Dds/Utils/StringUtils.cs
@@ -325,6 +325,22 @@ namespace Utils
             return "(no date)";
         }
 
+        public static string GetLocalDate(DateTime dt)
+        {
+            DateTime localTime = dt.ToLocalTime();
+            return localTime.ToString("yyyy-MM-dd HH:mm:ss");
+        }
+
+        public static string GetLocalDate(DateTime? dt)
+        {
+            if (!dt.HasValue)
+            {
+                return "";
+            }
+
+            return GetLocalDate(dt.Value);
+        }
+        
         public static string GetFriendlyAge(DateTime dt)
         {
             DateTime localTime = dt.ToLocalTime();

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -367,7 +367,7 @@
             {
                 <li class="list-group-item">
                     <span class="badge">@job.ImageCount</span>
-                    @Html.ActionLink("" + job.Created, "Index", "Job", new {id = job.Id}, new {})
+                    @Html.ActionLink("" + StringUtils.GetLocalDate(job.Created), "Index", "Job", new {id = job.Id}, new {})
                     @{
                         if (Model.DbJobIdsToActiveBatches != null && Model.DbJobIdsToActiveBatches.ContainsKey(job.Id))
                         {
@@ -808,7 +808,7 @@
                     @foreach (var orphan in Model.SyncOperation.Orphans)
                     {
                         <tr>
-                            <td>@orphan.Created</td>
+                            <td>@StringUtils.GetLocalDate(orphan.Created)</td>
                             @*<td>@orphan.Width x @orphan.Height</td>*@
                             <td>@Model.GetAbridgedRoles(orphan.Roles)</td>
                             <td>@orphan.Error</td>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Shared/_JobList.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Shared/_JobList.cshtml
@@ -32,9 +32,9 @@
                     <td>@Html.ActionLink(job.Id.ToString(), "Index", "Job", new { id = job.Id }, new { })</td>
                 }
                 <td>@Html.ActionLink(manifestation, "Manifestation", "Dash", new { id = ((DdsIdentifier)manifestation).PathElementSafe }, new { })</td>
-                <td>@job.Created</td>
-                <td>@job.StartProcessed</td>
-                <td>@job.EndProcessed</td>
+                <td>@StringUtils.GetLocalDate(job.Created)</td>
+                <td>@StringUtils.GetLocalDate(job.StartProcessed)</td>
+                <td>StringUtils.GetLocalDate(@job.EndProcessed)</td>
                 <td>@job.AssetType</td>
                 <td>@job.ImageCount</td>
             </tr>

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Shared/_localBatches.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Shared/_localBatches.cshtml
@@ -34,8 +34,8 @@
             }
             <td>@batch.Id</td>
             <td>@batch.BatchSize</td>
-            <td>@batch.RequestSent</td>
-            <td>@batch.Finished</td>
+            <td>@StringUtils.GetLocalDate(batch.RequestSent)</td>
+            <td>@StringUtils.GetLocalDate(batch.Finished)</td>
             <td>@batch.ErrorCode</td>
     <td width="35%"><small>@batch.ErrorText</small></td>
             @if (isDetail)


### PR DESCRIPTION
A few date formatting stragglers still wrong from the UTC change (lucky we are doing this during BST)