### PR TITLE
prod Dds.Server uses cached storage map

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Production.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Production.json
@@ -27,7 +27,9 @@
 
   "Storage": {
     "StorageApiTemplate": "https://api.wellcomecollection.org/storage/v1/bags/{0}/{1}",
-    "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests"
+    "StorageApiTemplateIngest": "https://api.wellcomecollection.org/storage/v1/ingests",
+    "PreferCachedStorageMap": true,
+    "MaxAgeStorageMap": 7200
   },
   "BinaryObjectCache": {
     "Wellcome.Dds.AssetDomainRepositories.Mets.WellcomeBagAwareArchiveStorageMap": {


### PR DESCRIPTION
MaxAgeStorageMap is irrelevant here but I've given it a high value so it's visible.