### PR TITLE
Use location-of-original field without modification

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -190,8 +190,7 @@ namespace Wellcome.Dds.Repositories.Presentation
             var locationOfOriginal = manifestationMetadata.Metadata.GetLocationOfOriginal();
             if (locationOfOriginal.HasText())
             {
-                attribution =
-                    $"This material has been provided by {locationOfOriginal} where the originals may be consulted.";
+                attribution = locationOfOriginal;
             }
 
             if (StringUtils.AnyHaveText(usage, attribution))


### PR DESCRIPTION
(instead of inserting into a template)