### PR TITLE
List pdf thumbnails in S3 to see what's missing

### DIFF
--- a/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/DlcsJobProcessor/appsettings.Staging-Prod.json
@@ -15,7 +15,7 @@
   "Dlcs": {
     "CustomerDefaultSpace": 9,
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
-    "ApiEntryPoint": "https://newapi.dlcs.io/",
+    "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/",
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
     "SupportsDeliveryChannels": true

--- a/src/Wellcome.Dds/Utils.Aws/S3/S3CacheAwareStorage.cs
+++ b/src/Wellcome.Dds/Utils.Aws/S3/S3CacheAwareStorage.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -148,6 +150,24 @@ namespace Utils.Aws.S3
                     getObjectRequest, e.StatusCode);
                 throw;
             }
+        }
+
+        public async Task<List<ISimpleStoredFileInfo>> GetFiles(string container, string prefix)
+        {
+            var resp = await amazonS3.ListObjectsV2Async(new ListObjectsV2Request
+            {
+                BucketName = container,
+                Prefix = prefix
+            });
+            var files = new List<ISimpleStoredFileInfo>();
+            foreach (var s3Object in resp.S3Objects)
+            {
+                var file = new S3StoredFileInfo(s3Object.BucketName, s3Object.Key, null);
+                file.SetMetadata(true, s3Object.LastModified, s3Object.Size);
+                files.Add(file);
+            }
+
+            return files;
         }
 
         private T Deserialize<T>(Stream source, ISimpleStoredFileInfo fileInfo)

--- a/src/Wellcome.Dds/Utils.Aws/S3/S3Storage.cs
+++ b/src/Wellcome.Dds/Utils.Aws/S3/S3Storage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
@@ -106,6 +107,11 @@ namespace Utils.Aws.S3
                     getObjectRequest, e.StatusCode);
                 throw;
             }
+        }
+
+        public Task<List<ISimpleStoredFileInfo>> GetFiles(string container, string prefix)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Wellcome.Dds/Utils.Tests/Caching/BinaryObjectCacheTests.cs
+++ b/src/Wellcome.Dds/Utils.Tests/Caching/BinaryObjectCacheTests.cs
@@ -261,5 +261,7 @@ namespace Utils.Tests.Caching
         {
             Path = path;
         }
+
+        public long? Size { get; }
     }
 }

--- a/src/Wellcome.Dds/Utils.Tests/StringUtilsTests.cs
+++ b/src/Wellcome.Dds/Utils.Tests/StringUtilsTests.cs
@@ -83,6 +83,73 @@ namespace Utils.Tests
             result.Should().Be(str);
         }
 
+                
+        [Fact]
+        public void RemoveEnd_ReturnsNull_IfStringNull()
+        {
+            // Arrange 
+            const string str = null;
+            
+            // Act
+            var result = str.RemoveEnd("hi");
+            
+            // Assert
+            result.Should().BeNull();
+        }
+        
+        [Fact]
+        public void RemoveEnd_ReturnsEmptyString_IfStringEmpty()
+        {
+            // Arrange 
+            const string str = "";
+            
+            // Act
+            var result = str.RemoveEnd("hi");
+            
+            // Assert
+            result.Should().BeEmpty();
+        }
+        
+        [Fact]
+        public void RemoveEnd_RemovesEnd_IfProvidedStringEndsWith()
+        {
+            // Arrange 
+            const string str = "something";
+            const string expected = "some";
+            
+            // Act
+            var result = str.RemoveEnd("thing");
+            
+            // Assert
+            result.Should().Be(expected);
+        }
+        
+        [Fact]
+        public void RemoveEnd_ReturnsOriginalString_IfDoesntEndWith()
+        {
+            // Arrange 
+            const string str = "something";
+
+            // Act
+            var result = str.RemoveEnd("fing");
+            
+            // Assert
+            result.Should().Be(str);
+        }
+        
+        [Fact]
+        public void RemoveEnd_ReturnsOriginalString_IfEndsWithIsFullString()
+        {
+            // Arrange 
+            const string str = "something";
+
+            // Act
+            var result = str.RemoveEnd("something");
+            
+            // Assert
+            result.Should().Be(str);
+        }
+        
         [Theory]
         [InlineData(null)]
         [InlineData("")]

--- a/src/Wellcome.Dds/Utils/Storage/FileSystem/FileSystemStorage.cs
+++ b/src/Wellcome.Dds/Utils/Storage/FileSystem/FileSystemStorage.cs
@@ -1,8 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
 
 namespace Utils.Storage.FileSystem
@@ -15,8 +14,6 @@ namespace Utils.Storage.FileSystem
         {
             this.logger = logger;
         }
-
-        //public string Container { get; set; }
 
         public ISimpleStoredFileInfo GetCachedFileInfo(string container, string fileName)
         {
@@ -87,6 +84,11 @@ namespace Utils.Storage.FileSystem
         }
 
         public Task<Stream?> GetStream(string container, string fileName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<List<ISimpleStoredFileInfo>> GetFiles(string container, string prefix)
         {
             throw new NotImplementedException();
         }

--- a/src/Wellcome.Dds/Utils/Storage/FileSystem/FileSystemStoredFileInfo.cs
+++ b/src/Wellcome.Dds/Utils/Storage/FileSystem/FileSystemStoredFileInfo.cs
@@ -21,5 +21,7 @@ namespace Utils.Storage.FileSystem
         public string? Container => fileInfo.DirectoryName;
 
         public string Path => fileInfo.Name;
+
+        public long? Size => fileInfo.Length;
     }
 }

--- a/src/Wellcome.Dds/Utils/Storage/ISimpleStoredFile.cs
+++ b/src/Wellcome.Dds/Utils/Storage/ISimpleStoredFile.cs
@@ -14,6 +14,8 @@ namespace Utils.Storage
         // add folder/key idea here...
         public string? Container { get; }
         
-        public string Path { get; }
+        public string Path { get; } 
+        
+        public long? Size { get; }
     }
 }

--- a/src/Wellcome.Dds/Utils/Storage/IStorage.cs
+++ b/src/Wellcome.Dds/Utils/Storage/IStorage.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Utils.Storage
@@ -25,5 +26,8 @@ namespace Utils.Storage
         Task<T?> Read<T>(ISimpleStoredFileInfo fileInfo) where T : class;
 
         Task<Stream?> GetStream(string container, string fileName);
+
+        Task<List<ISimpleStoredFileInfo>> GetFiles(string container, string prefix);
+
     }
 }

--- a/src/Wellcome.Dds/Utils/StringUtils.cs
+++ b/src/Wellcome.Dds/Utils/StringUtils.cs
@@ -53,6 +53,19 @@ namespace Utils
 
             return str;
         }
+        
+        public static string? RemoveEnd(this string? str, string end)
+        {
+            if (str == null) return null;
+            if (str == string.Empty) return string.Empty;
+
+            if (str.EndsWith(end) && str.Length > end.Length)
+            {
+                return str[0..^end.Length];
+            }
+
+            return str;
+        }
 
         public static DateTime? GetNullableDateTime(string? s)
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/AssetType.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/AssetType.cshtml
@@ -1,4 +1,5 @@
-﻿@model Wellcome.Dds.Dashboard.Controllers.AssetTypeModel
+﻿@using Utils.Storage
+@model Wellcome.Dds.Dashboard.Controllers.AssetTypeModel
 
 @{
     ViewBag.Title = "Dash: Assets by Type";
@@ -38,7 +39,23 @@
                     <tr>
                         <td>@Html.ActionLink(dispId, "Manifestation", "Dash", new { id = dispId }, new { })</td>
                         <td width="165">@fm.Processed</td>
-                        <td>@fm.Label</td>@*formerly RootSectionTitle*@
+                        <td>@fm.Label
+                        @if (Model.Type == "application/pdf")
+                        {
+                            ISimpleStoredFileInfo file;
+                            if(Model.Thumbnails.TryGetValue(fm.ManifestationIdentifier, out file))
+                            {
+                                <br/><text>Thumbnail is </text> @StringUtils.FormatFileSize(file.Size!.Value);
+                            }
+                            else
+                            {
+                                <div class="alert small alert-danger" role="alert">
+                                    Missing thumbnail in S3
+                                </div>
+                            }
+                            
+                        }
+                        </td>@*formerly RootSectionTitle*@
                     </tr>
                 }
             }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/appsettings.Staging-Prod.json
@@ -16,7 +16,7 @@
     "CustomerDefaultSpace": 9,
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
     "SingleAssetManifestTemplate": "https://neworchestrator.dlcs.io/iiif-manifest/wellcome/{0}/{1}",
-    "ApiEntryPoint": "https://newapi.dlcs.io/",
+    "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/",
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
     "PreventSynchronisation": false,

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/appsettings.Staging-Prod.json
@@ -14,7 +14,7 @@
   "Dlcs": {
     "CustomerDefaultSpace": 9,
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
-    "ApiEntryPoint": "https://newapi.dlcs.io/",
+    "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/",
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
     "SupportsDeliveryChannels": true

--- a/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
+++ b/src/Wellcome.Dds/WorkflowProcessor/appsettings.Staging-Prod.json
@@ -15,7 +15,7 @@
   "Dlcs": {
     "CustomerDefaultSpace": 9,
     "SkeletonNamedQueryTemplate": "https://neworchestrator.dlcs.io/iiif-resource/wellcome/preview/{0}/{1}",
-    "ApiEntryPoint": "https://newapi.dlcs.io/",
+    "ApiEntryPoint": "https://api.dlcs.io/",
     "ResourceEntryPoint": "https://iiif-test.wellcomecollection.org/",
     "InternalResourceEntryPoint": "https://neworchestrator.dlcs.io/",
     "SupportsDeliveryChannels": true


### PR DESCRIPTION
I added a list operation to the existing IStorage implementation, which results in quite a few cascading file changes.

The `S3StoredFileInfo` is our own class but previously would lazy-load metadata form S3. Now you can also populate it manually, if you have just listed a bucket for example.

The ListObjects AWS S3 command has a limit of 1000, and we currently have 680 pdf thumbs. Rather than start paging we should implement thumbs for PDFs properly via DLCS rather than take this any further. 

Only 2 PDFs in local env but it will look like this:

<img width="921" alt="image" src="https://github.com/wellcomecollection/iiif-builder/assets/1443575/b86bb43f-a31a-4093-bd45-57627d4dee82">

Deploying to `test`.