### PR TITLE
Upgrade to iiif-net 0.2.0

### DIFF
--- a/src/Wellcome.Dds/OAuth2/OAuth2.csproj
+++ b/src/Wellcome.Dds/OAuth2/OAuth2.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
+++ b/src/Wellcome.Dds/Utils.Aws/Utils.Aws.csproj
@@ -14,7 +14,7 @@
       <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
       <PackageReference Include="AWSSDK.S3" Version="3.7.9.18" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
       <PackageReference Include="protobuf-net" Version="3.1.4" />
     </ItemGroup>
 

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomain/Wellcome.Dds.AssetDomain.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="iiif-net" Version="0.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
@@ -72,7 +72,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
             return new AuthAccessService2
             {
                 Id = uriPatterns.DlcsClickthroughLoginServiceV2Id(dlcsEntryPoint),
-                Profile = AuthAccessService2.InteractiveProfile,
+                Profile = AuthAccessService2.ActiveProfile,
                 Label = new LanguageMap("en", ClickthroughHeader),
                 Heading = new LanguageMap("en", ClickthroughHeader),
                 Note = new LanguageMap("en", ClickthroughLoginDescription),
@@ -100,7 +100,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
             return new AuthAccessService2
             {
                 Id = uriPatterns.DlcsLoginServiceV2Id(dlcsEntryPoint),
-                Profile = AuthAccessService2.InteractiveProfile,
+                Profile = AuthAccessService2.ActiveProfile,
                 Label = new LanguageMap("en", ClinicalHeader),
                 Heading = new LanguageMap("en", ClinicalHeader),
                 Note = new LanguageMap("en", ClinicalLoginDescription),

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -1505,7 +1505,7 @@ namespace Wellcome.Dds.Repositories.Presentation
 
             ((ICollectionItem)iiifResource).Services ??= new List<IService>();
             ((ICollectionItem)iiifResource).Services?.Add(
-                new ExternalResource("Text")
+                new SimpleTextBasedService
                 {
                     Id = iiifResource.Id + "#tracking",
                     Profile = Constants.Profiles.TrackingExtension,
@@ -1517,7 +1517,7 @@ namespace Wellcome.Dds.Repositories.Presentation
         {            
             ((ICollectionItem)iiifResource).Services ??= new List<IService>();
             ((ICollectionItem)iiifResource).Services?.Add(
-                new ExternalResource("Text")
+                new SimpleTextBasedService
                 {
                     Id = iiifResource.Id + "#timestamp",
                     Profile = Constants.Profiles.BuilderTime,
@@ -1546,7 +1546,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                     break;
             }        
             manifest.Services ??= new List<IService>();
-            var accessHintService = new ExternalResource("Text")
+            var accessHintService = new SimpleTextBasedService
             {
                 Id = manifest.Id + "#accesscontrolhints",
                 Profile = Constants.Profiles.AccessControlHints,

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/SimpleTextBasedService.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/SimpleTextBasedService.cs
@@ -1,0 +1,12 @@
+using IIIF;
+using IIIF.Presentation.V3.Content;
+
+namespace Wellcome.Dds.Repositories.Presentation;
+
+public class SimpleTextBasedService : ExternalResource, IService
+{
+    public SimpleTextBasedService() : base("Text")
+    {
+        
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Wellcome.Dds.Repositories.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="DeepCopy" Version="1.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
-    <PackageReference Include="iiif-net" Version="0.1.8" />
+    <PackageReference Include="iiif-net" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server.Tests/Wellcome.Dds.Server.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="iiif-net" Version="0.1.8" />
+        <PackageReference Include="iiif-net" Version="0.2.0" />
         <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.1.8" />
+      <PackageReference Include="iiif-net" Version="0.2.0" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.167" />
       <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="3.1.2" />
       <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />

--- a/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
+++ b/src/Wellcome.Dds/Wellcome.Dds/Wellcome.Dds.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="3.1.4" />
-    <PackageReference Include="iiif-net" Version="0.1.8" />
+    <PackageReference Include="iiif-net" Version="0.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bump iiif-net to 0.2.0 and also bump Newtonsoft to match.

In this version of iiif-net, ExternalResource does not implement IService, so we add a new `SimpleTextBasedService: ExternalResource, IService` to explicitly allow for Text resources (like our timestamp service) to be added to IIIF properties that expect IService.