### PR TITLE
ArchivematicaStrictDirectoryOrder controls metadata and submission dir handling

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsRepositoryTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Mets/MetsRepositoryTests.cs
@@ -4,11 +4,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.Dlcs;
 using Wellcome.Dds.AssetDomainRepositories.Mets;
 using Wellcome.Dds.AssetDomainRepositories.Mets.Model;
 using Wellcome.Dds.AssetDomainRepositories.Storage.FileSystem;
+using Wellcome.Dds.Common;
 using Xunit;
 using MetsManifestation = Wellcome.Dds.AssetDomainRepositories.Mets.Model.Manifestation;
 
@@ -27,7 +29,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Mets
         [Fact]
         public async Task Old_Workflow_Video_Yields_Collection()
         {
-            var metsRepository = new MetsRepository(workStorageFactory, new NullLogger<MetsRepository>());
+            var metsRepository = new MetsRepository(workStorageFactory, new NullLogger<MetsRepository>(), Options.Create(new DdsOptions()));
             var b16675630 = await metsRepository.GetAsync("b16675630");
             b16675630.Should().BeOfType<Collection>();
             b16675630.Partial.Should().BeFalse();
@@ -60,7 +62,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Mets
         [Fact]
         public async Task New_Workflow_Video_Yields_Multiple_Files()
         {
-            var metsRepository = new MetsRepository(workStorageFactory, new NullLogger<MetsRepository>());
+            var metsRepository = new MetsRepository(workStorageFactory, new NullLogger<MetsRepository>(), Options.Create(new DdsOptions()));
             var b30496160 = await metsRepository.GetAsync("b30496160");
             b30496160.Should().BeOfType<MetsManifestation>();
             b30496160.Partial.Should().BeFalse();
@@ -104,7 +106,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Mets
         [Fact]
         public async Task New_Model_Supports_Old_Alto()
         {
-            var metsRepository = new MetsRepository(workStorageFactory, new NullLogger<MetsRepository>());
+            var metsRepository = new MetsRepository(workStorageFactory, new NullLogger<MetsRepository>(), Options.Create(new DdsOptions()));
             var b30074976 = await metsRepository.GetAsync("b30074976");
             var mb30074976 = (MetsManifestation) b30074976;
             mb30074976.PosterImage.Should().BeNull();

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/MetsRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/MetsRepository.cs
@@ -26,6 +26,8 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets
         private const string Item = "Item";
         private const string TypeAttribute = "TYPE";
         private const string LabelAttribute = "LABEL";
+        private const string MetadataLabel = "metadata";
+        private const string SubmissionDocumentationLabel = "submissionDocumentation";
         
 
         public MetsRepository(
@@ -111,25 +113,25 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets
             var objectsChildren = objectsDir.Elements().ToArray();
 
             var metadataDirectories = objectsChildren
-                .Where(el => IsLabelledDirectory(el, "metadata")).ToList();
+                .Where(el => IsLabelledDirectory(el, MetadataLabel)).ToList();
             var submissionDocumentationDirectories = objectsChildren
-                .Where(el => IsLabelledDirectory(el, "submissionDocumentation")).ToList();
+                .Where(el => IsLabelledDirectory(el, SubmissionDocumentationLabel)).ToList();
             
             if (metadataDirectories.Count == 0)
             {
-                throw new NotSupportedException("Could not find directory labelled 'metadata' in objects directory");
+                throw new NotSupportedException($"Could not find directory labelled '{MetadataLabel}' in objects directory");
             }
             if (submissionDocumentationDirectories.Count == 0)
             {
-                throw new NotSupportedException("Could not find directory labelled 'submissionDocumentation' in objects directory");
+                throw new NotSupportedException($"Could not find directory labelled '{SubmissionDocumentationLabel}' in objects directory");
             }
             if (metadataDirectories.Count > 1)
             {
-                throw new NotSupportedException("More than one directory labelled 'metadata' in objects directory");
+                throw new NotSupportedException($"More than one directory labelled '{MetadataLabel}' in objects directory");
             }
             if (submissionDocumentationDirectories.Count > 1)
             {
-                throw new NotSupportedException("More than one directory labelled 'submissionDocumentation' in objects directory");
+                throw new NotSupportedException($"More than one directory labelled '{SubmissionDocumentationLabel}' in objects directory");
             }
             
             if (ddsOptions.ArchivematicaStrictDirectoryOrder)
@@ -138,9 +140,9 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets
                 if (objectsChildren.Length >= 2)
                 {
                     metadataDirectory = objectsChildren[^2..]
-                        .SingleOrDefault(el => IsLabelledDirectory(el, "metadata"));
+                        .SingleOrDefault(el => IsLabelledDirectory(el, MetadataLabel));
                     submissionDocumentationDirectory = objectsChildren[^2..]
-                        .SingleOrDefault(el => IsLabelledDirectory(el, "submissionDocumentation"));
+                        .SingleOrDefault(el => IsLabelledDirectory(el, SubmissionDocumentationLabel));
                 }
                 if (metadataDirectory == null || submissionDocumentationDirectory == null)
                 {
@@ -154,7 +156,7 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets
                 metadataDirectory = metadataDirectories.Single();
                 submissionDocumentationDirectory = submissionDocumentationDirectories.Single();
                 digitalContent = objectsChildren.Where(el =>
-                    !(IsLabelledDirectory(el, "metadata") || IsLabelledDirectory(el, "submissionDocumentation")))
+                    !(IsLabelledDirectory(el, MetadataLabel) || IsLabelledDirectory(el, SubmissionDocumentationLabel)))
                     .ToArray();
             }
             

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/MetsRepository.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/Mets/MetsRepository.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Utils;
 using Wellcome.Dds.AssetDomain;
 using Wellcome.Dds.AssetDomain.Mets;
@@ -18,19 +19,23 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets
     {
         private readonly IWorkStorageFactory workStorageFactory;
         private readonly ILogger<MetsRepository> logger;
+        private readonly DdsOptions ddsOptions;
         
         // For born-digital
         private const string Directory = "Directory";
         private const string Item = "Item";
         private const string TypeAttribute = "TYPE";
         private const string LabelAttribute = "LABEL";
+        
 
         public MetsRepository(
             IWorkStorageFactory workStorageFactory,
-            ILogger<MetsRepository> logger)
+            ILogger<MetsRepository> logger,
+            IOptions<DdsOptions> options)
         {
             this.workStorageFactory = workStorageFactory;
             this.logger = logger;
+            ddsOptions = options.Value;
         }
 
         public async Task<IMetsResource?> GetAsync(DdsIdentifier identifier)
@@ -72,6 +77,11 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets
             throw new NotSupportedException("Unknown identifier");
         }
 
+        private bool IsLabelledDirectory(XElement el, string value)
+        {
+            return el.Attribute(TypeAttribute)?.Value == Directory && el.Attribute(LabelAttribute)?.Value == value;
+        }
+
         private async Task<IManifestation?> BuildBornDigitalManifestation(IWorkStore workStore)
         {
             // we can't get a logical struct map, because there isn't one in this METS.
@@ -95,28 +105,63 @@ namespace Wellcome.Dds.AssetDomainRepositories.Mets
             {
                 throw new NotSupportedException("Could not find objects directory in physical structMap");
             }
-            // These should be the last two, but we won't mind the order
             XElement? metadataDirectory = null;
             XElement? submissionDocumentationDirectory = null;
+            XElement[] digitalContent;
             var objectsChildren = objectsDir.Elements().ToArray();
-            if (objectsChildren.Length >= 2)
-            {
-                metadataDirectory = objectsChildren[^2..].SingleOrDefault(el =>
-                    el.Attribute(TypeAttribute)?.Value == Directory && el.Attribute(LabelAttribute)?.Value == "metadata");
-                submissionDocumentationDirectory = objectsChildren[^2..].SingleOrDefault(el =>
-                    el.Attribute(TypeAttribute)?.Value == Directory && el.Attribute(LabelAttribute)?.Value == "submissionDocumentation");
-            }
-            if (metadataDirectory == null || submissionDocumentationDirectory == null)
-            {
-                throw new NotSupportedException("Objects directory does not have metadata and submissionDocumentation as last two entries");
-            }
 
+            var metadataDirectories = objectsChildren
+                .Where(el => IsLabelledDirectory(el, "metadata")).ToList();
+            var submissionDocumentationDirectories = objectsChildren
+                .Where(el => IsLabelledDirectory(el, "submissionDocumentation")).ToList();
+            
+            if (metadataDirectories.Count == 0)
+            {
+                throw new NotSupportedException("Could not find directory labelled 'metadata' in objects directory");
+            }
+            if (submissionDocumentationDirectories.Count == 0)
+            {
+                throw new NotSupportedException("Could not find directory labelled 'submissionDocumentation' in objects directory");
+            }
+            if (metadataDirectories.Count > 1)
+            {
+                throw new NotSupportedException("More than one directory labelled 'metadata' in objects directory");
+            }
+            if (submissionDocumentationDirectories.Count > 1)
+            {
+                throw new NotSupportedException("More than one directory labelled 'submissionDocumentation' in objects directory");
+            }
+            
+            if (ddsOptions.ArchivematicaStrictDirectoryOrder)
+            {
+                // These should be the last two, but we won't mind the order
+                if (objectsChildren.Length >= 2)
+                {
+                    metadataDirectory = objectsChildren[^2..]
+                        .SingleOrDefault(el => IsLabelledDirectory(el, "metadata"));
+                    submissionDocumentationDirectory = objectsChildren[^2..]
+                        .SingleOrDefault(el => IsLabelledDirectory(el, "submissionDocumentation"));
+                }
+                if (metadataDirectory == null || submissionDocumentationDirectory == null)
+                {
+                    throw new NotSupportedException("Objects directory does not have metadata and submissionDocumentation as last two entries");
+                }
+                // We can now ignore the last two.
+                digitalContent = objectsChildren[..^2];
+            }
+            else
+            {
+                metadataDirectory = metadataDirectories.Single();
+                submissionDocumentationDirectory = submissionDocumentationDirectories.Single();
+                digitalContent = objectsChildren.Where(el =>
+                    !(IsLabelledDirectory(el, "metadata") || IsLabelledDirectory(el, "submissionDocumentation")))
+                    .ToArray();
+            }
+            
             // Get the path to the METS for submission doc if we need it later - it has the logical structMap
             // var subLabel = submissionDocumentationDirectory.Elements().First().Attribute(LabelAttribute)?.Value;
             // var submissionMetsRelativePath = $"submissionDocumentation/{subLabel}/METS.xml";
             
-            // We can now ignore the last two.
-            var digitalContent = objectsChildren[..^2];
             if (digitalContent.Length == 0)
             {
                 throw new NotSupportedException("The objects directory has no digital content");

--- a/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Common/DdsOptions.cs
@@ -77,5 +77,7 @@
         public string? IncludeExtraAccessConditionsInManifest { get; set; }
         
         public int PlaceholderCanvasCacheTimeDays { get; set; }
+
+        public bool ArchivematicaStrictDirectoryOrder { get; set; } = false;
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Fixtures/Fixtures.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Fixtures/Fixtures.cshtml
@@ -1,4 +1,4 @@
-@model ValueTuple<string, string>[]
+@model IEnumerable<ValueTuple<string, string>>
 
 @{
     ViewBag.Title = "Test Identifiers";

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Fixtures/FixturesList.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Fixtures/FixturesList.cshtml
@@ -1,5 +1,3 @@
-@model ValueTuple<string, string>[]
-
 @{
     ViewBag.Title = "Test Identifiers";
 }

--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/WorkflowCall/WorkflowCall.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/WorkflowCall/WorkflowCall.cshtml
@@ -66,7 +66,7 @@ else
     <li class="list-group-item"><a href="@Url.Action("PutWorkflowMessageOnQueue", "WorkflowCall", new {id = ddsId.PathElementSafe})"><span class="glyphicon glyphicon-bullhorn"></span> Push to workflow queue (SQS)</a></li>
     <li class="list-group-item">@Html.ActionLink("DDS View of " + ddsId, "Manifestation", "Dash", new {id = ddsId.PathElementSafe}, new {})</li>
     <li class="list-group-item"><a href="@Url.Action("StorageManifest", "Peek", new {id = ddsId.PathElementSafe})">Storage Manifest</a></li>
-    <li class="list-group-item"><a href="@Url.Action("XmlView", "Peek", new {id = ddsId.PathElementSafe, parts = ddsId.PathElementSafe + ".xml"})">METS file</a></li>
+    <li class="list-group-item"><a href="@Url.Action("XmlView", "Peek", new {id = ddsId.PackageIdentifierPathElementSafe })">METS file</a></li>
 </ul>
 <ul class="list-group">
     <li class="list-group-item">@Html.ActionLink("Show Recent Calls", "Recent", "WorkflowCall")</li>

--- a/src/Wellcome.Dds/Wellcome.Dds.sln.DotSettings
+++ b/src/Wellcome.Dds/Wellcome.Dds.sln.DotSettings
@@ -6,6 +6,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=altref/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AMDID/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Anno/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Archivematica/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bagger/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Biocrats/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bnumber/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
The new DdsOptions property (defaults to false) specifies whether these two directories must be the last two in the objects directory, and also verifies that each only appears once.