### PR TITLE
Add an SVG Controller to emit SVG for text

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DatabaseStatusProviderTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DatabaseStatusProviderTests.cs
@@ -41,18 +41,18 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
 
         }
 
-        // [Fact]
-        // public void EarliestJobToTake_ReturnsCorrectValue()
-        // {
-        //     // Arrange
-        //     var date = DateTime.Today.AddDays(-4);
-        //     
-        //     // Act
-        //     var sut = GetSut(date);
-        //     
-        //     // Assert
-        //     sut.EarliestJobToTake.Should().Be(date);
-        // }
+        [Fact]
+        public void EarliestJobToTake_ReturnsCorrectValue()
+        {
+            // Arrange
+            var date = DateTime.Today.AddDays(-4);
+            
+            // Act
+            var sut = GetSut(date);
+            
+            // Assert
+            sut.EarliestJobToTake.Should().Be(date);
+        }
         
         [Fact]
         public void EarliestJobToTake_Null_IfNoValue()

--- a/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DatabaseStatusProviderTests.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories.Tests/Dashboard/DatabaseStatusProviderTests.cs
@@ -41,18 +41,18 @@ namespace Wellcome.Dds.AssetDomainRepositories.Tests.Dashboard
 
         }
 
-        [Fact]
-        public void EarliestJobToTake_ReturnsCorrectValue()
-        {
-            // Arrange
-            var date = DateTime.Today.AddDays(-4);
-            
-            // Act
-            var sut = GetSut(date);
-            
-            // Assert
-            sut.EarliestJobToTake.Should().Be(date);
-        }
+        // [Fact]
+        // public void EarliestJobToTake_ReturnsCorrectValue()
+        // {
+        //     // Arrange
+        //     var date = DateTime.Today.AddDays(-4);
+        //     
+        //     // Act
+        //     var sut = GetSut(date);
+        //     
+        //     // Assert
+        //     sut.EarliestJobToTake.Should().Be(date);
+        // }
         
         [Fact]
         public void EarliestJobToTake_Null_IfNoValue()

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilder.cs
@@ -518,6 +518,28 @@ namespace Wellcome.Dds.Repositories.Presentation
                 };
                 w3CPage.EnsurePresentation3Context();
                 string canvasId = uriPatterns.Canvas(manifestation.Identifier, altoPage.AssetIdentifier);
+                string manifestId = uriPatterns.Manifest(manifestation.Identifier);
+                if (altoPage.ActualWidth > 0 && altoPage.ActualHeight > 0)
+                {
+                    w3CPage.PartOf = new List<ResourceBase>
+                    {
+                        new Canvas
+                        {
+                            Id = canvasId,
+                            Width = altoPage.ActualWidth,
+                            Height = altoPage.ActualHeight,
+                            PartOf = new List<ResourceBase>
+                            {
+                                new Manifest
+                                {
+                                    Id = manifestId,
+                                    Label = Lang.Map(manifestation.Label ?? "Parent Manifest")
+                                }
+                            }
+                        }
+                    };
+                }
+                
 
                 // Do the W3C conversions
                 var w3CTextLines = altoPage.TextLines
@@ -537,7 +559,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                     // NB this won't have any effect if the TargetConverter Serialiser is in use
                     firstAnnoCanvas.PartOf = new List<ResourceBase>
                     {
-                        new Manifest {Id = uriPatterns.Manifest(manifestation.Identifier)}
+                        new Manifest {Id = manifestId}
                     };
                 }
                 result.AllContentAnnotations?.Items?.AddRange(allW3CPageAnnotations);

--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -402,6 +402,13 @@ namespace Wellcome.Dds.Repositories.Presentation
                                     Label = Lang.Map(physicalFile.OrderLabel.HasText() ? $"Text of page {physicalFile.OrderLabel}" : "Text of this page")
                                 }
                             };
+                            canvas.Rendering ??= new List<ExternalResource>();
+                            canvas.Rendering.Add(new("Image")
+                            {
+                                Id = uriPatterns.SvgPage(manifestIdentifier, assetIdentifier),
+                                Format = "image/svg+xml",
+                                Label = new LanguageMap("en", "SVG XML for page text")
+                            });
                         }
 
                         AddAuthServices(mainImage, physicalFile, foundAuthServices);

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
@@ -84,42 +84,47 @@ public class SvgController : ControllerBase
         using (XmlWriter writer = XmlWriter.Create(sb, _xmlWriterSettings))
         {
             writer.WriteStartElement("svg", "http://www.w3.org/2000/svg");
-            writer.WriteAttributeString("width", $"{wh.Item1}px");
-            writer.WriteAttributeString("height", $"{wh.Item2}px");
+            // writer.WriteAttributeString("width", $"{wh.Item1}px");
+            // writer.WriteAttributeString("height", $"{wh.Item2}px");
             writer.WriteAttributeString("viewbox", $"0 0 {wh.Item1} {wh.Item2}");
-            foreach (var jAnno in v3Annos["items"])
-            {
-                var anno = (JObject) jAnno;
-                var target = anno["target"]?.Value<string>().Split("=")[^1];
-                if (target == null)
+            var items = v3Annos["items"];
+            if (items != null)
+            { 
+                foreach (var jAnno in items)
                 {
-                    continue;
+                    var anno = (JObject) jAnno;
+                    var target = anno["target"]?.Value<string>().Split("=")[^1];
+                    if (target == null)
+                    {
+                        continue;
+                    }
+                    var xywh = target.Split(",");
+                    if (xywh.Length != 4)
+                    {
+                        continue;
+                    }
+                    var body = anno["body"]?["value"]?.Value<string>();
+                    if (body.IsNullOrWhiteSpace())
+                    {
+                        continue;
+                    }
+                    writer.WriteStartElement("text");
+                    writer.WriteAttributeString("x", xywh[0]);
+                    var y = Convert.ToInt32(xywh[1]);
+                    var h = Convert.ToInt32(xywh[3]);
+                    writer.WriteAttributeString("y", $"{(int)(y + h * 0.75)}");
+                    writer.WriteAttributeString("textLength", xywh[2]);
+                    writer.WriteAttributeString("font-size", xywh[3]);
+                    writer.WriteAttributeString("lengthAdjust", "spacingAndGlyphs");
+                    writer.WriteAttributeString("class", "text-line-segment");
+                    writer.WriteString(body);
+                    writer.WriteEndElement();
                 }
-                var xywh = target.Split(",");
-                if (xywh.Length != 4)
-                {
-                    continue;
-                }
-                var body = anno["body"]?["value"]?.Value<string>();
-                if (body.IsNullOrWhiteSpace())
-                {
-                    continue;
-                }
-                writer.WriteStartElement("text");
-                writer.WriteAttributeString("x", xywh[0]);
-                var y = Convert.ToInt32(xywh[1]);
-                var h = Convert.ToInt32(xywh[3]);
-                writer.WriteAttributeString("y", $"{(int)(y + h * 0.75)}");
-                writer.WriteAttributeString("textLength", xywh[2]);
-                writer.WriteAttributeString("font-size", xywh[3]);
-                writer.WriteAttributeString("lengthAdjust", "spacingAndGlyphs");
-                writer.WriteAttributeString("class", "text-line-segment");
-                writer.WriteString(body);
+                writer.WriteStartElement("style");
+                writer.WriteString(invisibleStyle);
                 writer.WriteEndElement();
-            }
-            writer.WriteStartElement("style");
-            writer.WriteString(invisibleStyle);
-            writer.WriteEndElement();
+                
+            }   
             writer.WriteEndElement();
         }
 

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
@@ -15,7 +15,7 @@ using Wellcome.Dds.Common;
 namespace Wellcome.Dds.Server.Controllers;
 
 
-[FeatureGate(FeatureFlags.PresentationServices)]
+[FeatureGate(FeatureFlags.TextServices)]
 [Route("text/[controller]")]
 [ApiController]
 public class SvgController : ControllerBase

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
@@ -86,7 +86,7 @@ public class SvgController : ControllerBase
             writer.WriteStartElement("svg", "http://www.w3.org/2000/svg");
             // writer.WriteAttributeString("width", $"{wh.Item1}px");
             // writer.WriteAttributeString("height", $"{wh.Item2}px");
-            writer.WriteAttributeString("viewbox", $"0 0 {wh.Item1} {wh.Item2}");
+            writer.WriteAttributeString("viewBox", $"0 0 {wh.Item1} {wh.Item2}");
             var items = v3Annos["items"];
             if (items != null)
             { 

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
@@ -76,16 +76,10 @@ public class SvgController : ControllerBase
     {
         var sb = new StringBuilder();
 
-        const string invisibleStyle = """
-                                      
-                                          .text-line-segment {
-                                              fill: rgba(0,0,0,0);
-                                          }
-                                          .text-line-segment::selection {
-                                              fill: #000;
-                                          }
-
-                                      """;
+        const string invisibleStyle = @"                                     
+.text-line-segment { fill: rgba(0,0,0,0) }
+.text-line-segment::selection { fill: #fff; background: rgba(15, 76, 155, 0.8) }
+  ";
         
         using (XmlWriter writer = XmlWriter.Create(sb, _xmlWriterSettings))
         {

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
@@ -15,8 +15,8 @@ using Wellcome.Dds.Common;
 namespace Wellcome.Dds.Server.Controllers;
 
 
-[FeatureGate(FeatureFlags.TextServices)]
-[Route("text/[controller]")]
+[FeatureGate(FeatureFlags.PresentationServices)]
+[Route("[controller]")]
 [ApiController]
 public class SvgController : ControllerBase
 {

--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Controllers/SvgController.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement.Mvc;
+using Newtonsoft.Json.Linq;
+using Utils;
+using Utils.Caching;
+using Wellcome.Dds.Common;
+
+namespace Wellcome.Dds.Server.Controllers;
+
+
+[FeatureGate(FeatureFlags.PresentationServices)]
+[Route("text/[controller]")]
+[ApiController]
+public class SvgController : ControllerBase
+{
+    private readonly DdsOptions ddsOptions;
+    private Helpers helpers;
+    private readonly ISimpleCache cache;
+    private ILogger<SvgController> logger;
+
+    private static XmlWriterSettings _xmlWriterSettings = new XmlWriterSettings()
+    {
+        Indent = true,
+        OmitXmlDeclaration = true
+    };
+    
+    public SvgController(
+        IOptions<DdsOptions> options,
+        Helpers helpers,
+        ISimpleCache cache,
+        ILogger<SvgController> logger)
+    {
+        ddsOptions = options.Value;
+        this.helpers = helpers;
+        this.cache = cache;
+        this.logger = logger;
+    }
+    
+    [HttpGet("{identifier}/{assetIdentifier}")]
+    public async Task<IActionResult> GetTextAsSvg(string identifier, string assetIdentifier)
+    {
+        // load the v3 Key
+        var key = $"v3/{identifier}/{assetIdentifier}/line";
+        var v3Annos = await helpers.LoadAsJson(ddsOptions.AnnotationContainer, key);
+
+        if (v3Annos == null)
+        {
+            return NotFound($"No annotation page available for {identifier}/{assetIdentifier}.");
+        }
+
+        Dictionary<string, Tuple<int, int>> sizeMap =
+            await cache.GetCached(20, $"sizemap-{identifier}",
+                () => GetSizeMap(identifier));
+
+        if (!sizeMap.ContainsKey(assetIdentifier))
+        {
+            return NotFound($"No canvas size for {identifier}/{assetIdentifier}.");
+        }
+        var wh = sizeMap[assetIdentifier];
+        var xmlString = GetXmlString(wh, v3Annos);
+        if (xmlString.HasText())
+        {
+            return Content(xmlString, "image/svg+xml");
+        }
+        return NotFound($"No XML SVG for {identifier}/{assetIdentifier}.");
+    }
+
+    private string GetXmlString(Tuple<int, int> wh, JObject v3Annos)
+    {
+        var sb = new StringBuilder();
+
+        const string invisibleStyle = """
+                                      
+                                          .text-line-segment {
+                                              fill: rgba(0,0,0,0);
+                                          }
+                                          .text-line-segment::selection {
+                                              fill: #000;
+                                          }
+
+                                      """;
+        
+        using (XmlWriter writer = XmlWriter.Create(sb, _xmlWriterSettings))
+        {
+            writer.WriteStartElement("svg", "http://www.w3.org/2000/svg");
+            writer.WriteAttributeString("width", $"{wh.Item1}px");
+            writer.WriteAttributeString("height", $"{wh.Item2}px");
+            writer.WriteAttributeString("viewbox", $"0 0 {wh.Item1} {wh.Item2}");
+            foreach (var jAnno in v3Annos["items"])
+            {
+                var anno = (JObject) jAnno;
+                var target = anno["target"]?.Value<string>().Split("=")[^1];
+                if (target == null)
+                {
+                    continue;
+                }
+                var xywh = target.Split(",");
+                if (xywh.Length != 4)
+                {
+                    continue;
+                }
+                var body = anno["body"]?["value"]?.Value<string>();
+                if (body.IsNullOrWhiteSpace())
+                {
+                    continue;
+                }
+                writer.WriteStartElement("text");
+                writer.WriteAttributeString("x", xywh[0]);
+                var y = Convert.ToInt32(xywh[1]);
+                var h = Convert.ToInt32(xywh[3]);
+                writer.WriteAttributeString("y", $"{(int)(y + h * 0.75)}");
+                writer.WriteAttributeString("textLength", xywh[2]);
+                writer.WriteAttributeString("font-size", xywh[3]);
+                writer.WriteAttributeString("lengthAdjust", "spacingAndGlyphs");
+                writer.WriteAttributeString("class", "text-line-segment");
+                writer.WriteString(body);
+                writer.WriteEndElement();
+            }
+            writer.WriteStartElement("style");
+            writer.WriteString(invisibleStyle);
+            writer.WriteEndElement();
+            writer.WriteEndElement();
+        }
+
+        return sb.ToString();
+    }
+
+    private async Task<Dictionary<string, Tuple<int, int>>> GetSizeMap(string identifier)
+    {
+        var start = DateTime.Now;
+        var manifest = await helpers.LoadAsJson(ddsOptions.PresentationContainer, $"v3/{identifier}");
+        var dict = new Dictionary<string, Tuple<int, int>>();
+        foreach (var jCanvas in manifest["items"])
+        {
+            var canvas = (JObject)jCanvas;
+            var assetId = canvas["id"].Value<string>().Split('/')[^1];
+            var w = canvas["width"].Value<int>();
+            var h = canvas["height"].Value<int>();
+            dict.Add(assetId, new(w, h));
+        }
+
+        var timeTaken = (DateTime.Now - start).Milliseconds;
+        logger.LogDebug("Sizemap built in {timeTaken} ms with {dictSize} entries", timeTaken, dict.Keys.Count);
+
+        return dict;
+    }
+}

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -62,6 +62,7 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string RawTextFormat =              "/text/v1/{identifier}"; // v1 refers to Wellcome API
         private const string MetsAltoFormat =             "/text/alto/{identifier}/{assetIdentifier}"; // not versioned
         private const string WorkTextZipFormat =          "/text/v1/{identifier}.zip";
+        private const string SvgPageFormat =              "/svg/{identifier}/{assetIdentifier}";
         
         // Other resources
         private const string WorkThumbnailFormat =                  "/thumb/{identifier}";
@@ -342,6 +343,11 @@ namespace Wellcome.Dds.IIIFBuilding
         public string MetsAlto(string manifestIdentifier, string? assetIdentifier)
         {
             return ApiManifestAndAssetIdentifiers(MetsAltoFormat, manifestIdentifier, assetIdentifier);
+        }
+        
+        public string SvgPage(string manifestIdentifier, string? assetIdentifier)
+        {
+            return ManifestAndAssetIdentifiers(SvgPageFormat, manifestIdentifier, assetIdentifier);
         }
 
         public string WorkZippedText(string manifestIdentifier)

--- a/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/AnnotationPage.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/AnnotationPage.cs
@@ -29,6 +29,12 @@ namespace Wellcome.Dds.WordsAndPictures.SimpleAltoServices
         
         [ProtoMember(6)]
         public string AssetIdentifier { get; set; }
+        
+        [ProtoMember(7)]
+        public int ActualWidth { get; set; }
+        
+        [ProtoMember(8)]
+        public int ActualHeight { get; set; }
     }
 
     [Serializable]

--- a/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/SimpleAltoProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/WordsAndPictures/SimpleAltoServices/SimpleAltoProvider.cs
@@ -85,7 +85,9 @@ namespace Wellcome.Dds.WordsAndPictures.SimpleAltoServices
                 ComposedBlocks = Array.Empty<Illustration>(),
                 ManifestationIdentifier = manifestationIdentifier,
                 AssetIdentifier = assetIdentifier,
-                Index = index
+                Index = index,
+                ActualWidth = actualWidth,
+                ActualHeight = actualHeight
             };
         }
 


### PR DESCRIPTION
Converts an existing Annotation Page from S3 to SVG XML.

The annotation page does not record the canvas size (would be a useful addition) so we need to load the manifest and obtain the size. As multiple requests for different pages from the same manifest will come in, we build a map of canvas ID to size (w, h) and cache for 20s.

Typical build times for this map (including loading manifest from S3) are a few hundred ms.