### PR TITLE
Handle no batches for active (running) job

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Views/Dash/Manifestation.cshtml
@@ -173,18 +173,27 @@
                     <h3 class="panel-title">Running...</h3>
                 </div>
                 <div class="panel-body">
-                    @foreach (var activeBatch in Model.BatchesForImages)
+                    @if (Model.BatchesForImages.Any())
                     {
-                        RenderBatchProgress(activeBatch);
-                    }
-                    @{
-                        var latest = Model.BatchesForImages.OrderByDescending(b => b.Submitted).First();
-                        <p><em><small>Most recent batch: @StringUtils.GetLocalDate(latest.Submitted)</small></em></p>
-                        <p><a href="#" onclick="location.reload(); return false;" class="btn btn-primary"><span class="glyphicon glyphicon-refresh"></span> Refresh</a></p>
-                        if (latest.Submitted < DateTime.UtcNow.AddMinutes(-10))
+                        @foreach (var activeBatch in Model.BatchesForImages)
                         {
-                            <p><a href="@Url.Action("Resubmit", "Job", new {id = Model.DdsIdentifier.PathElementSafe})" class="btn btn-info"><span class="glyphicon glyphicon-transfer"></span> Resubmit*</a></p>
+                            RenderBatchProgress(activeBatch);
                         }
+                        {
+                            var latest = Model.BatchesForImages.OrderByDescending(b => b.Submitted).First();
+                            <p><em><small>Most recent batch: @StringUtils.GetLocalDate(latest.Submitted)</small></em></p>
+                            <p><a href="#" onclick="location.reload(); return false;" class="btn btn-primary"><span class="glyphicon glyphicon-refresh"></span> Refresh</a></p>
+                            if (latest.Submitted < DateTime.UtcNow.AddMinutes(-10))
+                            {
+                                <p><a href="@Url.Action("Resubmit", "Job", new { id = Model.DdsIdentifier.PathElementSafe })" class="btn btn-info"><span class="glyphicon glyphicon-transfer"></span> Resubmit*</a></p>
+                            }
+                        }
+                    }
+                    else
+                    {
+                        <p class="text-danger">
+                            A sync is currently running, but there are no batches for the images in this manifestation.
+                        </p>
                     }
                 </div>
             </div>


### PR DESCRIPTION
Diagnosing a problem with Engine, and the dashboard could not render the manifestation view for when the manifestation is a _running_ job `syncOperation.DlcsImagesCurrentlyIngesting.Count > 0` BUT none of the images in the manifestation have a value for Batch:

https://github.com/wellcomecollection/iiif-builder/blob/a09d63dae006ca446f9cc3c2fa602600790bb3e4/src/Wellcome.Dds/Wellcome.Dds.AssetDomainRepositories/DigitalObjects/DigitalObjectRepository.cs#L422

Has Engine overwritten them?