### PR TITLE
Use rewritten URL for rendering property not DLCS url

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/IIIFBuilderParts.cs
@@ -420,7 +420,7 @@ namespace Wellcome.Dds.Repositories.Presentation
                             var label = physicalFile.MimeType == "image/jp2" ? "JPEG 2000" : physicalFile.MimeType;
                             var rendering = new Image
                             {
-                                Id = asFile.DlcsUrl,
+                                Id = uriPatterns.DlcsFile(dlcsEntryPoint, physicalFile.StorageIdentifier),
                                 Format = physicalFile.MimeType,
                                 Label = Lang.Map(label ?? "(unknown format)")
                             };


### PR DESCRIPTION
## What does this change?

The rendering property for an image in a born digital manifest was using the un-rewritten dlcs.io URL
This make it use the wellcomecollection.org url.

