### PR TITLE
Allow search for CALM-id manifestation

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashController.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Dashboard/Controllers/DashController.cs
@@ -268,9 +268,15 @@ namespace Wellcome.Dds.Dashboard.Controllers
                 {
                     return RedirectToAction("Manifestation", new { id = ddsId.ToString() });
                 }
-                // for now, just try to turn it into a b number and redirect
-                var bnumber = WellcomeLibraryIdentifiers.GetNormalisedBNumber(q, false);
-                return RedirectToAction("Manifestation", new { id = bnumber });
+                if (ddsId.HasBNumber)
+                {
+                    var bnumber = WellcomeLibraryIdentifiers.GetNormalisedBNumber(q, false);
+                    return RedirectToAction("Manifestation", new { id = bnumber });
+                }
+                else
+                {
+                    return RedirectToAction("Manifestation", new { id = ddsId.PackageIdentifierPathElementSafe });
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
## What does this change?

Allows you to search for a CALM identifier from the dash top bar - it was still assuming your search term could be turned into a b number.

## How to test

Find manifestations by CALM ID

## How can we measure success?

## Have we considered potential risks?
 No risk
