### PR TITLE
Dashboard breaks if active DB batch is not JSON

### DIFF
--- a/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
+++ b/src/Wellcome.Dds/DlcsWebClient/Config/DlcsOptions.cs
@@ -24,7 +24,7 @@
         /// <summary>
         /// Whether to call the DLCS using old Deliverator AssetFamily, or protagonist delivery channels
         /// </summary>
-        public bool SupportsDeliveryChannels { get; set; } = false;
+        public bool SupportsDeliveryChannels { get; set; } = true;
         
         public string? PortalPageTemplate { get; set; }
         public string? PortalBatchTemplate { get; set; }


### PR DESCRIPTION
## What does this change?

In testing delivery channels a bug emerged in the dashboard (bug had been there for a long time but DC work uncovered it).

If a Manifestation's active batches had returned a non-JSON response from the DLCS (in this case an HTML page for error 502 from the ALB) then the dash view can't deserialise them and breaks.

This change fixes that.

## How to test

View a manifestation with invalid batches in the DdsInstrumentation database.
Was b33096442 but is now fixed, so non currently in this state

## How can we measure success?

n/a

## Have we considered potential risks?

n/a
