### PR TITLE
Update to dotnet 8 base images

### DIFF
--- a/Dockerfile-dashboard
+++ b/Dockerfile-dashboard
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/Wellcome.Dds.Dashboard/Wellcome.Dds.Dashboard.csproj Wellcome.Dds.Dashboard/
@@ -30,7 +30,7 @@ WORKDIR "/src/Wellcome.Dds.Dashboard"
 RUN dotnet publish "Wellcome.Dds.Dashboard.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 ENV TZ Europe/London
 ENV LANG en_GB.UTF8

--- a/Dockerfile-iiifbuilder
+++ b/Dockerfile-iiifbuilder
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/Wellcome.Dds.Server/Wellcome.Dds.Server.csproj Wellcome.Dds.Server/
@@ -25,7 +25,7 @@ WORKDIR "/src/Wellcome.Dds.Server"
 RUN dotnet publish "Wellcome.Dds.Server.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/wellcomecollection/iiif-builder

--- a/Dockerfile-jobprocessor
+++ b/Dockerfile-jobprocessor
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/DlcsJobProcessor/DlcsJobProcessor.csproj DlcsJobProcessor/
@@ -23,7 +23,7 @@ WORKDIR "/src/DlcsJobProcessor"
 RUN dotnet publish "DlcsJobProcessor.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/wellcomecollection/iiif-builder

--- a/Dockerfile-workflowprocessor
+++ b/Dockerfile-workflowprocessor
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 WORKDIR /src
 
 COPY src/Wellcome.Dds/WorkflowProcessor/WorkflowProcessor.csproj WorkflowProcessor/
@@ -27,7 +27,7 @@ WORKDIR "/src/WorkflowProcessor"
 RUN dotnet publish "WorkflowProcessor.csproj" -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/wellcomecollection/iiif-builder


### PR DESCRIPTION
## What does this change?

Some dotnet8 syntax is now used to upgrading base Docker image from dotnet6 to 8 (`:6.0-bullseye-slim` to `:8.0-bookworm-slim`).

`6.0` -> `8.0` is bumping dotnet version.
`bullseye-slim` -> `bookwork-slim` is because when base images are built MS support latest stable version of Debian at time of dotnet release, which is now `bookworm`, at time of dotnet6 it was `bullseye`.

See https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md#linux

## How to test

Build images and test locally, also run and test in test environment.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

