### PR TITLE
Use correct DLCS logout service IDs

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Repositories/Presentation/AuthServices/IIIFAuthServiceProvider.cs
@@ -69,6 +69,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
 
         public IService GetAcceptTermsAuthServicesV2()
         {
+            var logoutService = uriPatterns.DlcsClickthroughLogoutServiceV2Id(dlcsEntryPoint);
             return new AuthAccessService2
             {
                 Id = uriPatterns.DlcsClickthroughLoginServiceV2Id(dlcsEntryPoint),
@@ -77,7 +78,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
                 Heading = new LanguageMap("en", ClickthroughHeader),
                 Note = new LanguageMap("en", ClickthroughLoginDescription),
                 ConfirmLabel = new LanguageMap("en", ClickthroughConfirmlabel),
-                Service = GetCommonChildAuthServicesV2()
+                Service = GetCommonChildAuthServicesV2(logoutService)
             };
         }
         
@@ -97,6 +98,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
 
         public IService GetLoginServicesV2()
         {
+            var logoutService = uriPatterns.DlcsLoginLogoutServiceV2Id(dlcsEntryPoint);
             return new AuthAccessService2
             {
                 Id = uriPatterns.DlcsLoginServiceV2Id(dlcsEntryPoint),
@@ -105,7 +107,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
                 Heading = new LanguageMap("en", ClinicalHeader),
                 Note = new LanguageMap("en", ClinicalLoginDescription),
                 ConfirmLabel = new LanguageMap("en", "LOGIN"),
-                Service = GetCommonChildAuthServicesV2()
+                Service = GetCommonChildAuthServicesV2(logoutService)
             };
         }
         
@@ -124,6 +126,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
 
         public IService GetRestrictedLoginServicesV2()
         {
+            var logoutService = uriPatterns.DlcsRestrictedLoginLogoutServiceV2Id(dlcsEntryPoint);
             return new AuthAccessService2
             {
                 Id = uriPatterns.DlcsRestrictedLoginServiceV2Id(dlcsEntryPoint),
@@ -131,7 +134,7 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
                 Label = new LanguageMap("en", RestrictedHeader),
                 Heading = new LanguageMap("en", RestrictedHeader),
                 Note = new LanguageMap("en", RestrictedFailureDescription),
-                Service = GetCommonChildAuthServicesV2()
+                Service = GetCommonChildAuthServicesV2(logoutService)
             };
         }
 
@@ -167,34 +170,34 @@ namespace Wellcome.Dds.Repositories.Presentation.AuthServices
         
         private List<IService> GetCommonChildAuthServicesV1()
         {
-            return new List<IService>
-            {
+            return
+            [
                 new AuthTokenService
                 {
                     Id = uriPatterns.DlcsTokenServiceId(dlcsEntryPoint)
-                },           
+                },
                 new AuthLogoutService
                 {
                     Id = uriPatterns.DlcsLogoutServiceId(dlcsEntryPoint),
                     Label = new MetaDataValue(LogoutLabel)
                 }
-            };
+            ];
         }
 
-        private List<IService> GetCommonChildAuthServicesV2()
+        private List<IService> GetCommonChildAuthServicesV2(string logoutService)
         {
-            return new List<IService>
-            {
+            return
+            [
                 new AuthAccessTokenService2
                 {
                     Id = uriPatterns.DlcsTokenServiceV2Id(dlcsEntryPoint)
                 },
                 new AuthLogoutService2
                 {
-                    Id = uriPatterns.DlcsLogoutServiceV2Id(dlcsEntryPoint),
+                    Id = logoutService,
                     Label = new LanguageMap("en", LogoutLabel)
                 }
-            };
+            ];
         }
     }
 }

--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/UriPatterns.cs
@@ -83,17 +83,19 @@ namespace Wellcome.Dds.IIIFBuilding
         private const string DlcsFileTemplate         = "{dlcsEntryPoint}file/{assetIdentifier}";
         
         // Auth
-        private const string DlcsProbeServiceV2Template               = "{dlcsEntryPoint}auth/v2/probe/{assetIdentifier}";
-        private const string DlcsClickthroughLoginServiceIdTemplate   = "{dlcsEntryPoint}auth/clickthrough";
-        private const string DlcsClickthroughLoginServiceV2IdTemplate = "{dlcsEntryPoint}auth/v2/access/clickthrough";
-        private const string DlcsClinicalLoginServiceIdTemplate       = "{dlcsEntryPoint}auth/clinicalLogin";
-        private const string DlcsLoginServiceV2IdTemplate             = "{dlcsEntryPoint}auth/v2/access/login";
-        private const string DlcsRestrictedLoginServiceIdTemplate     = "{dlcsEntryPoint}auth/restrictedlogin";
-        private const string DlcsRestrictedLoginServiceV2IdTemplate   = "{dlcsEntryPoint}auth/v2/access/restrictedlogin";
-        private const string DlcsTokenServiceIdTemplate               = "{dlcsEntryPoint}auth/token";
-        private const string DlcsTokenServiceV2IdTemplate             = "{dlcsEntryPoint}auth/v2/access/token";
-        private const string DlcsLogoutServiceIdTemplate              = "{dlcsEntryPoint}auth/logout";
-        private const string DlcsLogoutServiceV2IdTemplate            = "{dlcsEntryPoint}auth/v2/access/logout";
+        private const string DlcsClickthroughLoginServiceIdTemplate       = "{dlcsEntryPoint}auth/clickthrough";
+        private const string DlcsClinicalLoginServiceIdTemplate           = "{dlcsEntryPoint}auth/clinicalLogin";
+        private const string DlcsRestrictedLoginServiceIdTemplate         = "{dlcsEntryPoint}auth/restrictedlogin";
+        private const string DlcsTokenServiceIdTemplate                   = "{dlcsEntryPoint}auth/token";
+        private const string DlcsLogoutServiceIdTemplate                  = "{dlcsEntryPoint}auth/logout";
+        private const string DlcsProbeServiceV2Template                   = "{dlcsEntryPoint}auth/v2/probe/{assetIdentifier}";
+        private const string DlcsClickthroughLoginServiceV2IdTemplate     = "{dlcsEntryPoint}auth/v2/access/clickthrough";
+        private const string DlcsClickthroughLogoutServiceV2IdTemplate    = "{dlcsEntryPoint}auth/v2/access/clickthrough/logout";
+        private const string DlcsLoginServiceV2IdTemplate                 = "{dlcsEntryPoint}auth/v2/access/login";
+        private const string DlcsLoginLogoutServiceV2IdTemplate           = "{dlcsEntryPoint}auth/v2/access/login/logout";
+        private const string DlcsRestrictedLoginServiceV2IdTemplate       = "{dlcsEntryPoint}auth/v2/access/restrictedlogin";
+        private const string DlcsRestrictedLoginLogoutServiceV2IdTemplate = "{dlcsEntryPoint}auth/v2/access/restrictedlogin/logout";
+        private const string DlcsTokenServiceV2IdTemplate                 = "{dlcsEntryPoint}auth/v2/access/token";
 
         public UriPatterns(IOptions<DdsOptions> ddsOptions)
         {
@@ -318,9 +320,18 @@ namespace Wellcome.Dds.IIIFBuilding
             return DlcsService(DlcsLogoutServiceIdTemplate, dlcsEntryPoint);
         }
 
-        public string DlcsLogoutServiceV2Id(string dlcsEntryPoint)
+        public string DlcsClickthroughLogoutServiceV2Id(string dlcsEntryPoint)
         {
-            return DlcsService(DlcsLogoutServiceV2IdTemplate, dlcsEntryPoint);
+            return DlcsService(DlcsClickthroughLogoutServiceV2IdTemplate, dlcsEntryPoint);
+        }
+        
+        public string DlcsRestrictedLoginLogoutServiceV2Id(string dlcsEntryPoint)
+        {
+            return DlcsService(DlcsRestrictedLoginLogoutServiceV2IdTemplate, dlcsEntryPoint);
+        }
+        public string DlcsLoginLogoutServiceV2Id(string dlcsEntryPoint)
+        {
+            return DlcsService(DlcsLoginLogoutServiceV2IdTemplate, dlcsEntryPoint);
         }
 
         private string DlcsIdentifier(string template, string dlcsEntryPointToken, string? assetIdentifier)


### PR DESCRIPTION
## What does this change?

Although not used on Wellcome work page, the auth service logout URLs were incorrect in the manifest (different from the info.json)

## How to test

Verify that logout IDs listed in manifest.services match those in the info.json

## How can we measure success?

(as above)


