### PR TITLE
Allow the Peek-Raw IIIF Manifest to skip checking DLCS generated sizes

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds/IIIFBuilding/IIIIFBuilder.cs
@@ -26,8 +26,9 @@ namespace Wellcome.Dds.IIIFBuilding
         /// </summary>
         /// <param name="ddsId">e.g., b12345678, b87654321_0001</param>
         /// <param name="work">If you already have a work, the class will use it, otherwise it will acquire it from the catalogue</param>
+        /// <param name="skipDlcsSizeCheck"></param>
         /// <returns></returns>
-        public Task<MultipleBuildResult> Build(DdsIdentifier ddsId, Work? work = null);
+        public Task<MultipleBuildResult> Build(DdsIdentifier ddsId, Work? work = null, bool skipDlcsSizeCheck = false);
 
         /// <summary>
         /// Builds ALL Manifests and Collections for the given bNumber.


### PR DESCRIPTION
## What does this change?

In the dashboard only, add a query string parameter to the raw IIIF preview:

.../Peek/IIIFRaw/b33123354?skipDlcsSizeCheck=true

This means that even if configured to do so, DDS won't ask DLCS for named query manifest and patch any mismatched sizes.

Purpose is debugging/testing.

## Have we considered potential risks?

Have checked that this won't be called inadvertently.
