### PR TITLE
ensure application/json+ld responses are compressed

### DIFF
--- a/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
+++ b/src/Wellcome.Dds/Wellcome.Dds.Server/Startup.cs
@@ -7,6 +7,7 @@ using DlcsWebClient.Dlcs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,6 +85,17 @@ namespace Wellcome.Dds.Server
                 options.IdleTimeout = TimeSpan.FromSeconds(3600);
                 options.Cookie.HttpOnly = true;
                 options.Cookie.IsEssential = true;
+            });
+
+            services.AddResponseCompression(options =>
+            {
+                // TLS terminates upstream so requests arrive as HTTP, but keep this
+                // in case forwarded-headers handling is ever added.
+                options.EnableForHttps = true;
+                options.Providers.Add<BrotliCompressionProvider>();
+                options.Providers.Add<GzipCompressionProvider>();
+                options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(
+                    new[] { "application/ld+json" });
             });
 
             services.AddSwagger();
@@ -182,6 +194,7 @@ namespace Wellcome.Dds.Server
             }
 
             app.UseCors("CorsPolicy");
+            app.UseResponseCompression();
             app.SetupSwagger();
             app.UseStaticFiles();
             app.UseRouting();


### PR DESCRIPTION
## What does this change?

1. Added using Microsoft.AspNetCore.ResponseCompression;
2. Registered the services in ConfigureServices (Startup.cs:90) with Brotli and gzip providers, application/ld+json added to the default MIME list, and EnableForHttps = true kept with a comment explaining it's future-proofing for if forwarded-headers handling is ever added.
3. Added app.UseResponseCompression() in Configure (Startup.cs:198), right after CORS and before Swagger/static files so those responses get compressed too.

